### PR TITLE
feat: 모바일 틸 리브랜딩 - 디자인 토큰, 오늘 화면, 하단 탭바

### DIFF
--- a/client/src/App.styles.tsx
+++ b/client/src/App.styles.tsx
@@ -50,12 +50,13 @@ const TabButton = styled.button<{ $active: boolean }>`
   }
 `;
 
-const Main = styled.main`
+const Main = styled.main<{ $bottomInset?: number }>`
   display: flex;
   flex-direction: column;
   height: 100%;
   width: 100%;
   flex: 1;
+  padding-bottom: ${({ $bottomInset }) => ($bottomInset ? `${$bottomInset}px` : "0")};
 `;
 
 const MobileTabContainer = styled.div`

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,22 +7,31 @@ import { useState } from "react";
 import { Container, Main } from "@/App.styles";
 import SNB from "@/layouts/snb/snb";
 import MobileDrawer from "@/layouts/snb/mobileDrawer";
+import MobileHeader from "@/layouts/mobileHeader/mobileHeader";
+import BottomTabBar from "@/layouts/bottomTabBar/bottomTabBar";
+import { BOTTOM_TAB_BAR_HEIGHT } from "@/layouts/bottomTabBar/bottomTabBar.styles";
 import styled from "styled-components";
+import { useMediaQuery } from "@/shared/hooks";
 
 const App = () => {
   const [isopen, setIsOpen] = useState(true);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const isMobile = useMediaQuery("tablet");
 
   return (
     <Container>
-      <Header onMenuOpen={() => setIsMobileMenuOpen(true)} />
+      {isMobile ? (
+        <MobileHeader onAvatarClick={() => setIsMobileMenuOpen(true)} />
+      ) : (
+        <Header onMenuOpen={() => setIsMobileMenuOpen(true)} />
+      )}
       <ContentContainer>
         <SNB isopen={isopen} setIsOpen={setIsOpen} />
-        <Main>
+        <Main $bottomInset={isMobile ? BOTTOM_TAB_BAR_HEIGHT : 0}>
           <Outlet />
         </Main>
       </ContentContainer>
-      <Footer />
+      {isMobile ? <BottomTabBar /> : <Footer />}
       <MobileDrawer
         isOpen={isMobileMenuOpen}
         onClose={() => setIsMobileMenuOpen(false)}

--- a/client/src/features/today/components/dailyProgress.styles.tsx
+++ b/client/src/features/today/components/dailyProgress.styles.tsx
@@ -1,0 +1,49 @@
+import { styled } from "styled-components";
+import { colors } from "@/styles/colors";
+
+const Container = styled.div`
+  padding: 12px 16px;
+`;
+
+const Header = styled.div`
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 8px;
+`;
+
+const DateLabel = styled.span`
+  font-size: 15px;
+  font-weight: 600;
+  color: ${colors.text.primary};
+`;
+
+const CompletionLabel = styled.span`
+  font-size: 13px;
+  font-weight: 500;
+  color: ${colors.brand.primary};
+`;
+
+const ProgressBarTrack = styled.div`
+  width: 100%;
+  height: 6px;
+  border-radius: 3px;
+  background-color: ${colors.background.secondary};
+  overflow: hidden;
+`;
+
+const ProgressBarFill = styled.div`
+  height: 100%;
+  border-radius: 3px;
+  background-color: ${colors.brand.secondary};
+  transition: width 0.2s ease;
+`;
+
+export {
+  Container,
+  Header,
+  DateLabel,
+  CompletionLabel,
+  ProgressBarTrack,
+  ProgressBarFill,
+};

--- a/client/src/features/today/components/dailyProgress.tsx
+++ b/client/src/features/today/components/dailyProgress.tsx
@@ -1,0 +1,38 @@
+import {
+  Container,
+  Header,
+  DateLabel,
+  CompletionLabel,
+  ProgressBarTrack,
+  ProgressBarFill,
+} from "./dailyProgress.styles";
+
+interface DailyProgressProps {
+  dateLabel: string;
+  doneCount: number;
+  totalCount: number;
+}
+
+const DailyProgress = ({
+  dateLabel,
+  doneCount,
+  totalCount,
+}: DailyProgressProps) => {
+  const percentage = totalCount === 0 ? 0 : (doneCount / totalCount) * 100;
+
+  return (
+    <Container>
+      <Header>
+        <DateLabel>{dateLabel}</DateLabel>
+        <CompletionLabel>
+          {doneCount} / {totalCount} 완료
+        </CompletionLabel>
+      </Header>
+      <ProgressBarTrack>
+        <ProgressBarFill style={{ width: `${percentage}%` }} />
+      </ProgressBarTrack>
+    </Container>
+  );
+};
+
+export default DailyProgress;

--- a/client/src/features/today/components/todaySection.styles.tsx
+++ b/client/src/features/today/components/todaySection.styles.tsx
@@ -1,0 +1,15 @@
+import { styled } from "styled-components";
+import { colors } from "@/styles/colors";
+
+const Container = styled.section`
+  padding: 12px 16px;
+`;
+
+const Title = styled.h2`
+  margin: 0 0 8px 0;
+  font-size: 12px;
+  font-weight: 500;
+  color: ${colors.text.tertiary};
+`;
+
+export { Container, Title };

--- a/client/src/features/today/components/todaySection.tsx
+++ b/client/src/features/today/components/todaySection.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from "react";
+import { Container, Title } from "./todaySection.styles";
+
+interface TodaySectionProps {
+  title: "진행 중" | "완료";
+  children: ReactNode;
+}
+
+const TodaySection = ({ title, children }: TodaySectionProps) => {
+  return (
+    <Container>
+      <Title>{title}</Title>
+      {children}
+    </Container>
+  );
+};
+
+export default TodaySection;

--- a/client/src/features/today/components/todayTodoItem.styles.tsx
+++ b/client/src/features/today/components/todayTodoItem.styles.tsx
@@ -1,0 +1,107 @@
+import { styled } from "styled-components";
+import { colors } from "@/styles/colors";
+import { radius } from "@/styles/radius";
+
+const Row = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 44px;
+  padding: 12px 0;
+  border-bottom: 1px solid ${colors.border.tertiary};
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+const Checkbox = styled.button<{ $isDone: boolean; $isDanger: boolean }>`
+  position: relative;
+  flex-shrink: 0;
+  width: 44px;
+  height: 44px;
+  margin: -13px 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+
+  &::after {
+    content: "";
+    position: absolute;
+    width: 18px;
+    height: 18px;
+    border-radius: ${radius.full};
+    box-sizing: border-box;
+    border: 1.5px solid
+      ${({ $isDone, $isDanger }) =>
+        $isDone
+          ? "transparent"
+          : $isDanger
+            ? colors.border.danger
+            : colors.border.secondary};
+    background-color: ${({ $isDone }) =>
+      $isDone ? colors.brand.secondary : "transparent"};
+    transition: background-color 0.15s ease;
+  }
+
+  svg {
+    position: relative;
+    z-index: 1;
+  }
+`;
+
+const Content = styled.div`
+  flex: 1;
+  min-width: 0;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`;
+
+const Title = styled.span<{ $isDone: boolean }>`
+  font-size: 14px;
+  color: ${({ $isDone }) => ($isDone ? colors.text.tertiary : colors.text.primary)};
+  text-decoration: ${({ $isDone }) => ($isDone ? "line-through" : "none")};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const Description = styled.span`
+  font-size: 12px;
+  color: ${colors.text.secondary};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const TimeLabel = styled.span`
+  flex-shrink: 0;
+  font-size: 12px;
+  color: ${colors.text.secondary};
+`;
+
+const OverdueBadge = styled.span`
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 7px;
+  border-radius: 99px;
+  background-color: ${colors.danger.background};
+  color: ${colors.danger.text};
+`;
+
+export {
+  Row,
+  Checkbox,
+  Content,
+  Title,
+  Description,
+  TimeLabel,
+  OverdueBadge,
+};

--- a/client/src/features/today/components/todayTodoItem.tsx
+++ b/client/src/features/today/components/todayTodoItem.tsx
@@ -1,0 +1,58 @@
+import { Check } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import type { Todo } from "@/features/todo/types";
+import { getDaysLeft, getDueBadgeLabel } from "@/shared/utils/due";
+import { formatDueTime } from "@/shared/utils/formatToday";
+import {
+  Row,
+  Checkbox,
+  Content,
+  Title,
+  Description,
+  TimeLabel,
+  OverdueBadge,
+} from "./todayTodoItem.styles";
+
+interface TodayTodoItemProps {
+  todo: Todo;
+  onToggleDone: (todo: Todo) => void;
+}
+
+const TodayTodoItem = ({ todo, onToggleDone }: TodayTodoItemProps) => {
+  const navigate = useNavigate();
+  const isDone = todo.status === "done";
+  const daysLeft = todo.dueAt ? getDaysLeft(todo.dueAt) : null;
+  const isOverdue = !isDone && daysLeft !== null && daysLeft < 0;
+  const dueTime = todo.dueAt ? formatDueTime(todo.dueAt) : null;
+
+  const handleItemClick = () => navigate(`/todo/${todo.id}`);
+
+  return (
+    <Row>
+      <Checkbox
+        role="checkbox"
+        aria-checked={isDone}
+        aria-label={`${todo.title} 완료 처리`}
+        $isDone={isDone}
+        $isDanger={isOverdue}
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggleDone(todo);
+        }}
+      >
+        {isDone && <Check size={12} color="#FFFFFF" />}
+      </Checkbox>
+      <Content onClick={handleItemClick}>
+        <Title $isDone={isDone}>{todo.title}</Title>
+        {todo.description && <Description>{todo.description}</Description>}
+      </Content>
+      {!isDone && isOverdue && daysLeft !== null ? (
+        <OverdueBadge>{getDueBadgeLabel(daysLeft)}</OverdueBadge>
+      ) : (
+        !isDone && dueTime && <TimeLabel>{dueTime}</TimeLabel>
+      )}
+    </Row>
+  );
+};
+
+export default TodayTodoItem;

--- a/client/src/features/today/components/weekStrip.styles.tsx
+++ b/client/src/features/today/components/weekStrip.styles.tsx
@@ -1,0 +1,67 @@
+import { styled } from "styled-components";
+import { colors } from "@/styles/colors";
+import { radius } from "@/styles/radius";
+
+const Container = styled.div`
+  display: flex;
+  gap: 8px;
+  padding: 8px 16px;
+  overflow-x: auto;
+`;
+
+const DayCell = styled.div<{ $isSelected: boolean; $isToday: boolean }>`
+  flex-shrink: 0;
+  width: 38px;
+  min-height: 44px;
+  padding: 8px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  border-radius: ${radius.md};
+  cursor: pointer;
+  box-sizing: border-box;
+  background-color: ${({ $isSelected }) =>
+    $isSelected ? colors.brand.primary : "transparent"};
+  border: 1.5px solid
+    ${({ $isSelected, $isToday }) =>
+      !$isSelected && $isToday ? colors.brand.primary : "transparent"};
+
+  &:focus-visible {
+    outline: 2px solid ${colors.brand.primary};
+    outline-offset: 2px;
+  }
+`;
+
+const DayLabel = styled.span<{ $isSelected: boolean }>`
+  font-size: 11px;
+  color: ${({ $isSelected }) => ($isSelected ? "#FFFFFF" : colors.text.tertiary)};
+`;
+
+const DateLabel = styled.span<{ $isSelected: boolean; $isToday: boolean }>`
+  font-size: 14px;
+  font-weight: 500;
+  color: ${({ $isSelected, $isToday }) =>
+    $isSelected
+      ? "#FFFFFF"
+      : $isToday
+        ? colors.brand.primary
+        : colors.text.primary};
+`;
+
+const Dot = styled.span<{
+  $marker: "none" | "normal" | "danger";
+  $onColoredBackground: boolean;
+}>`
+  width: 4px;
+  height: 4px;
+  border-radius: ${radius.full};
+  background-color: ${({ $marker, $onColoredBackground }) => {
+    if ($marker === "none") return "transparent";
+    if ($onColoredBackground) return "#FFFFFF";
+    return $marker === "danger" ? colors.danger.main : colors.brand.primary;
+  }};
+`;
+
+export { Container, DayCell, DayLabel, DateLabel, Dot };

--- a/client/src/features/today/components/weekStrip.tsx
+++ b/client/src/features/today/components/weekStrip.tsx
@@ -1,0 +1,78 @@
+import type { DayMarker } from "../hooks/useTodayTodos";
+import { getWeekDates, isSameLocalDay, toDateKey } from "@/shared/utils/date";
+import {
+  Container,
+  DayCell,
+  DayLabel,
+  DateLabel,
+  Dot,
+} from "./weekStrip.styles";
+
+const WEEKDAY_SHORT_LABELS = ["일", "월", "화", "수", "목", "금", "토"];
+const WEEKDAY_FULL_LABELS = [
+  "일요일",
+  "월요일",
+  "화요일",
+  "수요일",
+  "목요일",
+  "금요일",
+  "토요일",
+];
+
+interface WeekStripProps {
+  selectedDate: string;
+  markers: Record<string, DayMarker>;
+  onSelectDate: (date: string) => void;
+}
+
+const WeekStrip = ({ selectedDate, markers, onSelectDate }: WeekStripProps) => {
+  const today = new Date();
+  const weekDates = getWeekDates(selectedDate);
+
+  return (
+    <Container role="list" aria-label="주간 날짜 선택">
+      {weekDates.map((date) => {
+        const dateKey = toDateKey(date);
+        const isSelected = dateKey === selectedDate;
+        const isToday = isSameLocalDay(date, today);
+        const marker = markers[dateKey] ?? "none";
+        const weekdayShort = WEEKDAY_SHORT_LABELS[date.getDay()];
+        const weekdayFull = WEEKDAY_FULL_LABELS[date.getDay()];
+
+        const scheduleInfo =
+          marker === "danger"
+            ? "마감 위험 일정 있음"
+            : marker === "normal"
+              ? "일정 있음"
+              : "일정 없음";
+
+        return (
+          <DayCell
+            key={dateKey}
+            role="button"
+            tabIndex={0}
+            $isSelected={isSelected}
+            $isToday={isToday}
+            aria-pressed={isSelected}
+            aria-label={`${date.getMonth() + 1}월 ${date.getDate()}일 ${weekdayFull}, ${scheduleInfo}`}
+            onClick={() => onSelectDate(dateKey)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onSelectDate(dateKey);
+              }
+            }}
+          >
+            <DayLabel $isSelected={isSelected}>{weekdayShort}</DayLabel>
+            <DateLabel $isSelected={isSelected} $isToday={isToday}>
+              {date.getDate()}
+            </DateLabel>
+            <Dot $marker={marker} $onColoredBackground={isSelected} />
+          </DayCell>
+        );
+      })}
+    </Container>
+  );
+};
+
+export default WeekStrip;

--- a/client/src/features/today/hooks/__tests__/useTodayTodos.test.tsx
+++ b/client/src/features/today/hooks/__tests__/useTodayTodos.test.tsx
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { useTodayTodos } from '../useTodayTodos'
+import type { Todo } from '@/features/todo/types/todo.type'
+
+// Firebase 모킹
+vi.mock('@/shared/lib/firebase', () => ({
+  db: {},
+  auth: {
+    currentUser: { uid: 'test-user-id' },
+  },
+  googleProvider: {},
+}))
+
+// todoApi 모킹
+vi.mock('@/features/todo/api', () => ({
+  getTodos: vi.fn(),
+  getTodoDetail: vi.fn(),
+  createTodo: vi.fn(),
+  editTodo: vi.fn(),
+  deleteTodo: vi.fn(),
+  updateToDone: vi.fn(),
+  createChildTodo: vi.fn(),
+}))
+
+const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
+  id: 'todo-1',
+  userId: 'test-user-id',
+  title: '테스트 할 일',
+  status: 'todo',
+  priority: 'medium',
+  startAt: null,
+  dueAt: null,
+  doneAt: null,
+  parentId: null,
+  order: 0,
+  createdAt: '2026-06-14T00:00:00.000Z',
+  updatedAt: '2026-06-14T00:00:00.000Z',
+  ...overrides,
+})
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  })
+
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+
+  return Wrapper
+}
+
+// 로컬 타임존 기준 2026-06-15(월) 특정 시각의 ISO 문자열 생성
+const localISO = (y: number, m: number, d: number, h = 9, min = 0): string =>
+  new Date(y, m - 1, d, h, min).toISOString()
+
+describe('useTodayTodos 훅', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // waitFor가 내부적으로 실제 타이머에 의존하므로 shouldAdvanceTime으로
+    // 가짜 타이머와 호환시킨다. 2026-06-15 (월요일) 09:00 기준 고정.
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date(2026, 5, 15, 9, 0))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('selectedDate의 dueAt과 일치하는 todo만 골라 진행중/완료로 분리해야 한다', async () => {
+    const { getTodos } = await import('@/features/todo/api')
+    const mockTodos: Todo[] = [
+      makeTodo({ id: '1', title: '오늘 할 일 1', dueAt: localISO(2026, 6, 15, 14) }),
+      makeTodo({
+        id: '2',
+        title: '오늘 완료된 일',
+        status: 'done',
+        dueAt: localISO(2026, 6, 15, 10),
+        doneAt: localISO(2026, 6, 15, 11),
+      }),
+      makeTodo({ id: '3', title: '내일 할 일', dueAt: localISO(2026, 6, 16, 9) }),
+      makeTodo({ id: '4', title: '마감 없음', dueAt: null }),
+    ]
+    vi.mocked(getTodos).mockResolvedValue(mockTodos)
+
+    const { result } = renderHook(() => useTodayTodos('2026-06-15'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.inProgressTodos).toHaveLength(1)
+    expect(result.current.inProgressTodos[0].id).toBe('1')
+    expect(result.current.doneTodos).toHaveLength(1)
+    expect(result.current.doneTodos[0].id).toBe('2')
+    expect(result.current.totalCount).toBe(2)
+    expect(result.current.doneCount).toBe(1)
+  })
+
+  it('완료 목록은 doneAt 기준 내림차순으로 정렬되어야 한다', async () => {
+    const { getTodos } = await import('@/features/todo/api')
+    const mockTodos: Todo[] = [
+      makeTodo({
+        id: 'older',
+        status: 'done',
+        dueAt: localISO(2026, 6, 15, 10),
+        doneAt: localISO(2026, 6, 15, 9),
+      }),
+      makeTodo({
+        id: 'newer',
+        status: 'done',
+        dueAt: localISO(2026, 6, 15, 10),
+        doneAt: localISO(2026, 6, 15, 12),
+      }),
+    ]
+    vi.mocked(getTodos).mockResolvedValue(mockTodos)
+
+    const { result } = renderHook(() => useTodayTodos('2026-06-15'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.doneTodos.map((t) => t.id)).toEqual(['newer', 'older'])
+  })
+
+  it('해당 날짜에 todo가 없으면 markers는 "none"이어야 한다', async () => {
+    const { getTodos } = await import('@/features/todo/api')
+    vi.mocked(getTodos).mockResolvedValue([])
+
+    const { result } = renderHook(() => useTodayTodos('2026-06-15'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.markers['2026-06-15']).toBe('none')
+    // 일~토 7일 모두 키가 존재해야 한다
+    expect(Object.keys(result.current.markers)).toHaveLength(7)
+  })
+
+  it('마감일이 있고 초과되지 않았으면 markers는 "normal"이어야 한다', async () => {
+    const { getTodos } = await import('@/features/todo/api')
+    const mockTodos: Todo[] = [
+      makeTodo({ id: '1', dueAt: localISO(2026, 6, 17, 14) }), // 화 다음날(수), 2일 후
+    ]
+    vi.mocked(getTodos).mockResolvedValue(mockTodos)
+
+    const { result } = renderHook(() => useTodayTodos('2026-06-15'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.markers['2026-06-17']).toBe('normal')
+  })
+
+  it('마감 초과(getDaysLeft <= 0)인 todo가 있으면 markers는 "danger"여야 한다', async () => {
+    const { getTodos } = await import('@/features/todo/api')
+    const mockTodos: Todo[] = [
+      makeTodo({ id: '1', dueAt: localISO(2026, 6, 14, 10) }), // 일요일, 이미 지남
+    ]
+    vi.mocked(getTodos).mockResolvedValue(mockTodos)
+
+    const { result } = renderHook(() => useTodayTodos('2026-06-15'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.markers['2026-06-14']).toBe('danger')
+  })
+
+  it('주간 마커는 selectedDate가 속한 일~토 범위만 포함해야 한다', async () => {
+    const { getTodos } = await import('@/features/todo/api')
+    vi.mocked(getTodos).mockResolvedValue([])
+
+    const { result } = renderHook(() => useTodayTodos('2026-06-15'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    const keys = Object.keys(result.current.markers).sort()
+    expect(keys).toEqual([
+      '2026-06-14',
+      '2026-06-15',
+      '2026-06-16',
+      '2026-06-17',
+      '2026-06-18',
+      '2026-06-19',
+      '2026-06-20',
+    ])
+  })
+
+  it('toggleDone 호출 시 미완료 todo를 done으로 변경하고 doneAt을 세팅해야 한다', async () => {
+    const { getTodos, editTodo } = await import('@/features/todo/api')
+    const todo = makeTodo({ id: '1', status: 'todo', dueAt: localISO(2026, 6, 15, 14) })
+    vi.mocked(getTodos).mockResolvedValue([todo])
+    vi.mocked(editTodo).mockResolvedValue(todo)
+
+    const { result } = renderHook(() => useTodayTodos('2026-06-15'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    act(() => {
+      result.current.toggleDone(todo)
+    })
+
+    await waitFor(() => {
+      expect(vi.mocked(editTodo)).toHaveBeenCalled()
+    })
+
+    const [calledTodo] = vi.mocked(editTodo).mock.calls[0]
+    expect(calledTodo.status).toBe('done')
+    expect(calledTodo.doneAt).not.toBeNull()
+  })
+
+  it('toggleDone 호출 시 완료된 todo를 todo로 되돌리고 doneAt을 null로 세팅해야 한다', async () => {
+    const { getTodos, editTodo } = await import('@/features/todo/api')
+    const todo = makeTodo({
+      id: '1',
+      status: 'done',
+      dueAt: localISO(2026, 6, 15, 14),
+      doneAt: localISO(2026, 6, 15, 15),
+    })
+    vi.mocked(getTodos).mockResolvedValue([todo])
+    vi.mocked(editTodo).mockResolvedValue(todo)
+
+    const { result } = renderHook(() => useTodayTodos('2026-06-15'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    act(() => {
+      result.current.toggleDone(todo)
+    })
+
+    await waitFor(() => {
+      expect(vi.mocked(editTodo)).toHaveBeenCalled()
+    })
+
+    const [calledTodo] = vi.mocked(editTodo).mock.calls[0]
+    expect(calledTodo.status).toBe('todo')
+    expect(calledTodo.doneAt).toBeNull()
+  })
+
+  it('API 호출 실패 시 isError가 true여야 한다', async () => {
+    const { getTodos } = await import('@/features/todo/api')
+    vi.mocked(getTodos).mockRejectedValueOnce(new Error('Firestore 오류'))
+
+    const { result } = renderHook(() => useTodayTodos('2026-06-15'), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+    })
+  })
+})

--- a/client/src/features/today/hooks/useTodayTodos.ts
+++ b/client/src/features/today/hooks/useTodayTodos.ts
@@ -1,0 +1,102 @@
+import { useCallback, useMemo } from "react";
+import { useTodo } from "@/features/todo/hooks";
+import type { Todo } from "@/features/todo/types";
+import { getDaysLeft } from "@/shared/utils/due";
+import { getWeekDates, toDateKey, toDateKeyFromISO } from "@/shared/utils/date";
+
+export type DayMarker = "none" | "normal" | "danger";
+
+/** selectedDate가 속한 주(일~토)의 7개 날짜 키를 반환한다. */
+const getWeekDateKeys = (selectedDate: string): string[] =>
+  getWeekDates(selectedDate).map(toDateKey);
+
+export interface UseTodayTodosResult {
+  inProgressTodos: Todo[];
+  doneTodos: Todo[];
+  doneCount: number;
+  totalCount: number;
+  markers: Record<string, DayMarker>;
+  isLoading: boolean;
+  isError: boolean;
+  toggleDone: (todo: Todo) => void;
+}
+
+/**
+ * 선택된 날짜(dueAt 기준)에 해당하는 todo를 진행중/완료로 분리하고,
+ * 주간 스트립용 마커와 완료율을 계산한다.
+ */
+export const useTodayTodos = (selectedDate: string): UseTodayTodosResult => {
+  const { useGetTodos, useUpdateTodo } = useTodo();
+  const { data: todos, isLoading, isError } = useGetTodos;
+  const { mutate: updateTodo } = useUpdateTodo;
+
+  const todosForSelectedDate = useMemo(() => {
+    if (!todos) return [];
+    return todos.filter(
+      (todo) => todo.dueAt && toDateKeyFromISO(todo.dueAt) === selectedDate,
+    );
+  }, [todos, selectedDate]);
+
+  const inProgressTodos = useMemo(
+    () => todosForSelectedDate.filter((todo) => todo.status !== "done"),
+    [todosForSelectedDate],
+  );
+
+  const doneTodos = useMemo(
+    () =>
+      todosForSelectedDate
+        .filter((todo) => todo.status === "done")
+        .sort((a, b) => {
+          const aTime = a.doneAt ? new Date(a.doneAt).getTime() : 0;
+          const bTime = b.doneAt ? new Date(b.doneAt).getTime() : 0;
+          return bTime - aTime;
+        }),
+    [todosForSelectedDate],
+  );
+
+  const markers = useMemo(() => {
+    const weekDateKeys = getWeekDateKeys(selectedDate);
+    const result: Record<string, DayMarker> = {};
+
+    for (const dateKey of weekDateKeys) {
+      const todosOnDate = (todos ?? []).filter(
+        (todo) => todo.dueAt && toDateKeyFromISO(todo.dueAt) === dateKey,
+      );
+
+      if (todosOnDate.length === 0) {
+        result[dateKey] = "none";
+        continue;
+      }
+
+      const hasDanger = todosOnDate.some(
+        (todo) => getDaysLeft(todo.dueAt as string) <= 0,
+      );
+      result[dateKey] = hasDanger ? "danger" : "normal";
+    }
+
+    return result;
+  }, [todos, selectedDate]);
+
+  const toggleDone = useCallback(
+    (todo: Todo) => {
+      const isDone = todo.status === "done";
+      updateTodo({
+        ...todo,
+        status: isDone ? "todo" : "done",
+        doneAt: isDone ? null : new Date().toISOString(),
+      });
+    },
+    [updateTodo],
+  );
+
+  return {
+    inProgressTodos,
+    doneTodos,
+    doneCount: doneTodos.length,
+    totalCount: todosForSelectedDate.length,
+    markers,
+    isLoading,
+    isError,
+    toggleDone,
+  };
+};

--- a/client/src/features/today/pages/todayPage.styles.tsx
+++ b/client/src/features/today/pages/todayPage.styles.tsx
@@ -1,0 +1,15 @@
+import { styled } from "styled-components";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+`;
+
+const List = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export { Container, List };

--- a/client/src/features/today/pages/todayPage.tsx
+++ b/client/src/features/today/pages/todayPage.tsx
@@ -1,0 +1,110 @@
+import { useState } from "react";
+import { Sun, Plus } from "lucide-react";
+import { useTodayTodos } from "../hooks/useTodayTodos";
+import { useTodo } from "@/features/todo/hooks";
+import { formatTodayLabel } from "@/shared/utils/formatToday";
+import { toDateKey } from "@/shared/utils/date";
+import { EmptyState, TodayItemSkeleton, Modal } from "@/shared";
+import TodoForm from "@/features/todo/components/todoForm/todoForm";
+import WeekStrip from "../components/weekStrip";
+import DailyProgress from "../components/dailyProgress";
+import TodaySection from "../components/todaySection";
+import TodayTodoItem from "../components/todayTodoItem";
+import { Container, List } from "./todayPage.styles";
+
+const TodayPage = () => {
+  const [selectedDate, setSelectedDate] = useState(() => toDateKey(new Date()));
+  const [isAddOpen, setIsAddOpen] = useState(false);
+
+  const {
+    inProgressTodos,
+    doneTodos,
+    doneCount,
+    totalCount,
+    markers,
+    isLoading,
+    isError,
+    toggleDone,
+  } = useTodayTodos(selectedDate);
+  const { useGetTodos } = useTodo();
+
+  const hasTodos = inProgressTodos.length > 0 || doneTodos.length > 0;
+
+  return (
+    <Container>
+      <WeekStrip
+        selectedDate={selectedDate}
+        markers={markers}
+        onSelectDate={setSelectedDate}
+      />
+      <DailyProgress
+        dateLabel={formatTodayLabel(selectedDate)}
+        doneCount={doneCount}
+        totalCount={totalCount}
+      />
+
+      {isLoading && <TodayItemSkeleton />}
+
+      {!isLoading && isError && (
+        <EmptyState
+          icon={Sun}
+          title="할 일을 불러오지 못했습니다"
+          description="잠시 후 다시 시도해주세요"
+          actionLabel="다시 시도"
+          onAction={() => useGetTodos.refetch()}
+        />
+      )}
+
+      {!isLoading && !isError && !hasTodos && (
+        <EmptyState
+          icon={Sun}
+          title="오늘 할 일이 없습니다"
+          description="여유로운 하루네요. 새로운 할 일을 추가해보세요"
+          actionLabel="새 할 일 추가"
+          actionIcon={Plus}
+          onAction={() => setIsAddOpen(true)}
+        />
+      )}
+
+      {!isLoading && !isError && hasTodos && (
+        <>
+          {inProgressTodos.length > 0 && (
+            <TodaySection title="진행 중">
+              <List>
+                {inProgressTodos.map((todo) => (
+                  <TodayTodoItem
+                    key={todo.id}
+                    todo={todo}
+                    onToggleDone={toggleDone}
+                  />
+                ))}
+              </List>
+            </TodaySection>
+          )}
+
+          {doneTodos.length > 0 && (
+            <TodaySection title="완료">
+              <List>
+                {doneTodos.map((todo) => (
+                  <TodayTodoItem
+                    key={todo.id}
+                    todo={todo}
+                    onToggleDone={toggleDone}
+                  />
+                ))}
+              </List>
+            </TodaySection>
+          )}
+        </>
+      )}
+
+      <Modal
+        isOpen={isAddOpen}
+        setIsOpen={setIsAddOpen}
+        children={<TodoForm onClose={() => setIsAddOpen(false)} />}
+      />
+    </Container>
+  );
+};
+
+export default TodayPage;

--- a/client/src/layouts/bottomTabBar/bottomTabBar.styles.tsx
+++ b/client/src/layouts/bottomTabBar/bottomTabBar.styles.tsx
@@ -1,0 +1,39 @@
+import { styled } from "styled-components";
+import { NavLink } from "react-router-dom";
+import { colors } from "@/styles/colors";
+
+/** 탭바 전체 높이(약): padding 10px*2 + 아이콘 20px + gap 4px + 라벨 약 13px */
+export const BOTTOM_TAB_BAR_HEIGHT = 57;
+
+const TabBarContainer = styled.nav`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-around;
+  padding: 10px 0;
+  background-color: ${colors.background.primary};
+  border-top: 0.5px solid ${colors.border.tertiary};
+  z-index: 10;
+`;
+
+const TabNavLink = styled(NavLink)`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  min-height: 44px;
+  font-size: 11px;
+  color: ${colors.text.tertiary};
+  text-decoration: none;
+
+  &.active {
+    color: ${colors.brand.primary};
+    font-weight: 500;
+  }
+`;
+
+export { TabBarContainer, TabNavLink };

--- a/client/src/layouts/bottomTabBar/bottomTabBar.tsx
+++ b/client/src/layouts/bottomTabBar/bottomTabBar.tsx
@@ -1,0 +1,24 @@
+import { Sun, ListChecks, PieChart, KanbanIcon } from "lucide-react";
+import { TabNavLink, TabBarContainer } from "./bottomTabBar.styles";
+
+const TAB_ITEMS = [
+  { path: "/today", icon: Sun, label: "오늘" },
+  { path: "/todo", icon: ListChecks, label: "목록" },
+  { path: "/pie-chart", icon: PieChart, label: "차트" },
+  { path: "/kanban", icon: KanbanIcon, label: "칸반" },
+] as const;
+
+const BottomTabBar = () => {
+  return (
+    <TabBarContainer role="navigation" aria-label="하단 탭 메뉴">
+      {TAB_ITEMS.map(({ path, icon: Icon, label }) => (
+        <TabNavLink key={path} to={path} aria-label={label}>
+          <Icon size={20} />
+          <span>{label}</span>
+        </TabNavLink>
+      ))}
+    </TabBarContainer>
+  );
+};
+
+export default BottomTabBar;

--- a/client/src/layouts/mobileHeader/mobileHeader.styles.tsx
+++ b/client/src/layouts/mobileHeader/mobileHeader.styles.tsx
@@ -1,0 +1,54 @@
+import { styled } from "styled-components";
+import { colors } from "@/styles/colors";
+import { radius } from "@/styles/radius";
+
+const HeaderContainer = styled.header`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 56px;
+  padding: 0 16px;
+  background-color: ${colors.background.primary};
+  border-bottom: 1px solid ${colors.border.tertiary};
+`;
+
+const LogoGroup = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const LogoMark = styled.span`
+  width: 24px;
+  height: 24px;
+  border-radius: ${radius.md};
+  background-color: ${colors.brand.primary};
+`;
+
+const LogoText = styled.span`
+  font-size: 16px;
+  font-weight: 600;
+  color: ${colors.text.primary};
+`;
+
+const AvatarButton = styled.button`
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+`;
+
+const AvatarImage = styled.img`
+  width: 28px;
+  height: 28px;
+  border-radius: ${radius.full};
+  background-color: ${colors.background.secondary};
+  object-fit: cover;
+`;
+
+export { HeaderContainer, LogoGroup, LogoMark, LogoText, AvatarButton, AvatarImage };

--- a/client/src/layouts/mobileHeader/mobileHeader.tsx
+++ b/client/src/layouts/mobileHeader/mobileHeader.tsx
@@ -1,0 +1,31 @@
+import { useAuth } from "@/features/auth/context/useAuth";
+import {
+  HeaderContainer,
+  LogoGroup,
+  LogoMark,
+  LogoText,
+  AvatarButton,
+  AvatarImage,
+} from "./mobileHeader.styles";
+
+interface MobileHeaderProps {
+  onAvatarClick: () => void;
+}
+
+const MobileHeader = ({ onAvatarClick }: MobileHeaderProps) => {
+  const { user } = useAuth();
+
+  return (
+    <HeaderContainer>
+      <LogoGroup>
+        <LogoMark aria-hidden="true" />
+        <LogoText>tododo</LogoText>
+      </LogoGroup>
+      <AvatarButton onClick={onAvatarClick} aria-label="사용자 메뉴 열기">
+        <AvatarImage src={user?.photoURL || ""} alt="" />
+      </AvatarButton>
+    </HeaderContainer>
+  );
+};
+
+export default MobileHeader;

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -8,6 +8,7 @@ import HomePage from "@/HomePage";
 import { TodoDetail } from "@/features/todo";
 import LoginPage from "@/features/auth/pages/loginPage";
 import ProtectedRoute from "@/features/auth/components/protectedRoute";
+import TodayPage from "@/features/today/pages/todayPage";
 
 export const router = createBrowserRouter([
   {
@@ -31,6 +32,10 @@ export const router = createBrowserRouter([
             element: <TodoDetail />,
           },
         ],
+      },
+      {
+        path: "today",
+        element: <TodayPage />,
       },
       {
         path: "todo",

--- a/client/src/shared/ui/index.ts
+++ b/client/src/shared/ui/index.ts
@@ -5,6 +5,7 @@ export { default as ConfirmModal } from "./confirmModal/confirmModal";
 export { default as EmptyState } from "./emptyState/emptyState";
 export { default as CheckboxSkeleton } from "./skeleton/checkboxSkeleton";
 export { default as KanbanSkeleton } from "./skeleton/kanbanSkeleton";
+export { default as TodayItemSkeleton } from "./skeleton/todayItemSkeleton";
 export { ToastProvider } from "./toast/toastContext";
 export { useToast } from "./toast/useToast";
 export { default as BottomSheet } from "./bottomSheet/bottomSheet";

--- a/client/src/shared/ui/skeleton/todayItemSkeleton.styles.tsx
+++ b/client/src/shared/ui/skeleton/todayItemSkeleton.styles.tsx
@@ -1,0 +1,84 @@
+import { styled, keyframes } from "styled-components";
+import { colors } from "@/styles/colors";
+import { radius } from "@/styles/radius";
+
+const shimmer = keyframes`
+  0% {
+    background-position: -200px 0;
+  }
+  100% {
+    background-position: 200px 0;
+  }
+`;
+
+const pulse = keyframes`
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+`;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 0 16px;
+`;
+
+const SkeletonItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid ${colors.border.tertiary};
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+const CheckboxCircle = styled.div<{ $delay: number }>`
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  border-radius: ${radius.full};
+  background-color: ${colors.background.secondary};
+  animation: ${pulse} 1.5s ease-in-out infinite;
+  animation-delay: ${({ $delay }) => $delay}s;
+`;
+
+const TextGroup = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+`;
+
+const SkeletonText = styled.div<{ $width: string; $delay: number }>`
+  height: 14px;
+  width: ${({ $width }) => $width};
+  background: linear-gradient(
+    90deg,
+    ${colors.background.secondary} 25%,
+    ${colors.border.tertiary} 50%,
+    ${colors.background.secondary} 75%
+  );
+  background-size: 400px 100%;
+  border-radius: 4px;
+  animation: ${shimmer} 1.5s ease-in-out infinite;
+  animation-delay: ${({ $delay }) => $delay * 0.1}s;
+`;
+
+const SkeletonSubText = styled(SkeletonText)`
+  height: 10px;
+`;
+
+export {
+  Container,
+  SkeletonItem,
+  CheckboxCircle,
+  TextGroup,
+  SkeletonText,
+  SkeletonSubText,
+};

--- a/client/src/shared/ui/skeleton/todayItemSkeleton.tsx
+++ b/client/src/shared/ui/skeleton/todayItemSkeleton.tsx
@@ -1,0 +1,33 @@
+import {
+  Container,
+  SkeletonItem,
+  CheckboxCircle,
+  TextGroup,
+  SkeletonText,
+  SkeletonSubText,
+} from "./todayItemSkeleton.styles";
+
+interface TodayItemSkeletonProps {
+  count?: number;
+}
+
+const TodayItemSkeleton = ({ count = 3 }: TodayItemSkeletonProps) => {
+  const items = Array.from({ length: count }, (_, i) => i);
+  const widths = ["70%", "55%", "65%", "45%"];
+
+  return (
+    <Container>
+      {items.map((index) => (
+        <SkeletonItem key={index}>
+          <CheckboxCircle $delay={index * 0.2} />
+          <TextGroup>
+            <SkeletonText $width={widths[index % widths.length]} $delay={index} />
+            <SkeletonSubText $width="35%" $delay={index} />
+          </TextGroup>
+        </SkeletonItem>
+      ))}
+    </Container>
+  );
+};
+
+export default TodayItemSkeleton;

--- a/client/src/shared/utils/__tests__/formatToday.test.ts
+++ b/client/src/shared/utils/__tests__/formatToday.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { formatTodayLabel, formatDueTime } from '../formatToday'
+
+describe('formatToday 유틸 함수', () => {
+  beforeEach(() => {
+    // 2026-06-15 (월요일) 기준으로 고정
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-15T03:00:00'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('formatTodayLabel', () => {
+    it('오늘 날짜이면 "N월 N일, 오늘" 형식을 반환해야 한다', () => {
+      expect(formatTodayLabel('2026-06-15')).toBe('6월 15일, 오늘')
+    })
+
+    it('오늘이 아니면 "N월 N일, 요일" 형식을 반환해야 한다', () => {
+      expect(formatTodayLabel('2026-06-16')).toBe('6월 16일, 화요일')
+    })
+
+    it('과거 날짜도 요일 형식으로 반환해야 한다', () => {
+      expect(formatTodayLabel('2026-06-14')).toBe('6월 14일, 일요일')
+    })
+
+    it('월/일이 바뀌는 경계에서도 올바르게 동작해야 한다', () => {
+      expect(formatTodayLabel('2026-07-01')).toBe('7월 1일, 수요일')
+    })
+  })
+
+  describe('formatDueTime', () => {
+    it('오전 시간이면 "오전 N시"를 반환해야 한다', () => {
+      const dueAt = new Date(2026, 5, 15, 9, 0).toISOString()
+      expect(formatDueTime(dueAt)).toBe('오전 9시')
+    })
+
+    it('오후 시간이면 "오후 N시"를 반환해야 한다', () => {
+      const dueAt = new Date(2026, 5, 15, 14, 0).toISOString()
+      expect(formatDueTime(dueAt)).toBe('오후 2시')
+    })
+
+    it('정오(12시)는 "오후 12시"를 반환해야 한다', () => {
+      const dueAt = new Date(2026, 5, 15, 12, 0).toISOString()
+      expect(formatDueTime(dueAt)).toBe('오후 12시')
+    })
+
+    it('자정(00:00)이면 시간 정보 없음으로 간주하여 null을 반환해야 한다', () => {
+      const dueAt = new Date(2026, 5, 15, 0, 0).toISOString()
+      expect(formatDueTime(dueAt)).toBeNull()
+    })
+
+    it('분 단위가 있어도 시 단위로만 표시해야 한다', () => {
+      const dueAt = new Date(2026, 5, 15, 18, 30).toISOString()
+      expect(formatDueTime(dueAt)).toBe('오후 6시')
+    })
+  })
+})

--- a/client/src/shared/utils/date.ts
+++ b/client/src/shared/utils/date.ts
@@ -1,0 +1,38 @@
+/**
+ * "yyyy-MM-dd" 형태의 날짜 문자열을 로컬 타임존 기준 Date로 변환한다.
+ * `new Date("yyyy-MM-dd")`는 UTC 자정으로 해석되어 타임존에 따라
+ * 하루가 어긋날 수 있으므로, 연/월/일을 분리해 로컬 Date를 직접 생성한다.
+ */
+export const parseLocalDateOnly = (date: string): Date => {
+  const [year, month, day] = date.split("-").map(Number);
+  return new Date(year, (month ?? 1) - 1, day ?? 1);
+};
+
+/** Date를 로컬 타임존 기준 "yyyy-MM-dd" 문자열로 변환한다. */
+export const toDateKey = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+/** ISO 문자열을 로컬 타임존 기준 "yyyy-MM-dd" 키로 변환한다. */
+export const toDateKeyFromISO = (iso: string): string => toDateKey(new Date(iso));
+
+export const isSameLocalDay = (a: Date, b: Date): boolean =>
+  a.getFullYear() === b.getFullYear() &&
+  a.getMonth() === b.getMonth() &&
+  a.getDate() === b.getDate();
+
+/** selectedDate가 속한 주(일~토)의 7개 Date를 반환한다. */
+export const getWeekDates = (selectedDate: string): Date[] => {
+  const target = parseLocalDateOnly(selectedDate);
+  const sunday = new Date(target);
+  sunday.setDate(target.getDate() - target.getDay());
+
+  return Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(sunday);
+    d.setDate(sunday.getDate() + i);
+    return d;
+  });
+};

--- a/client/src/shared/utils/formatToday.ts
+++ b/client/src/shared/utils/formatToday.ts
@@ -1,0 +1,44 @@
+import { parseLocalDateOnly, isSameLocalDay } from "./date";
+
+const WEEKDAY_LABELS = ["일요일", "월요일", "화요일", "수요일", "목요일", "금요일", "토요일"];
+
+/**
+ * 날짜 타이틀 포맷.
+ * - 오늘이면 "6월 15일, 오늘"
+ * - 오늘이 아니면 "6월 16일, 화요일"
+ */
+export function formatTodayLabel(date: string): string {
+  const target = parseLocalDateOnly(date);
+  const today = new Date();
+
+  const month = target.getMonth() + 1;
+  const day = target.getDate();
+  const datePart = `${month}월 ${day}일`;
+
+  if (isSameLocalDay(target, today)) {
+    return `${datePart}, 오늘`;
+  }
+
+  const weekday = WEEKDAY_LABELS[target.getDay()];
+  return `${datePart}, ${weekday}`;
+}
+
+/**
+ * 마감 시각 포맷. "오후 2시" 형태.
+ * dueAt이 자정(00:00, 시간 정보 없음으로 간주)이면 null을 반환한다.
+ */
+export function formatDueTime(dueAt: string): string | null {
+  const due = new Date(dueAt);
+
+  const hours = due.getHours();
+  const minutes = due.getMinutes();
+
+  if (hours === 0 && minutes === 0) {
+    return null;
+  }
+
+  const period = hours < 12 ? "오전" : "오후";
+  const hour12 = hours % 12 === 0 ? 12 : hours % 12;
+
+  return `${period} ${hour12}시`;
+}

--- a/client/src/shared/utils/index.ts
+++ b/client/src/shared/utils/index.ts
@@ -1,2 +1,10 @@
 export { api } from "./api";
 export { DUE_SOON_DAYS, getDaysLeft, getDueBadgeLabel } from "./due";
+export { formatTodayLabel, formatDueTime } from "./formatToday";
+export {
+  parseLocalDateOnly,
+  toDateKey,
+  toDateKeyFromISO,
+  isSameLocalDay,
+  getWeekDates,
+} from "./date";

--- a/client/src/styles/__tests__/statusColors.test.ts
+++ b/client/src/styles/__tests__/statusColors.test.ts
@@ -27,7 +27,8 @@ describe('statusColors', () => {
     })
 
     it('done 상태는 초록색 계열 색상을 가져야 한다', () => {
-      expect(statusColors.done.main).toBe('#10b981')
+      // 리브랜딩 스펙(1-4) 기준 브랜드 secondary 틸 색상으로 통일됨
+      expect(statusColors.done.main).toBe('#1D9E75')
     })
   })
 

--- a/client/src/styles/colors.ts
+++ b/client/src/styles/colors.ts
@@ -1,0 +1,25 @@
+export const colors = {
+  brand: {
+    primary: "#0F6E56",
+    secondary: "#1D9E75",
+  },
+  danger: {
+    main: "#E24B4A",
+    background: "#FBEAEA",
+    text: "#C53A39",
+  },
+  background: {
+    primary: "#FFFFFF",
+    secondary: "#F4F5F6",
+  },
+  text: {
+    primary: "#1A1A1A",
+    secondary: "#5F6368",
+    tertiary: "#9AA0A6",
+  },
+  border: {
+    secondary: "#D1D5DB",
+    tertiary: "#E5E7EB",
+    danger: "#E24B4A",
+  },
+} as const;

--- a/client/src/styles/design/rebranding-spec.md
+++ b/client/src/styles/design/rebranding-spec.md
@@ -1,0 +1,308 @@
+# ToDoDo 리브랜딩 스펙 — 모바일 "오늘" 화면 (Teal)
+
+- 시안 소스: `tododo_mobile_planner_teal.html` (정적 HTML 목업, Tabler Icons 가정)
+- 작업 범위: ① 전역 디자인 토큰 도입 ② 모바일 "오늘" 화면 신규 구현 ③ 모바일 하단 탭바 신규 도입
+- 상태: **설계 완료 / 구현 대기**. 사용자 승인 후 ui-ux-improver가 구현.
+
+---
+
+## 0. 현재 코드베이스 조사 결과 (Gap 분석 근거)
+
+### 0-1. 디자인 토큰 시스템
+- `ThemeProvider`/`GlobalStyle` 없음. styled-components를 사용하지만 테마 객체가 존재하지 않음.
+- 존재하는 토큰 파일은 2개뿐:
+  - `client/src/styles/statusColors.ts` — todo/doing/done 상태 색상만 정의 (main/light/border)
+  - `client/src/styles/breakpoints.ts` — `mobile(480)/tablet(768)/desktop(1024)` + `media` 헬퍼
+- 브랜드 컬러는 **`#1c72eb` (블루)** 가 22개 파일에 하드코딩되어 분산. 그 외 텍스트/보더 색상(`#1a1a1a`, `#5f6368`, `#e0e0e0`, `#666`, `#9aa0a6` 등)도 각 styles 파일에 중복 정의됨.
+- CSS 변수(`--color-*`, `--border-radius-*`, `--font-sans`) 시스템은 **존재하지 않음**. 시안의 변수명은 새로 도입해야 함.
+- radius 값도 컴포넌트마다 제각각(`6px`, `8px`, `12px`, `50%`, `99px`)이며 통일된 scale 없음.
+
+### 0-2. 모바일 네비게이션 구조
+- 하단 탭바는 **존재하지 않음**.
+- 현재 모바일 처리: `tablet(768px)` 이하에서 좌측 SNB가 사라지고, `Header`의 햄버거 버튼 → `MobileDrawer`(좌측 슬라이드 오버레이, NavLink 4개: list/calendar/chart/kanban)로 대체됨.
+- `HomePage.tsx`는 `isMobile`(useMediaQuery("tablet")) 분기로 데스크톱은 `ResizeableLayout`(3분할: TodoList/DueTodo/PieChart), 모바일은 `MobileHomePage`(상단 탭 3개: 할 일/마감 임박/차트)를 렌더링. 시안의 "오늘" 단일 화면 + 하단 탭바 구조와는 완전히 다른 패턴.
+- `App.tsx`가 `Header` + `SNB` + `Outlet` + `Footer` + `MobileDrawer`를 항상 렌더링하는 공통 셸. 모바일 전용 셸(헤더+하단탭바, Footer 제외)은 없음.
+
+### 0-3. "오늘" / 홈 화면 현황
+- `client/src/pages/MobileHomePage.tsx`: 상단 탭(할 일/마감 임박/차트) 전환형 UI. 시안의 "주간 스트립 + 진행률 + 진행중/완료 리스트" 구조와 다름 → **신규로 다시 설계**해야 함(완전 대체 또는 신규 라우트 분리 필요, 아래 3-1 결정사항 참고).
+- 데스크톱용 `DueTodo`(`features/todo/components/dueTodo.tsx`)가 "마감 임박" 배지 로직(`getDaysLeft`, `getDueBadgeLabel`, `DUE_SOON_DAYS=3`)을 이미 보유 — 시안의 "38일 초과" 배지와 동일한 패턴이라 그대로 재사용 가능.
+- `StatusSelect`(`features/todo/components/todoListItem/statusSelect.tsx`)가 상태 변경 BottomSheet UI를 이미 보유 — 시안의 원형 체크박스와는 다른 패턴(상태 3종 vs 체크 토글)이라 신규 컴포넌트 필요.
+
+### 0-4. 아이콘 라이브러리
+- **`lucide-react`** 사용 중. 시안은 Tabler Icons(`ti ti-*`) 기준이나 이는 목업 생성 도구의 기본값으로 추정.
+- **결정: Tabler Icons를 새로 도입하지 않고 lucide-react로 매핑한다** (의존성 추가 비용 대비 이점 없음, 기존 전체 코드베이스와의 일관성 우선).
+  - `ti-sun` → `Sun`
+  - `ti-list-check` → `ListChecks` (기존 SNB에서는 `ListCheckIcon` 별칭 사용 중)
+  - `ti-chart-pie` → `PieChart`
+  - `ti-layout-kanban` → `LayoutDashboard` 또는 `Trello`(lucide-react에 `LayoutKanban` 없음 — 대체 필요, 아래 1-5 참고)
+  - `ti-check` → `Check`
+
+### 0-5. 데이터 모델 매핑 검증
+- 시안 "투두두 프로젝트" (하위 텍스트) → 현 데이터 모델에는 "프로젝트" 엔티티가 없음. `parentId`는 하위 할 일(subtask) 계층만 표현하며 "프로젝트 그룹"이 아님.
+  - **결론: 이번 리브랜딩 범위에서는 "프로젝트명" 서브텍스트를 그대로 구현하지 않는다.** 데이터 모델에 없는 개념이므로 임의로 지어내면 잘못된 정보. 대체로 `description`(있는 경우) 또는 빈 값 처리. 신규 "프로젝트" 개념 도입은 별도 PM 논의 필요 — 범위 제외.
+- 시안 "오후 2시" (마감 시간 표시) → `dueAt`에서 시간 파싱 가능. `dueAt`이 자정(00:00) 데이터인 기존 레코드가 많을 경우 "시간 없음" 처리 필요 (아래 3-3 참고).
+- 시안 "38일 초과" 배지 → `getDaysLeft(dueAt)` + `getDueBadgeLabel`로 이미 구현된 로직과 100% 일치. 그대로 재사용.
+- 시안 "2/5 완료" + 진행률 바 → `status === "done"` 카운트 / 오늘 날짜에 해당하는 todo 전체 카운트로 계산. "오늘 날짜에 해당하는 todo"의 기준은 `dueAt`이 해당 날짜인 것으로 정의(아래 1-2 참고).
+- 시안 "완료" 섹션 체크 아이콘 → `status === "done"`이며 `doneAt` 존재. 정렬 기준은 `doneAt` desc 권장.
+- 주간 스트립의 "일정 있는 날 dot 마커" → 해당 날짜에 `dueAt`이 있는 todo 존재 여부. 레드 dot(위험)은 그 날짜에 마감 임박/초과(`getDaysLeft <= 0`) 항목이 있는 경우로 정의.
+
+---
+
+## 1. 디자인 토큰 정의
+
+### 1-1. 신규 파일: `client/src/styles/colors.ts`
+시안의 CSS 변수명을 의미 기반 토큰명으로 채택하고 실제 값을 확정한다. 기존 `statusColors.ts`는 유지하되 동일한 의미 축(예: `done`)에 모순 없도록 정리한다.
+
+```ts
+export const colors = {
+  brand: {
+    primary: "#0F6E56",   // 딥 틸 — 로고, 오늘 날짜 하이라이트, 활성 탭 아이콘
+    secondary: "#1D9E75", // 밝은 틸 — 진행률 바, 완료 체크 배경
+  },
+  danger: {
+    main: "#E24B4A",      // 레드 — 마감 초과/위험 dot, 배지 보더
+    background: "#FBEAEA", // 레드 배경(배지) — 신규 산정값, 디자이너 검토 필요(시안에 실값 없음)
+    text: "#C53A39",        // 레드 텍스트(배지) — 신규 산정값, 디자이너 검토 필요(시안에 실값 없음)
+  },
+  background: {
+    primary: "#FFFFFF",
+    secondary: "#F4F5F6",   // 진행률 바 배경, 아바타 배경 등
+  },
+  text: {
+    primary: "#1A1A1A",
+    secondary: "#5F6368",
+    tertiary: "#9AA0A6",    // 날짜 스트립 비활성, 보조 라벨
+  },
+  border: {
+    secondary: "#D1D5DB",   // 체크박스 미체크 보더
+    tertiary: "#E5E7EB",    // 리스트 구분선, 카드 보더
+    danger: "#E24B4A",      // 위험 항목 체크박스 보더
+  },
+} as const;
+```
+
+> **확인 필요 사항(승인 시 결정)**: 시안 HTML에는 `--color-background-danger`, `--color-text-danger`, `--color-border-secondary` 등의 실제 값이 정의되어 있지 않았다(변수명만 존재). 위 표의 danger 배경/텍스트 값은 브랜드 레드(`#E24B4A`)에서 합리적으로 도출한 추정값이다. 디자이너 검토 시 확정 필요.
+
+### 1-2. 신규 파일: `client/src/styles/radius.ts`
+```ts
+export const radius = {
+  sm: "6px",   // 날짜 스트립 셀, 배지
+  md: "8px",   // 카드, 배지(시안 --border-radius-md)
+  xl: "20px",  // 모바일 화면 컨테이너 라운드(시안 --border-radius-xl, 데스크톱 프리뷰 프레임용 — 실제 모바일 풀스크린에서는 미적용)
+  full: "50%", // 원형(체크박스, 아바타)
+} as const;
+```
+
+### 1-3. 타이포그래피
+신규 폰트 도입 없음. 시안의 `--font-sans`는 시스템 기본 산세리프로 간주하고 별도 웹폰트 로드는 하지 않는다(기존 프로젝트에 폰트 로드 코드 없음 확인됨). 폰트 크기 스케일만 컴포넌트 설계에서 직접 px 지정(아래 2장 참고) — 별도 typography 토큰 파일은 이번 범위에서 생성하지 않음(과설계 방지, 추후 필요 시 확장).
+
+### 1-4. `statusColors.ts` 와의 관계
+- `statusColors.done.main = "#10b981"`(현재)과 시안의 완료 체크 색상 `#1D9E75`(brand.secondary)는 다른 값.
+- **결정: `statusColors.done.main`을 `#1D9E75`로 통일한다.** 리스트뷰(`StatusSelect`)와 모바일 "오늘" 화면에서 "완료"가 다른 초록색으로 보이는 불일치를 제거. `statusColors.doing`, `statusColors.todo`는 이번 범위에서 변경하지 않음(시안에 해당 상태 표현 없음, 별도 작업으로 분리).
+
+### 1-5. 아이콘 매핑 확정
+| 시안 (Tabler) | lucide-react | 용도 |
+|---|---|---|
+| `ti-sun` | `Sun` | 하단 탭 "오늘" |
+| `ti-list-check` | `ListChecks` | 하단 탭 "목록" (기존 SNB `ListCheckIcon`과 동일 아이콘, import명 통일 권장) |
+| `ti-chart-pie` | `PieChart` | 하단 탭 "차트" |
+| `ti-layout-kanban` | `LayoutDashboard` | 하단 탭 "칸반" — lucide-react에 정확한 kanban 아이콘 없음. `LayoutDashboard`로 대체(기존 SNB는 `KanbanIcon`을 쓰고 있으나 이는 lucide의 실제 export명이 아닐 수 있음 — **ui-ux-improver는 구현 시 `lucide-react` 패키지에 실제로 존재하는 export인지 빌드 타임에 검증할 것**) |
+| `ti-check` | `Check` | 완료 체크 아이콘 |
+
+---
+
+## 2. 화면 구조 — 모바일 "오늘" 화면
+
+### 2-1. 라우팅 결정
+- 신규 라우트: `/today` (모바일 전용 진입점). 기존 `/`(HomePage)의 모바일 분기(`MobileHomePage`, 상단 탭형)는 이번 리브랜딩에서 **교체**한다.
+- 데스크톱(`tablet` 이상)에서는 기존 `ResizeableLayout` 3분할 그대로 유지 — 이번 스펙은 모바일(`tablet` 이하, ≤768px) 범위만 다룬다.
+- `useMediaQuery("tablet")` 분기 유지: `isMobile === true`일 때 신규 `TodayPage`(가칭) 렌더링.
+
+### 2-2. ASCII 와이어프레임
+
+```
+┌─────────────────────────────────────┐
+│ [틸 로고24] tododo          (수영)○ │  ← 헤더, 56px
+├─────────────────────────────────────┤
+│ 일14  [월15●]  화16˙ 수17  목18˙ 금19 토20 │  ← 주간 스트립, 가로 스크롤
+├─────────────────────────────────────┤
+│ 6월 15일, 오늘            2 / 5 완료 │  ← 날짜 타이틀 + 완료율(틸)
+│ ▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░░░░░░░░░░░░░  │  ← 진행률 바 6px
+├─────────────────────────────────────┤
+│ 진행 중                              │
+│ ○  투두두                  오후 2시  │
+│    투두두 프로젝트                   │
+│ ○  블로그 글쓰기            오후 6시  │
+│    블로그 글쓰기 프로젝트             │
+│ ○  마카이브            [38일 초과]   │  ← 레드 보더 + 레드 배지
+│    마카이브 프로젝트                  │
+├─────────────────────────────────────┤
+│ 완료                                 │
+│ ●✓ 버그 픽스: 리다이렉트 수정 (취소선)│
+│ ●✓ 디자인 시안 검토 (취소선)         │
+├─────────────────────────────────────┤
+│  ☀오늘   ☑목록   ◔차트   ▦칸반      │  ← 하단 탭바, 활성=틸
+└─────────────────────────────────────┘
+```
+
+### 2-3. 데스크톱과의 관계
+- 헤더(로고+아바타)와 하단 탭바는 **모바일 전용**. 데스크톱 `Header`(로고+사용자명+로그아웃 텍스트)와 `SNB`는 변경하지 않음 — 이번 스펙 범위 밖.
+- "오늘" 화면 자체(주간 스트립~완료 리스트)는 모바일 전용 신규 화면이며 데스크톱에 대응 화면 없음(데스크톱은 기존 3분할 유지).
+
+---
+
+## 3. 컴포넌트 설계
+
+### 3-0. 디렉토리 구조 제안
+```
+client/src/features/today/              # 신규 feature
+├── components/
+│   ├── weekStrip.tsx
+│   ├── weekStrip.styles.tsx
+│   ├── dailyProgress.tsx
+│   ├── dailyProgress.styles.tsx
+│   ├── todaySection.tsx          # "진행 중"/"완료" 섹션 공용
+│   ├── todaySection.styles.tsx
+│   ├── todayTodoItem.tsx
+│   └── todayTodoItem.styles.tsx
+├── hooks/
+│   └── useTodayTodos.ts          # 오늘자 todos 필터링 + 진행률 계산
+└── pages/
+    └── todayPage.tsx
+
+client/src/layouts/bottomTabBar/         # 신규 (layouts 하위, App 셸 레벨)
+├── bottomTabBar.tsx
+└── bottomTabBar.styles.tsx
+```
+
+`features/todo`의 기존 자산(타입, `useTodo`, `DUE_SOON_DAYS`/`getDaysLeft`/`getDueBadgeLabel`)을 import해서 사용 — 중복 구현 금지.
+
+### 3-1. `App.tsx` 변경 방향 (모바일 전용 하단 탭바 삽입)
+- 모바일(`isMobile`)일 때만 `BottomTabBar`를 `Footer` 대신 렌더링. 데스크톱 `Footer`(GitHub/Contact 링크)는 모바일에서 의미가 낮으므로 유지 여부는 PM 확인 필요 — **기본 제안: 모바일에서는 `Footer` 숨기고 `BottomTabBar`로 대체**.
+- 모바일에서 `Header`도 시안처럼 "로고+아바타만" 보이는 축약형으로 바꿀지, 기존 `Header`(로그아웃 버튼 포함)를 유지할지 결정 필요 — **기본 제안: 모바일 전용 `MobileHeader` 신규 컴포넌트(로고 24px 틸 라운드사각형 + "tododo" 텍스트 + 우측 아바타, 클릭 시 기존 `MobileDrawer` 오픈)** 도입. 기존 `MobileDrawer`(로그아웃/네비) 진입점을 아바타 클릭으로 변경.
+- `MobileHomePage.tsx`(상단 탭형)는 신규 `TodayPage` 도입 후 더 이상 `/` 라우트에서 쓰이지 않게 됨. 완전 삭제 여부는 다른 화면(목록/차트 탭 전환 UX)이 하단 탭바로 대체되는 시점에 결정 — **이번 범위에서는 파일을 삭제하지 않고 미사용 상태로 둔 뒤, 하단 탭바 라우팅 전환이 끝나면 후속 작업에서 제거**.
+
+### 3-2. `WeekStrip`
+```ts
+interface WeekStripProps {
+  selectedDate: string;       // ISO yyyy-MM-dd
+  markers: Record<string, "none" | "normal" | "danger">; // 날짜별 dot 색상
+  onSelectDate: (date: string) => void;
+}
+```
+- 7일 = 선택된 날짜를 중심으로 일~토 1주(시안과 동일, 일요일 시작 가정 — 기존 코드베이스에 주 시작 요일 설정 없음, 신규 결정 필요시 PM 확인).
+- 가로 스크롤 가능 (`overflow-x: auto`), 각 셀 너비 38px, gap 8px — 시안 그대로.
+- 오늘 셀: `background: colors.brand.primary`, 텍스트 `#fff`. 비활성 셀: `color: colors.text.tertiary`.
+- dot 마커: `normal` → `colors.brand.primary` 4px 원, `danger` → `colors.danger.main` 4px 원. 둘 다 없으면 dot 미표시.
+- 터치 타겟: 셀 전체 클릭 가능 영역 최소 44px height 확보 위해 `padding: 8px 0` + 내부 컨텐츠로 시안의 38x~46px 셀을 44px 이상으로 보정(시안은 시각 목업이라 44px 터치 타겟 미고려 — **ui-ux-improver는 셀 높이를 44px 이상으로 확보할 것**).
+
+### 3-3. `DailyProgress`
+```ts
+interface DailyProgressProps {
+  dateLabel: string;     // "6월 15일, 오늘"
+  doneCount: number;
+  totalCount: number;    // 오늘 dueAt 기준 todo 전체 개수
+}
+```
+- 완료율 텍스트: `${doneCount} / ${totalCount} 완료`, 색상 `colors.brand.primary`, 13px/500.
+- 진행률 바: height 6px, radius 3px, 배경 `colors.background.secondary`, 채움 `colors.brand.secondary`, width `${(doneCount/totalCount)*100}%`. `totalCount === 0`이면 바를 0%로 렌더링(빈 상태는 3-6 참고).
+- 날짜 타이틀 포맷: 기존 코드베이스에 날짜 포맷 유틸 부재 확인됨 — `Intl.DateTimeFormat` 또는 신규 `formatTodayLabel` 유틸 추가 필요(`shared/utils`).
+
+### 3-4. `TodaySection` (진행 중 / 완료 공용 섹션 래퍼)
+```ts
+interface TodaySectionProps {
+  title: "진행 중" | "완료";
+  children: React.ReactNode;
+}
+```
+- 섹션 타이틀: 12px/500, `colors.text.tertiary`, margin-bottom 8px.
+
+### 3-5. `TodayTodoItem`
+```ts
+interface TodayTodoItemProps {
+  todo: Todo;
+  onToggleDone: (todo: Todo) => void; // 원형 체크박스 클릭 → status를 done/todo로 토글
+  onClick: (todo: Todo) => void;       // 항목 클릭 → 상세 이동
+}
+```
+- 미완료 상태: 18px 원형 체크박스(미체크) — 보더만, `colors.border.secondary`(일반) / `colors.border.danger`(마감 초과·위험).
+  - **위험 판정 기준**: `getDaysLeft(todo.dueAt) < 0` (마감 초과)일 때 danger 보더 적용. 시안의 "마카이브" 항목처럼 보더만 레드, 텍스트는 기본색 유지.
+- 완료 상태: 18px 원형, 배경 `colors.brand.secondary`, 내부 `Check` 아이콘(lucide) 12px 흰색.
+- 텍스트: 제목 14px, 완료 시 `text-decoration: line-through` + `color: colors.text.tertiary`.
+- 서브텍스트(시안의 "프로젝트명"): **이번 범위에서 미구현**(0-5 참고). 대신 `todo.description`이 있으면 1줄 표시, 없으면 서브텍스트 자체를 렌더링하지 않음(레이아웃은 서브텍스트 유무에 따라 가변).
+- 우측 영역: `dueAt` 존재 + 시간 정보 있음 → "오후 2시" 포맷(`오전/오후 N시`), `getDaysLeft < 0`이면 기존 `DueBadge`/`getDueBadgeLabel` 재사용(레드 배경 배지, "N일 초과" 텍스트는 이미 일치). `dueAt` 없으면 우측 영역 비표시.
+- 한 줄 높이: 시안은 `padding: 12px 0`이나 콘텐츠 높이가 44px 미만일 수 있음 — **ui-ux-improver는 row 전체 클릭 영역을 최소 44px로 보정**.
+- 클릭 시 상세 이동은 기존 `TodoListItem`과 동일 패턴(`navigate(/todo/${id})`) 재사용.
+
+### 3-6. 빈 상태 / 로딩 / 에러
+- **로딩**: `shared/ui/skeleton`에 todo 리스트용 skeleton이 없음(현재 `checkboxSkeleton`, `kanbanSkeleton`만 존재) → 신규 `todayItemSkeleton` 추가 필요(체크박스 원형 + 텍스트 바 2개 placeholder, shimmer 애니메이션은 기존 skeleton 컴포넌트 패턴 따름).
+- **에러**: 기존 `useToast`(`shared/ui/toast`) 패턴 재사용. "할 일을 불러오지 못했습니다" + 토스트 내 재시도 액션 또는 화면 중앙에 재시도 버튼(기존 `EmptyState` 컴포넌트의 `actionLabel`/`onAction` 패턴 재사용 가능).
+- **빈 상태(오늘 할 일 없음)**: 기존 `shared/ui/emptyState/EmptyState` 재사용.
+  - icon: lucide `Sun` 또는 `CheckCircle`
+  - title: "오늘 할 일이 없습니다"
+  - description: "여유로운 하루네요. 새로운 할 일을 추가해보세요"
+  - actionLabel: "새 할 일 추가" / actionIcon: `Plus` / onAction: 할 일 추가 모달 오픈(기존 `TodoForm` 재사용)
+
+### 3-7. `BottomTabBar` (신규, layouts)
+```ts
+interface BottomTabBarProps {
+  // 별도 props 없음 — NavLink 기반, react-router 활성 경로로 자동 판정
+}
+```
+- 4개 탭: 오늘(`/today`), 목록(`/todo`), 차트(`/pie-chart`), 칸반(`/kanban`) — 기존 라우트 경로 그대로 사용(시안 라우팅 신규 추가 없음, `/today`만 신규).
+- 활성 탭: `color: colors.brand.primary`, `font-weight: 500`.
+- 비활성 탭: `color: colors.text.tertiary`.
+- 아이콘 20px, 라벨 11px, `flex-direction: column`, `gap: 4px`.
+- `position: fixed; bottom: 0;`, `border-top: 0.5px solid colors.border.tertiary`, `background: colors.background.primary`, `padding: 10px 0`, `justify-content: space-around`.
+- 각 탭 터치 영역 최소 44px height 확보(아이콘+라벨+패딩 합산 검증 필요 — 현재 시안 수치로는 약 44px 근접, ui-ux-improver가 실측 후 패딩 보정).
+- `Main` 컨텐츠 영역은 `BottomTabBar` 높이만큼 `padding-bottom` 보정 필요(겹침 방지).
+
+---
+
+## 4. 인터랙션 정의
+
+| 요소 | 인터랙션 |
+|---|---|
+| 주간 스트립 날짜 셀 | 클릭 → 해당 날짜를 `selectedDate`로 설정, "오늘" 화면 데이터 갱신(다른 날짜 조회는 이번 범위에서 UI만 대응, 실제 미래/과거 날짜 todo 필터링 로직은 `useTodayTodos`에서 `dueAt` 기준 day-match로 구현) |
+| 원형 체크박스(진행 중 항목) | 클릭 → `status: "done"`로 변경, `doneAt` 현재시각 세팅, 완료 섹션으로 이동(애니메이션: 기존 코드베이스에 리스트 reorder 애니메이션 없음 — 신규 도입하지 않고 즉시 리렌더링) |
+| 완료 항목 체크 아이콘 | 클릭 → `status: "todo"`로 되돌리기(토글), `doneAt: null` |
+| 항목 텍스트 영역 클릭 | `/todo/:id` 상세 이동(기존 `TodoDetail` 라우트, 모바일에서도 동일 패턴 유지) |
+| 하단 탭바 탭 클릭 | 라우트 이동, `NavLink` active 스타일 자동 적용 |
+| 아바타 클릭(헤더) | 기존 `MobileDrawer` 오픈(로그아웃 등 부가 메뉴) |
+| 진행률 바 | 인터랙션 없음(읽기 전용 표시) |
+
+전환 애니메이션: 기존 코드베이스는 `MobileDrawer`에만 `keyframes` 기반 슬라이드/페이드(0.2~0.25s ease)를 사용 중. "오늘" 화면 내 신규 컴포넌트는 **애니메이션을 추가하지 않는다**(과설계 방지, 기존 패턴 일관성 유지). 단, 체크박스 토글 시 색상 전환은 `transition: background-color 0.15s ease` 정도의 미세 트랜지션 허용.
+
+---
+
+## 5. 접근성 요구사항
+
+- 원형 체크박스: `role="checkbox"`, `aria-checked={todo.status === "done"}`, `aria-label="${todo.title} 완료 처리"`.
+- 하단 탭바 각 탭: `NavLink`는 기본적으로 `<a>` 역할 — `aria-label`로 탭 이름 명시(아이콘만으로 의미 전달 부족 보완, 단 라벨 텍스트가 이미 보이므로 `aria-current="page"`는 `NavLink`의 `aria-current` 기본 동작에 의존).
+- 주간 스트립 날짜 셀: `role="button"`, `aria-label="6월 16일 화요일, 일정 있음"`(dot 마커 정보를 시각 요소뿐 아니라 aria-label에도 포함).
+- 헤더 아바타 버튼: `aria-label="사용자 메뉴 열기"`.
+- 모든 인터랙티브 요소 최소 44x44px 터치 타겟 확보(위 3-2, 3-5, 3-7에서 개별 명시).
+- 레드 배지("N일 초과")는 색상에만 의존하지 않고 텍스트로 의미 전달(이미 충족 — `getDueBadgeLabel` 텍스트 자체가 의미 전달).
+
+---
+
+## 6. 단계적 적용 범위 (Phase)
+
+1. **Phase 1 (토큰)**: `colors.ts`, `radius.ts` 신규 추가. `statusColors.done.main`을 `#1D9E75`로 통일. 기존 화면에는 즉시 적용하지 않고 신규 토큰만 준비(기존 22개 파일의 `#1c72eb` 일괄 교체는 이번 스펙 범위 밖 — 별도 후속 작업으로 분리 권장, 리스크가 크고 전체 화면 톤이 바뀌므로 PM 의사결정 필요).
+2. **Phase 2 (모바일 "오늘" 화면)**: `features/today/` 신규 구현, `/today` 라우트 추가, 기존 `/` 모바일 분기는 유지(병행 운영 — 사용자가 양쪽을 비교할 수 있도록 일정 기간 공존시키는 옵션도 고려 가능, 최종 결정은 PM).
+3. **Phase 3 (모바일 셸)**: `MobileHeader`, `BottomTabBar` 도입. `App.tsx`에서 모바일 분기 시 `Footer`→`BottomTabBar` 교체, `Header`→`MobileHeader` 교체.
+4. **Phase 4 (정리)**: `/` 라우트의 모바일 분기를 `/today`로 리다이렉트하거나 통합, `MobileHomePage.tsx` 제거.
+
+이번 스펙은 Phase 1~3 구현에 필요한 모든 정보를 포함한다. Phase 4(라우팅 통합 방식)는 사용자 승인 시 함께 결정 필요.
+
+---
+
+## 7. ui-ux-improver에게 전달할 사항 (요약)
+
+1. 신규 토큰 파일 2개(`colors.ts`, `radius.ts`) 생성 후 기존 `statusColors.ts`의 `done.main`만 값 변경, 나머지 기존 하드코딩 색상은 건드리지 않음(범위 외).
+2. `features/today/` 신규 feature 생성, `features/todo`의 기존 유틸(`getDaysLeft`, `getDueBadgeLabel`, `DUE_SOON_DAYS`, `useTodo`)과 `shared/ui`(`EmptyState`, `Toast`, `Skeleton` 패턴)를 최대한 재사용.
+3. "프로젝트명" 서브텍스트는 데이터 모델에 없는 개념이므로 구현하지 않음(0-5 참고) — 임의로 `parentId` 상위 todo 제목을 끌어다 쓰지 말 것(의미가 다름, 향후 별도 "프로젝트" 엔티티 도입 시 재논의).
+4. `LayoutKanban`처럼 lucide-react에 정확히 존재하지 않을 수 있는 아이콘명은 구현 시점에 실제 패키지 export를 확인하고 대체 아이콘 선택할 것.
+5. 애니메이션은 추가하지 않음(기존 패턴 일관성), 단 체크박스 토글 색상 전환만 짧은 transition 허용.
+6. 접근성: 체크박스 `role="checkbox"`+`aria-checked`, 모든 터치 타겟 44px 이상, 날짜 셀 `aria-label`에 일정 정보 포함.
+7. Phase 1(토큰)→Phase 2(오늘 화면)→Phase 3(모바일 셸) 순서로 구현 권장. Phase 4(라우팅 통합)는 별도 승인 필요.

--- a/client/src/styles/radius.ts
+++ b/client/src/styles/radius.ts
@@ -1,0 +1,6 @@
+export const radius = {
+  sm: "6px",
+  md: "8px",
+  xl: "20px",
+  full: "50%",
+} as const;

--- a/client/src/styles/statusColors.ts
+++ b/client/src/styles/statusColors.ts
@@ -10,7 +10,7 @@ export const statusColors = {
     border: "#60a5fa",
   },
   done: {
-    main: "#10b981", // 초록 - 완료
+    main: "#1D9E75", // 초록(틸) - 완료, 리브랜딩 스펙 1-4 통일값
     light: "#d1fae5", // 연한 배경
     border: "#34d399",
   },


### PR DESCRIPTION
## Summary
- 승인된 디자인 시안(teal)을 기반으로 디자인 토큰(`colors.ts`, `radius.ts`) 신설, `statusColors.done`을 틸 계열로 통일
- 모바일 전용 `/today` 화면 신규 구현: 주간 날짜 스트립, 일일 진행률, 진행중/완료 리스트 (`features/today`)
- 모바일 전용 셸(`MobileHeader`, `BottomTabBar`) 도입, `App.tsx`에서 모바일/데스크톱 분기 렌더링
- 날짜 계산 유틸을 `shared/utils/date.ts`로 통합, `useCallback` 적용 등 코드 리뷰 권장사항 반영

데스크톱 레이아웃과 기존 22개 파일의 하드코딩 브랜드 컬러(`#1c72eb`)는 이번 범위에서 변경하지 않았습니다(별도 후속 작업). `MobileHomePage`는 라우팅 통합(Phase 4) 전까지 미사용 상태로 유지됩니다.

## Test plan
- [x] `npm run lint` (에러 0, 기존 무관 경고 2건만)
- [x] `npm run test` (15 파일 / 107 테스트 통과)
- [x] `npm run build` (타입체크 + 빌드 성공)
- [ ] 로그인 후 모바일 뷰포트에서 `/today` 화면 및 하단 탭바 직접 확인 (Firebase Google 로그인 필요해 자동화 환경에서 미확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)