### PR TITLE
security: Firestore 소유권 검증 및 Security Rules 추가

### DIFF
--- a/client/src/features/todo/api/todoApi.ts
+++ b/client/src/features/todo/api/todoApi.ts
@@ -33,9 +33,12 @@ export const getTodos = async () => {
 };
 
 export const getTodoDetail = async (id: string) => {
+  const userId = getUserId();
   const snapshot = await getDoc(doc(db, "todos", id));
   if (!snapshot.exists()) throw new Error("Todo not found");
-  return mapDocToTodo(snapshot.id, snapshot.data());
+  const data = snapshot.data();
+  if (data.userId !== userId) throw new Error("Forbidden");
+  return mapDocToTodo(snapshot.id, data);
 };
 
 export const getSearchTodoList = async (queryStr: string) => {
@@ -74,8 +77,14 @@ const calcParentStatus = (
 };
 
 export const editTodo = async (todo: Todo, allTodos: Todo[]) => {
+  const userId = getUserId();
   const { id, ...data } = todo;
   const now = new Date().toISOString();
+
+  const docRef = doc(db, "todos", id);
+  const existing = await getDoc(docRef);
+  if (!existing.exists()) throw new Error("Todo not found");
+  if (existing.data().userId !== userId) throw new Error("Forbidden");
 
   const writes: Array<{ id: string; updates: object }> = [
     { id, updates: { ...data, updatedAt: now } },
@@ -117,15 +126,23 @@ export const editTodo = async (todo: Todo, allTodos: Todo[]) => {
 };
 
 export const deleteTodo = async (id: string) => {
-  await deleteDoc(doc(db, "todos", id));
+  const userId = getUserId();
+  const docRef = doc(db, "todos", id);
+  const existing = await getDoc(docRef);
+  if (!existing.exists()) throw new Error("Todo not found");
+  if (existing.data().userId !== userId) throw new Error("Forbidden");
+  await deleteDoc(docRef);
 };
 
 export const updateToDone = async (id: string) => {
+  const userId = getUserId();
   const now = new Date().toISOString();
   const docRef = doc(db, "todos", id);
+  const existing = await getDoc(docRef);
+  if (!existing.exists()) throw new Error("Todo not found");
+  if (existing.data().userId !== userId) throw new Error("Forbidden");
   await updateDoc(docRef, { status: "done", doneAt: now, updatedAt: now });
-  const snapshot = await getDoc(docRef);
-  return mapDocToTodo(snapshot.id, snapshot.data()!);
+  return mapDocToTodo(docRef.id, { ...existing.data(), status: "done", doneAt: now, updatedAt: now });
 };
 
 export const createChildTodo = async (

--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,7 @@
 {
+  "firestore": {
+    "rules": "firestore.rules"
+  },
   "hosting": {
     "site": "tododo-83576",
     "public": "client/dist",

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,11 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /todos/{todoId} {
+      allow read:   if request.auth != null && resource.data.userId == request.auth.uid;
+      allow create: if request.auth != null && request.resource.data.userId == request.auth.uid;
+      allow update: if request.auth != null && resource.data.userId == request.auth.uid;
+      allow delete: if request.auth != null && resource.data.userId == request.auth.uid;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `firestore.rules` 신규 생성 — 인증된 사용자가 자신의 Todo만 읽기/쓰기 가능하도록 서버 레벨 규칙 적용
- `firebase.json`에 `firestore.rules` 연결
- `getTodoDetail`, `editTodo`, `deleteTodo`, `updateToDone`에 클라이언트 레벨 userId 소유권 검증 추가
- `updateToDone`의 `snapshot.data()!` non-null 단언 제거 및 불필요한 2번째 `getDoc` 제거

## 변경 배경

기존에는 `getTodoDetail`이 문서 ID만으로 조회했기 때문에, URL에 타인의 Todo ID를 입력하면 해당 문서에 접근 가능했습니다. `editTodo`, `deleteTodo`, `updateToDone`도 소유권 확인 없이 ID만으로 수정·삭제할 수 있었습니다. Firestore Security Rules 파일 자체도 버전 관리에 없었습니다.

## 보안 레이어

| 레이어 | 방어 내용 |
|---|---|
| Firestore Rules (서버) | `resource.data.userId == request.auth.uid` — 어떤 클라이언트도 타인 데이터 접근 불가 |
| 클라이언트 검증 | `getDoc` 후 userId 비교 → 의미 있는 에러("Forbidden") 반환 |

## Test plan

- [ ] 본인 Todo 상세 조회 정상 동작 확인
- [ ] 타인의 Todo ID로 URL 직접 접근 시 에러 처리 확인
- [ ] Todo 생성 / 수정 / 삭제 / 완료 처리 정상 동작 확인
- [ ] Firebase Console에서 Security Rules 배포 후 Rules Playground로 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)