### PR TITLE
fix: todo 생성 시 order 필드 누락 및 검색 쿼리 버그 수정

### DIFF
--- a/client/src/features/todo/api/todoApi.ts
+++ b/client/src/features/todo/api/todoApi.ts
@@ -52,6 +52,15 @@ export const createTodo = async (todo: Todo) => {
   const userId = getUserId();
   const now = new Date().toISOString();
   const { id: _, ...todoData } = todo; // eslint-disable-line @typescript-eslint/no-unused-vars
+
+  const rootTodosSnapshot = await getDocs(
+    query(todosRef, where("userId", "==", userId), where("parentId", "==", null)),
+  );
+  const maxOrder = rootTodosSnapshot.docs.reduce(
+    (max, d) => Math.max(max, (d.data().order as number) ?? 0),
+    -1,
+  );
+
   const docRef = await addDoc(todosRef, {
     ...todoData,
     userId,
@@ -59,6 +68,7 @@ export const createTodo = async (todo: Todo) => {
     updatedAt: now,
     parentId: null,
     status: "todo",
+    order: maxOrder + 1,
   });
   return { ...todo, id: docRef.id };
 };
@@ -152,6 +162,13 @@ export const createChildTodo = async (
 ) => {
   const userId = getUserId();
   const now = new Date().toISOString();
+
+  const existingSiblings = allTodos.filter((t) => t.parentId === parentId);
+  const maxOrder = existingSiblings.reduce(
+    (max, t) => Math.max(max, t.order ?? 0),
+    -1,
+  );
+
   const docRef = await addDoc(todosRef, {
     ...todo,
     parentId,
@@ -159,11 +176,12 @@ export const createChildTodo = async (
     createdAt: now,
     updatedAt: now,
     status: "todo",
+    order: maxOrder + 1,
   });
 
   // 새 하위(todo) 추가 → 상위 상태 재계산
   const newChild = { id: docRef.id, status: "todo" as const, parentId } as Todo;
-  const siblings = [...allTodos.filter((t) => t.parentId === parentId), newChild];
+  const siblings = [...existingSiblings, newChild];
   const { status: parentStatus, doneAt } = calcParentStatus(siblings);
   await updateDoc(doc(db, "todos", parentId), {
     status: parentStatus,

--- a/client/src/features/todo/hooks/useTodo.ts
+++ b/client/src/features/todo/hooks/useTodo.ts
@@ -8,7 +8,6 @@ import {
   updateToDone,
   createChildTodo,
   getTodoDetail,
-  getSearchTodoList,
 } from "../api";
 
 export const useTodo = () => {
@@ -18,12 +17,6 @@ export const useTodo = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["todos"] });
     },
-  });
-
-  const useGetSearchTodoList = useQuery({
-    queryKey: ["searchTodoList"],
-    queryFn: ({ queryKey }: { queryKey: string[] }) =>
-      getSearchTodoList(queryKey[1]),
   });
 
   const useUpdateTodo = useMutation({
@@ -133,7 +126,6 @@ export const useTodo = () => {
     useGetTodos,
     useUpdateToDone,
     useCreateChildTodo,
-    useGetSearchTodoList,
   };
 };
 


### PR DESCRIPTION
## Summary

- `createTodo`: 루트 todo 생성 시 Firestore에서 기존 최대 `order` 값을 조회해 `+1` 설정
- `createChildTodo`: 캐시된 형제 todo들의 최대 `order`를 계산해 `+1` 설정
- `useTodo`: 항상 `undefined`로 쿼리되던 `useGetSearchTodoList` 제거 — 이미 별도로 올바르게 구현된 `useSearchTodo(query)` 훅이 사용 중

## Test plan

- [ ] 루트 todo 생성 후 목록 순서가 생성 순서대로 표시되는지 확인
- [ ] 하위 todo 생성 후 형제 간 순서가 올바른지 확인
- [ ] 검색 기능 정상 동작 확인 (`useSearchTodo` 훅 경유)

🤖 Generated with [Claude Code](https://claude.com/claude-code)