### PR TITLE
feat: 접근성 및 UX 보완사항 적용

### DIFF
--- a/client/src/features/auth/pages/loginPage.styles.tsx
+++ b/client/src/features/auth/pages/loginPage.styles.tsx
@@ -41,12 +41,28 @@ export const GoogleButton = styled.button`
   transition: box-shadow 0.2s ease, background-color 0.2s ease;
   white-space: nowrap;
 
-  &:hover {
+  &:hover:not(:disabled) {
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
     background-color: #f8f9fa;
   }
 
-  &:active {
+  &:active:not(:disabled) {
     background-color: #f1f3f4;
   }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+`;
+
+export const ErrorMessage = styled.p`
+  font-size: 14px;
+  color: #d93025;
+  text-align: center;
+  margin: 0;
+  padding: 8px 12px;
+  background-color: #fce8e6;
+  border-radius: 6px;
+  width: 100%;
 `;

--- a/client/src/features/auth/pages/loginPage.tsx
+++ b/client/src/features/auth/pages/loginPage.tsx
@@ -1,7 +1,8 @@
 import { signInWithPopup } from "firebase/auth";
 import { auth, googleProvider } from "@/shared/lib/firebase";
 import { useNavigate } from "react-router-dom";
-import { Container, Card, Title, GoogleButton } from "./loginPage.styles";
+import { useState } from "react";
+import { Container, Card, Title, GoogleButton, ErrorMessage } from "./loginPage.styles";
 
 const GoogleIcon = () => (
   <svg width="20" height="20" viewBox="0 0 48 48">
@@ -14,19 +15,35 @@ const GoogleIcon = () => (
 
 const LoginPage = () => {
   const navigate = useNavigate();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
 
   const handleGoogleLogin = async () => {
-    await signInWithPopup(auth, googleProvider);
-    navigate("/");
+    setErrorMessage(null);
+    setIsLoading(true);
+    try {
+      await signInWithPopup(auth, googleProvider);
+      navigate("/");
+    } catch (err: unknown) {
+      const code = (err as { code?: string })?.code;
+      if (code === "auth/popup-closed-by-user" || code === "auth/cancelled-popup-request") {
+        // 사용자가 직접 닫은 경우 - 에러 메시지 불필요
+      } else {
+        setErrorMessage("로그인 중 오류가 발생했습니다. 다시 시도해주세요.");
+      }
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return (
     <Container>
       <Card>
         <Title>ToDoDo</Title>
-        <GoogleButton onClick={handleGoogleLogin}>
+        {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
+        <GoogleButton onClick={handleGoogleLogin} disabled={isLoading}>
           <GoogleIcon />
-          Google로 로그인
+          {isLoading ? "로그인 중..." : "Google로 로그인"}
         </GoogleButton>
       </Card>
     </Container>

--- a/client/src/features/dashboard/components/calendar.tsx
+++ b/client/src/features/dashboard/components/calendar.tsx
@@ -15,7 +15,9 @@ import {
   EmptyMessage,
 } from "./calendar.styles";
 import { statusColors, type Status } from "../../../styles/statusColors";
-import { BottomSheet } from "@/shared";
+import { BottomSheet, EmptyState } from "@/shared";
+import { AlertCircle } from "lucide-react";
+import styled, { keyframes } from "styled-components";
 
 const statusLabels: Record<Status, string> = {
   todo: "할 일",
@@ -27,7 +29,7 @@ const Calendar = () => {
   const calendarRef = useRef<FullCalendar>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const { useGetTodos } = useTodo();
-  const { data: todos } = useGetTodos;
+  const { data: todos, isLoading, isError } = useGetTodos;
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
 
@@ -97,6 +99,24 @@ const Calendar = () => {
     });
   };
 
+  if (isLoading) {
+    return (
+      <LoadingWrapper>
+        <Spinner />
+      </LoadingWrapper>
+    );
+  }
+
+  if (isError) {
+    return (
+      <EmptyState
+        icon={AlertCircle}
+        title="캘린더 데이터를 불러오지 못했습니다"
+        description="네트워크 연결을 확인하고 다시 시도해주세요"
+      />
+    );
+  }
+
   return (
     <>
       <CalendarContainer ref={containerRef}>
@@ -143,5 +163,27 @@ const Calendar = () => {
     </>
   );
 };
+
+const spin = keyframes`
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+`;
+
+const LoadingWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  min-height: 200px;
+`;
+
+const Spinner = styled.div`
+  width: 36px;
+  height: 36px;
+  border: 3px solid #e0e0e0;
+  border-top-color: #1c72eb;
+  border-radius: 50%;
+  animation: ${spin} 0.8s linear infinite;
+`;
 
 export default Calendar;

--- a/client/src/features/dashboard/components/pieChart.tsx
+++ b/client/src/features/dashboard/components/pieChart.tsx
@@ -4,10 +4,13 @@ import type { Todo } from "@/features/todo";
 import { useTodo } from "@/features/todo";
 import { PieChartContainer } from "./pieChart.styles";
 import { statusColors, type Status } from "../../../styles/statusColors";
+import { EmptyState } from "@/shared";
+import { AlertCircle, ChartPie } from "lucide-react";
+import styled, { keyframes } from "styled-components";
 
 const PieChartComponent = () => {
   const { useGetTodos } = useTodo();
-  const { data: todos } = useGetTodos;
+  const { data: todos, isLoading, isError } = useGetTodos;
 
   const statusLabels: Record<string, string> = {
     todo: "할 일",
@@ -34,6 +37,34 @@ const PieChartComponent = () => {
       value: count,
     }));
   }, [todos]);
+  if (isLoading) {
+    return (
+      <LoadingWrapper>
+        <Spinner />
+      </LoadingWrapper>
+    );
+  }
+
+  if (isError) {
+    return (
+      <EmptyState
+        icon={AlertCircle}
+        title="차트 데이터를 불러오지 못했습니다"
+        description="네트워크 연결을 확인하고 다시 시도해주세요"
+      />
+    );
+  }
+
+  if (!todos || todos.length === 0) {
+    return (
+      <EmptyState
+        icon={ChartPie}
+        title="표시할 데이터가 없습니다"
+        description="할 일을 추가하면 상태별 통계를 확인할 수 있습니다"
+      />
+    );
+  }
+
   return (
     <PieChartContainer>
       <ResponsiveContainer width="100%" height="100%">
@@ -68,5 +99,27 @@ const PieChartComponent = () => {
     </PieChartContainer>
   );
 };
+
+const spin = keyframes`
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+`;
+
+const LoadingWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  min-height: 200px;
+`;
+
+const Spinner = styled.div`
+  width: 36px;
+  height: 36px;
+  border: 3px solid #e0e0e0;
+  border-top-color: #1c72eb;
+  border-radius: 50%;
+  animation: ${spin} 0.8s linear infinite;
+`;
 
 export default PieChartComponent;

--- a/client/src/features/kanban/hooks/useKanbanDrag.ts
+++ b/client/src/features/kanban/hooks/useKanbanDrag.ts
@@ -3,6 +3,7 @@ import {
   useSensor,
   useSensors,
   PointerSensor,
+  TouchSensor,
   type DragStartEvent,
   type DragEndEvent,
 } from "@dnd-kit/core";
@@ -21,6 +22,12 @@ export const useKanbanDrag = ({ todos, onUpdateTodo }: UseKanbanDragProps) => {
     useSensor(PointerSensor, {
       activationConstraint: {
         distance: 8,
+      },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        delay: 200,
+        tolerance: 8,
       },
     })
   );

--- a/client/src/features/todo/components/todoDetail/todoDetail.tsx
+++ b/client/src/features/todo/components/todoDetail/todoDetail.tsx
@@ -3,6 +3,7 @@ import { useForm } from "react-hook-form";
 import { useTodoDetail, useTodo } from "../../hooks";
 import type { Todo } from "../../types";
 import { X } from "lucide-react";
+import { useToast } from "@/shared";
 import {
   Overlay,
   Panel,
@@ -51,6 +52,7 @@ const TodoDetail = () => {
   const navigate = useNavigate();
   const { todo } = useTodoDetail({ id: id! });
   const { useUpdateTodo } = useTodo();
+  const toast = useToast();
 
   const {
     register,
@@ -89,7 +91,11 @@ const TodoDetail = () => {
       } as Todo,
       {
         onSuccess: () => {
+          toast.success("저장 완료", "할 일이 성공적으로 저장되었습니다");
           handleClose();
+        },
+        onError: () => {
+          toast.error("저장 실패", "할 일 저장 중 오류가 발생했습니다. 다시 시도해주세요");
         },
       }
     );
@@ -105,7 +111,7 @@ const TodoDetail = () => {
       <Panel>
         <PanelHeader>
           <PanelTitle>Todo 상세</PanelTitle>
-          <CloseButton onClick={handleClose}>
+          <CloseButton onClick={handleClose} aria-label="닫기">
             <X size={20} />
           </CloseButton>
         </PanelHeader>

--- a/client/src/features/todo/components/todoListItem/todoListItem.tsx
+++ b/client/src/features/todo/components/todoListItem/todoListItem.tsx
@@ -97,10 +97,10 @@ const TodoListItem = ({
           <DueBadge $daysLeft={daysLeft!}>{getDueBadgeLabel(daysLeft!)}</DueBadge>
         )}
         <ButtonGroup>
-          <TodoIconButton onClick={() => onEdit?.(todo)}>
+          <TodoIconButton onClick={() => onEdit?.(todo)} aria-label="할 일 편집">
             <PencilIcon size={16} />
           </TodoIconButton>
-          <TodoIconButton $variant="danger" onClick={() => setIsDeleteModalOpen(true)}>
+          <TodoIconButton $variant="danger" onClick={() => setIsDeleteModalOpen(true)} aria-label="할 일 삭제">
             <TrashIcon size={16} />
           </TodoIconButton>
         </ButtonGroup>

--- a/client/src/features/todo/pages/todoListPage.tsx
+++ b/client/src/features/todo/pages/todoListPage.tsx
@@ -1,7 +1,25 @@
 import TodoList from "@/features/todo/components/todoList";
 import { useTodo } from "@/features/todo/hooks";
+import { CheckboxSkeleton, EmptyState } from "@/shared";
+import { AlertCircle } from "lucide-react";
+
 export default function TodoListPage() {
   const { useGetTodos: todosQuery } = useTodo();
-  const { data: todos } = todosQuery;
+  const { data: todos, isLoading, isError } = todosQuery;
+
+  if (isLoading) {
+    return <CheckboxSkeleton count={5} />;
+  }
+
+  if (isError) {
+    return (
+      <EmptyState
+        icon={AlertCircle}
+        title="데이터를 불러오지 못했습니다"
+        description="네트워크 연결을 확인하고 다시 시도해주세요"
+      />
+    );
+  }
+
   return <TodoList todos={todos ?? []} />;
 }

--- a/client/src/layouts/header/header.tsx
+++ b/client/src/layouts/header/header.tsx
@@ -20,7 +20,7 @@ const Header = ({ onMenuOpen }: HeaderProps) => {
         <UserInfoImage src={user?.photoURL || ""} alt="user" />
         <LogoutButton onClick={logout}>로그아웃</LogoutButton>
       </UserInfo>
-      <HamburgerMenuButton onClick={onMenuOpen}>
+      <HamburgerMenuButton onClick={onMenuOpen} aria-label="메뉴 열기">
         <MenuIcon size={20} />
       </HamburgerMenuButton>
     </HeaderContainer>

--- a/client/src/layouts/snb/mobileDrawer.styles.tsx
+++ b/client/src/layouts/snb/mobileDrawer.styles.tsx
@@ -1,4 +1,5 @@
 import { styled, keyframes } from "styled-components";
+import { NavLink } from "react-router-dom";
 
 const fadeIn = keyframes`from { opacity: 0; } to { opacity: 1; }`;
 const fadeOut = keyframes`from { opacity: 1; } to { opacity: 0; }`;
@@ -84,5 +85,32 @@ export const NavItem = styled.div<{ $active?: boolean }>`
 
   &:hover {
     background-color: ${({ $active }) => ($active ? "#e8f0fe" : "#f1f3f4")};
+  }
+`;
+
+export const NavNavLink = styled(NavLink)`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 10px;
+  cursor: pointer;
+  font-size: 16px;
+  font-weight: 500;
+  color: #1a1a1a;
+  background-color: transparent;
+  border-radius: 8px;
+  text-decoration: none;
+
+  &:hover {
+    background-color: #f1f3f4;
+  }
+
+  &.active {
+    color: #1c72eb;
+    background-color: #e8f0fe;
+
+    &:hover {
+      background-color: #e8f0fe;
+    }
   }
 `;

--- a/client/src/layouts/snb/mobileDrawer.tsx
+++ b/client/src/layouts/snb/mobileDrawer.tsx
@@ -1,6 +1,5 @@
 import { useState, useCallback, useEffect } from "react";
 import { createPortal } from "react-dom";
-import { useNavigate, useLocation } from "react-router-dom";
 import {
   ListCheckIcon,
   CalendarCheckIcon,
@@ -17,7 +16,7 @@ import {
   UserName,
   LogoutButton,
   NavList,
-  NavItem,
+  NavNavLink,
 } from "./mobileDrawer.styles";
 
 interface MobileDrawerProps {
@@ -35,8 +34,6 @@ const NAV_ITEMS = [
 const MobileDrawer = ({ isOpen, onClose }: MobileDrawerProps) => {
   const [isClosing, setIsClosing] = useState(false);
   const { user, logout } = useAuth();
-  const navigate = useNavigate();
-  const { pathname } = useLocation();
 
   const handleClose = useCallback(() => {
     setIsClosing(true);
@@ -45,11 +42,6 @@ const MobileDrawer = ({ isOpen, onClose }: MobileDrawerProps) => {
       onClose();
     }, 200);
   }, [onClose]);
-
-  const handleNavigate = (path: string) => {
-    navigate(path);
-    handleClose();
-  };
 
   useEffect(() => {
     if (isOpen) document.body.style.overflow = "hidden";
@@ -73,14 +65,14 @@ const MobileDrawer = ({ isOpen, onClose }: MobileDrawerProps) => {
         </UserSection>
         <NavList>
           {NAV_ITEMS.map(({ path, icon, label }) => (
-            <NavItem
+            <NavNavLink
               key={path}
-              $active={pathname === path}
-              onClick={() => handleNavigate(path)}
+              to={path}
+              onClick={handleClose}
             >
               {icon}
               <span>{label}</span>
-            </NavItem>
+            </NavNavLink>
           ))}
         </NavList>
       </DrawerContainer>

--- a/client/src/layouts/snb/snb.tsx
+++ b/client/src/layouts/snb/snb.tsx
@@ -6,9 +6,16 @@ import {
   KanbanIcon,
   ListCheckIcon,
 } from "lucide-react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { NavLink } from "react-router-dom";
 import styled from "styled-components";
 import { media } from "@/styles/breakpoints";
+
+const NAV_ITEMS = [
+  { path: "/todo", icon: <ListCheckIcon />, label: "list" },
+  { path: "/calendar", icon: <CalendarCheckIcon />, label: "calendar" },
+  { path: "/pie-chart", icon: <ChartPieIcon />, label: "chart" },
+  { path: "/kanban", icon: <KanbanIcon />, label: "kanban" },
+];
 
 const SNB = ({
   isopen,
@@ -17,43 +24,22 @@ const SNB = ({
   isopen: boolean;
   setIsOpen: (isOpen: boolean) => void;
 }) => {
-  const navigate = useNavigate();
-  const { pathname } = useLocation();
   return (
     <SNBContainer $isopen={isopen}>
       {isopen && (
         <>
-          <SidebarItem
-            $active={pathname === "/todo"}
-            onClick={() => navigate("/todo")}
-          >
-            <ListCheckIcon />
-            <span>list</span>
-          </SidebarItem>
-          <SidebarItem
-            $active={pathname === "/calendar"}
-            onClick={() => navigate("/calendar")}
-          >
-            <CalendarCheckIcon />
-            <span>calendar</span>
-          </SidebarItem>
-          <SidebarItem
-            $active={pathname === "/pie-chart"}
-            onClick={() => navigate("/pie-chart")}
-          >
-            <ChartPieIcon />
-            <span>chart</span>
-          </SidebarItem>
-          <SidebarItem
-            $active={pathname === "/kanban"}
-            onClick={() => navigate("/kanban")}
-          >
-            <KanbanIcon />
-            <span>kanban</span>
-          </SidebarItem>
+          {NAV_ITEMS.map(({ path, icon, label }) => (
+            <SidebarNavLink key={path} to={path}>
+              {icon}
+              <span>{label}</span>
+            </SidebarNavLink>
+          ))}
         </>
       )}
-      <SidebarButton onClick={() => setIsOpen(!isopen)}>
+      <SidebarButton
+        onClick={() => setIsOpen(!isopen)}
+        aria-label={isopen ? "사이드바 닫기" : "사이드바 열기"}
+      >
         {isopen ? <ArrowLeft size={20} /> : <ArrowRight size={20} />}
       </SidebarButton>
     </SNBContainer>
@@ -73,7 +59,7 @@ const SNBContainer = styled.div<{ $isopen: boolean }>`
   }
 `;
 
-const SidebarItem = styled.div<{ $active?: boolean }>`
+const SidebarNavLink = styled(NavLink)`
   display: flex;
   align-items: center;
   gap: 10px;
@@ -81,11 +67,22 @@ const SidebarItem = styled.div<{ $active?: boolean }>`
   cursor: pointer;
   font-size: 20px;
   font-weight: 500;
-  color: ${({ $active }) => ($active ? "#1c72eb" : "#1a1a1a")};
-  background-color: ${({ $active }) => ($active ? "#e8f0fe" : "transparent")};
+  color: #1a1a1a;
+  background-color: transparent;
   border-radius: 8px;
+  text-decoration: none;
+
   &:hover {
-    background-color: ${({ $active }) => ($active ? "#e8f0fe" : "#e0e0e0")};
+    background-color: #e0e0e0;
+  }
+
+  &.active {
+    color: #1c72eb;
+    background-color: #e8f0fe;
+
+    &:hover {
+      background-color: #e8f0fe;
+    }
   }
 `;
 

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -8,7 +8,13 @@ import { RouterProvider } from "react-router-dom";
 import { ToastProvider } from "@/shared";
 import { AuthProvider } from "@/features/auth/context/authProvider";
 import { router } from "./router";
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60_000, // 1분: 탭 전환 시 불필요한 재조회 방지
+    },
+  },
+});
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/client/src/shared/ui/modal/modal.tsx
+++ b/client/src/shared/ui/modal/modal.tsx
@@ -26,7 +26,7 @@ const Modal = ({
       <ModalBackground onClick={handleClose}>
         <ModalContainer onClick={(e) => e.stopPropagation()}>
           <ModalHeader>
-            <ModalCloseButton onClick={handleClose}>X</ModalCloseButton>
+            <ModalCloseButton onClick={handleClose} aria-label="모달 닫기">X</ModalCloseButton>
           </ModalHeader>
           <ModalBody>{children}</ModalBody>
           <ModalFooter>

--- a/client/src/shared/ui/toast/toast.tsx
+++ b/client/src/shared/ui/toast/toast.tsx
@@ -57,7 +57,7 @@ const Toast = ({ toasts, onClose }: ToastProps) => {
               <Title>{toast.title}</Title>
               {toast.message && <Message>{toast.message}</Message>}
             </Content>
-            <CloseButton onClick={() => onClose(toast.id)}>
+            <CloseButton onClick={() => onClose(toast.id)} aria-label="알림 닫기">
               <X size={16} />
             </CloseButton>
             {!toast.isExiting && <ProgressBar $type={toast.type} $duration={duration} />}


### PR DESCRIPTION
## Summary

- SNB 네비게이션을 `<NavLink>` 기반으로 교체하여 키보드 Tab/Enter 접근성 향상
- 아이콘 버튼(햄버거, 편집/삭제, 닫기)에 `aria-label` 일괄 추가
- 할 일 목록·캘린더·파이차트에 로딩 스켈레톤/스피너 및 에러 EmptyState 추가
- 저장·로그인 실패 시 토스트 알림 및 에러 메시지 피드백 연동
- 칸반 보드에 `TouchSensor` 추가로 모바일 드래그앤드롭 지원
- `QueryClient staleTime: 60_000` 설정으로 탭 전환 시 불필요한 재요청 방지

## Test plan

- [ ] SNB 메뉴를 Tab 키로 이동하고 Enter로 페이지 전환 확인
- [ ] 스크린리더에서 아이콘 버튼 aria-label 읽힘 확인
- [ ] 네트워크 느린 환경에서 로딩 스켈레톤/스피너 표시 확인
- [ ] 저장 실패 시 에러 토스트, 로그인 실패 시 에러 메시지 표시 확인
- [ ] 모바일 터치로 칸반 카드 드래그앤드롭 동작 확인
- [ ] 탭 전환 후 1분 이내 API 재호출 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)