### PR TITLE
feat: 모바일 오늘 페이지 날짜 스트립 윈도우 네비게이션 추가

### DIFF
--- a/client/src/features/today/components/weekStrip.styles.tsx
+++ b/client/src/features/today/components/weekStrip.styles.tsx
@@ -4,14 +4,69 @@ import { radius } from "@/styles/radius";
 
 const Container = styled.div`
   display: flex;
+  align-items: center;
+  padding: 8px;
+  gap: 4px;
+`;
+
+const StripScroll = styled.div`
+  display: flex;
+  flex: 1;
   gap: 8px;
-  padding: 8px 16px;
   overflow-x: auto;
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+const ArrowButton = styled.button`
+  flex-shrink: 0;
+  width: 28px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: ${colors.text.tertiary};
+  border-radius: ${radius.md};
+
+  &:hover {
+    color: ${colors.text.primary};
+  }
+  &:focus-visible {
+    outline: 2px solid ${colors.brand.primary};
+    outline-offset: 2px;
+  }
+`;
+
+const TodayChip = styled.button`
+  flex-shrink: 0;
+  height: 28px;
+  padding: 0 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: ${colors.brand.primary};
+  color: #ffffff;
+  border: none;
+  border-radius: ${radius.md};
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:focus-visible {
+    outline: 2px solid ${colors.brand.primary};
+    outline-offset: 2px;
+  }
 `;
 
 const DayCell = styled.div<{ $isSelected: boolean; $isToday: boolean }>`
-  flex-shrink: 0;
-  width: 38px;
+  flex: 1;
+  min-width: 0;
   min-height: 44px;
   padding: 8px 0;
   display: flex;
@@ -64,4 +119,4 @@ const Dot = styled.span<{
   }};
 `;
 
-export { Container, DayCell, DayLabel, DateLabel, Dot };
+export { Container, StripScroll, ArrowButton, TodayChip, DayCell, DayLabel, DateLabel, Dot };

--- a/client/src/features/today/components/weekStrip.tsx
+++ b/client/src/features/today/components/weekStrip.tsx
@@ -1,7 +1,11 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import type { DayMarker } from "../hooks/useTodayTodos";
-import { getWeekDates, isSameLocalDay, toDateKey } from "@/shared/utils/date";
+import { getStripDates, isSameLocalDay, toDateKey } from "@/shared/utils/date";
 import {
   Container,
+  StripScroll,
+  ArrowButton,
+  TodayChip,
   DayCell,
   DayLabel,
   DateLabel,
@@ -21,56 +25,84 @@ const WEEKDAY_FULL_LABELS = [
 
 interface WeekStripProps {
   selectedDate: string;
+  windowStart: string;
   markers: Record<string, DayMarker>;
   onSelectDate: (date: string) => void;
+  onShiftLeft: () => void;
+  onShiftRight: () => void;
+  onGoToToday: () => void;
 }
 
-const WeekStrip = ({ selectedDate, markers, onSelectDate }: WeekStripProps) => {
+const WeekStrip = ({
+  selectedDate,
+  windowStart,
+  markers,
+  onSelectDate,
+  onShiftLeft,
+  onShiftRight,
+  onGoToToday,
+}: WeekStripProps) => {
   const today = new Date();
-  const weekDates = getWeekDates(selectedDate);
+  const stripDates = getStripDates(windowStart);
+  const isTodayInStrip = stripDates.some((d) => isSameLocalDay(d, today));
 
   return (
-    <Container role="list" aria-label="주간 날짜 선택">
-      {weekDates.map((date) => {
-        const dateKey = toDateKey(date);
-        const isSelected = dateKey === selectedDate;
-        const isToday = isSameLocalDay(date, today);
-        const marker = markers[dateKey] ?? "none";
-        const weekdayShort = WEEKDAY_SHORT_LABELS[date.getDay()];
-        const weekdayFull = WEEKDAY_FULL_LABELS[date.getDay()];
+    <Container>
+      <ArrowButton onClick={onShiftLeft} aria-label="이전 날짜">
+        <ChevronLeft size={16} />
+      </ArrowButton>
+      <StripScroll aria-label="날짜 선택">
+        {stripDates.map((date) => {
+          const dateKey = toDateKey(date);
+          const isSelected = dateKey === selectedDate;
+          const isToday = isSameLocalDay(date, today);
+          const marker = markers[dateKey] ?? "none";
+          const weekdayShort = WEEKDAY_SHORT_LABELS[date.getDay()];
+          const weekdayFull = WEEKDAY_FULL_LABELS[date.getDay()];
 
-        const scheduleInfo =
-          marker === "danger"
-            ? "마감 위험 일정 있음"
-            : marker === "normal"
-              ? "일정 있음"
-              : "일정 없음";
+          const scheduleInfo =
+            marker === "danger"
+              ? "마감 위험 일정 있음"
+              : marker === "normal"
+                ? "일정 있음"
+                : "일정 없음";
 
-        return (
-          <DayCell
-            key={dateKey}
-            role="button"
-            tabIndex={0}
-            $isSelected={isSelected}
-            $isToday={isToday}
-            aria-pressed={isSelected}
-            aria-label={`${date.getMonth() + 1}월 ${date.getDate()}일 ${weekdayFull}, ${scheduleInfo}`}
-            onClick={() => onSelectDate(dateKey)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                onSelectDate(dateKey);
-              }
-            }}
-          >
-            <DayLabel $isSelected={isSelected}>{weekdayShort}</DayLabel>
-            <DateLabel $isSelected={isSelected} $isToday={isToday}>
-              {date.getDate()}
-            </DateLabel>
-            <Dot $marker={marker} $onColoredBackground={isSelected} />
-          </DayCell>
-        );
-      })}
+          return (
+            <DayCell
+              key={dateKey}
+              role="button"
+              tabIndex={0}
+              $isSelected={isSelected}
+              $isToday={isToday}
+              aria-pressed={isSelected}
+              aria-label={`${date.getMonth() + 1}월 ${date.getDate()}일 ${weekdayFull}, ${scheduleInfo}`}
+              onClick={() => onSelectDate(dateKey)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onSelectDate(dateKey);
+                }
+              }}
+            >
+              <DayLabel $isSelected={isSelected}>{weekdayShort}</DayLabel>
+              <DateLabel $isSelected={isSelected} $isToday={isToday}>
+                {date.getDate()}
+              </DateLabel>
+              <Dot $marker={marker} $onColoredBackground={isSelected} />
+            </DayCell>
+          );
+        })}
+      </StripScroll>
+      <ArrowButton onClick={onShiftRight} aria-label="다음 날짜">
+        <ChevronRight size={16} />
+      </ArrowButton>
+      <TodayChip
+        onClick={onGoToToday}
+        aria-label="오늘로 이동"
+        style={{ visibility: isTodayInStrip ? "hidden" : "visible" }}
+      >
+        오늘
+      </TodayChip>
     </Container>
   );
 };

--- a/client/src/features/today/hooks/__tests__/useTodayTodos.test.tsx
+++ b/client/src/features/today/hooks/__tests__/useTodayTodos.test.tsx
@@ -94,7 +94,7 @@ describe('useTodayTodos 훅', () => {
     ]
     vi.mocked(getTodos).mockResolvedValue(mockTodos)
 
-    const { result } = renderHook(() => useTodayTodos('2026-06-15'), {
+    const { result } = renderHook(() => useTodayTodos('2026-06-15', '2026-06-15'), {
       wrapper: createWrapper(),
     })
 
@@ -128,7 +128,7 @@ describe('useTodayTodos 훅', () => {
     ]
     vi.mocked(getTodos).mockResolvedValue(mockTodos)
 
-    const { result } = renderHook(() => useTodayTodos('2026-06-15'), {
+    const { result } = renderHook(() => useTodayTodos('2026-06-15', '2026-06-15'), {
       wrapper: createWrapper(),
     })
 
@@ -143,7 +143,7 @@ describe('useTodayTodos 훅', () => {
     const { getTodos } = await import('@/features/todo/api')
     vi.mocked(getTodos).mockResolvedValue([])
 
-    const { result } = renderHook(() => useTodayTodos('2026-06-15'), {
+    const { result } = renderHook(() => useTodayTodos('2026-06-15', '2026-06-15'), {
       wrapper: createWrapper(),
     })
 
@@ -163,7 +163,7 @@ describe('useTodayTodos 훅', () => {
     ]
     vi.mocked(getTodos).mockResolvedValue(mockTodos)
 
-    const { result } = renderHook(() => useTodayTodos('2026-06-15'), {
+    const { result } = renderHook(() => useTodayTodos('2026-06-15', '2026-06-15'), {
       wrapper: createWrapper(),
     })
 
@@ -177,11 +177,11 @@ describe('useTodayTodos 훅', () => {
   it('마감 초과(getDaysLeft <= 0)인 todo가 있으면 markers는 "danger"여야 한다', async () => {
     const { getTodos } = await import('@/features/todo/api')
     const mockTodos: Todo[] = [
-      makeTodo({ id: '1', dueAt: localISO(2026, 6, 14, 10) }), // 일요일, 이미 지남
+      makeTodo({ id: '1', dueAt: localISO(2026, 6, 15, 8) }), // 오늘 08:00, 현재(09:00) 기준 이미 지남
     ]
     vi.mocked(getTodos).mockResolvedValue(mockTodos)
 
-    const { result } = renderHook(() => useTodayTodos('2026-06-15'), {
+    const { result } = renderHook(() => useTodayTodos('2026-06-15', '2026-06-15'), {
       wrapper: createWrapper(),
     })
 
@@ -189,14 +189,14 @@ describe('useTodayTodos 훅', () => {
       expect(result.current.isLoading).toBe(false)
     })
 
-    expect(result.current.markers['2026-06-14']).toBe('danger')
+    expect(result.current.markers['2026-06-15']).toBe('danger')
   })
 
-  it('주간 마커는 selectedDate가 속한 일~토 범위만 포함해야 한다', async () => {
+  it('마커는 windowStart 기준 7일 범위만 포함해야 한다', async () => {
     const { getTodos } = await import('@/features/todo/api')
     vi.mocked(getTodos).mockResolvedValue([])
 
-    const { result } = renderHook(() => useTodayTodos('2026-06-15'), {
+    const { result } = renderHook(() => useTodayTodos('2026-06-15', '2026-06-15'), {
       wrapper: createWrapper(),
     })
 
@@ -206,14 +206,47 @@ describe('useTodayTodos 훅', () => {
 
     const keys = Object.keys(result.current.markers).sort()
     expect(keys).toEqual([
-      '2026-06-14',
       '2026-06-15',
       '2026-06-16',
       '2026-06-17',
       '2026-06-18',
       '2026-06-19',
       '2026-06-20',
+      '2026-06-21',
     ])
+  })
+
+  it('windowStart와 selectedDate가 다를 때 markers는 windowStart 기준으로 계산되어야 한다', async () => {
+    const { getTodos } = await import('@/features/todo/api')
+    const mockTodos: Todo[] = [
+      makeTodo({ id: '1', dueAt: localISO(2026, 6, 22, 10) }), // 2026-06-22, windowStart 범위 내
+      makeTodo({ id: '2', dueAt: localISO(2026, 6, 15, 10) }), // 2026-06-15, selectedDate이지만 windowStart 범위 밖
+    ]
+    vi.mocked(getTodos).mockResolvedValue(mockTodos)
+
+    const { result } = renderHook(
+      () => useTodayTodos('2026-06-15', '2026-06-22'),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    const keys = Object.keys(result.current.markers).sort()
+    // windowStart(2026-06-22)부터 7일: 06-22 ~ 06-28
+    expect(keys).toEqual([
+      '2026-06-22',
+      '2026-06-23',
+      '2026-06-24',
+      '2026-06-25',
+      '2026-06-26',
+      '2026-06-27',
+      '2026-06-28',
+    ])
+    expect(result.current.markers['2026-06-22']).toBe('normal')
+    // selectedDate(06-15)는 범위 밖이므로 markers에 없음
+    expect(result.current.markers['2026-06-15']).toBeUndefined()
   })
 
   it('toggleDone 호출 시 미완료 todo를 done으로 변경하고 doneAt을 세팅해야 한다', async () => {
@@ -222,7 +255,7 @@ describe('useTodayTodos 훅', () => {
     vi.mocked(getTodos).mockResolvedValue([todo])
     vi.mocked(editTodo).mockResolvedValue(todo)
 
-    const { result } = renderHook(() => useTodayTodos('2026-06-15'), {
+    const { result } = renderHook(() => useTodayTodos('2026-06-15', '2026-06-15'), {
       wrapper: createWrapper(),
     })
 
@@ -254,7 +287,7 @@ describe('useTodayTodos 훅', () => {
     vi.mocked(getTodos).mockResolvedValue([todo])
     vi.mocked(editTodo).mockResolvedValue(todo)
 
-    const { result } = renderHook(() => useTodayTodos('2026-06-15'), {
+    const { result } = renderHook(() => useTodayTodos('2026-06-15', '2026-06-15'), {
       wrapper: createWrapper(),
     })
 
@@ -279,7 +312,7 @@ describe('useTodayTodos 훅', () => {
     const { getTodos } = await import('@/features/todo/api')
     vi.mocked(getTodos).mockRejectedValueOnce(new Error('Firestore 오류'))
 
-    const { result } = renderHook(() => useTodayTodos('2026-06-15'), {
+    const { result } = renderHook(() => useTodayTodos('2026-06-15', '2026-06-15'), {
       wrapper: createWrapper(),
     })
 

--- a/client/src/features/today/hooks/useTodayTodos.ts
+++ b/client/src/features/today/hooks/useTodayTodos.ts
@@ -2,13 +2,9 @@ import { useCallback, useMemo } from "react";
 import { useTodo } from "@/features/todo/hooks";
 import type { Todo } from "@/features/todo/types";
 import { getDaysLeft } from "@/shared/utils/due";
-import { getWeekDates, toDateKey, toDateKeyFromISO } from "@/shared/utils/date";
+import { getStripDates, toDateKey, toDateKeyFromISO } from "@/shared/utils/date";
 
 export type DayMarker = "none" | "normal" | "danger";
-
-/** selectedDate가 속한 주(일~토)의 7개 날짜 키를 반환한다. */
-const getWeekDateKeys = (selectedDate: string): string[] =>
-  getWeekDates(selectedDate).map(toDateKey);
 
 export interface UseTodayTodosResult {
   inProgressTodos: Todo[];
@@ -25,7 +21,7 @@ export interface UseTodayTodosResult {
  * 선택된 날짜(dueAt 기준)에 해당하는 todo를 진행중/완료로 분리하고,
  * 주간 스트립용 마커와 완료율을 계산한다.
  */
-export const useTodayTodos = (selectedDate: string): UseTodayTodosResult => {
+export const useTodayTodos = (selectedDate: string, windowStart: string): UseTodayTodosResult => {
   const { useGetTodos, useUpdateTodo } = useTodo();
   const { data: todos, isLoading, isError } = useGetTodos;
   const { mutate: updateTodo } = useUpdateTodo;
@@ -55,10 +51,10 @@ export const useTodayTodos = (selectedDate: string): UseTodayTodosResult => {
   );
 
   const markers = useMemo(() => {
-    const weekDateKeys = getWeekDateKeys(selectedDate);
+    const stripDateKeys = getStripDates(windowStart).map(toDateKey);
     const result: Record<string, DayMarker> = {};
 
-    for (const dateKey of weekDateKeys) {
+    for (const dateKey of stripDateKeys) {
       const todosOnDate = (todos ?? []).filter(
         (todo) => todo.dueAt && toDateKeyFromISO(todo.dueAt) === dateKey,
       );
@@ -69,13 +65,13 @@ export const useTodayTodos = (selectedDate: string): UseTodayTodosResult => {
       }
 
       const hasDanger = todosOnDate.some(
-        (todo) => getDaysLeft(todo.dueAt as string) <= 0,
+        (todo) => todo.status !== "done" && getDaysLeft(todo.dueAt as string) <= 0,
       );
       result[dateKey] = hasDanger ? "danger" : "normal";
     }
 
     return result;
-  }, [todos, selectedDate]);
+  }, [todos, windowStart]);
 
   const toggleDone = useCallback(
     (todo: Todo) => {

--- a/client/src/features/today/pages/todayPage.tsx
+++ b/client/src/features/today/pages/todayPage.tsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { Sun, Plus } from "lucide-react";
 import { useTodayTodos } from "../hooks/useTodayTodos";
 import { useTodo } from "@/features/todo/hooks";
 import { formatTodayLabel } from "@/shared/utils/formatToday";
-import { toDateKey } from "@/shared/utils/date";
+import { toDateKey, parseLocalDateOnly } from "@/shared/utils/date";
 import { EmptyState, TodayItemSkeleton, Modal } from "@/shared";
 import TodoForm from "@/features/todo/components/todoForm/todoForm";
 import WeekStrip from "../components/weekStrip";
@@ -14,7 +14,22 @@ import { Container, List } from "./todayPage.styles";
 
 const TodayPage = () => {
   const [selectedDate, setSelectedDate] = useState(() => toDateKey(new Date()));
+  const [windowStart, setWindowStart] = useState(() => toDateKey(new Date()));
   const [isAddOpen, setIsAddOpen] = useState(false);
+
+  const shiftWindow = useCallback((days: number) => {
+    setWindowStart((prev) => {
+      const d = parseLocalDateOnly(prev);
+      d.setDate(d.getDate() + days);
+      return toDateKey(d);
+    });
+  }, []);
+
+  const handleGoToToday = useCallback(() => {
+    const today = toDateKey(new Date());
+    setWindowStart(today);
+    setSelectedDate(today);
+  }, []);
 
   const {
     inProgressTodos,
@@ -25,7 +40,7 @@ const TodayPage = () => {
     isLoading,
     isError,
     toggleDone,
-  } = useTodayTodos(selectedDate);
+  } = useTodayTodos(selectedDate, windowStart);
   const { useGetTodos } = useTodo();
 
   const hasTodos = inProgressTodos.length > 0 || doneTodos.length > 0;
@@ -34,8 +49,12 @@ const TodayPage = () => {
     <Container>
       <WeekStrip
         selectedDate={selectedDate}
+        windowStart={windowStart}
         markers={markers}
         onSelectDate={setSelectedDate}
+        onShiftLeft={() => shiftWindow(-7)}
+        onShiftRight={() => shiftWindow(7)}
+        onGoToToday={handleGoToToday}
       />
       <DailyProgress
         dateLabel={formatTodayLabel(selectedDate)}

--- a/client/src/shared/utils/date.ts
+++ b/client/src/shared/utils/date.ts
@@ -24,6 +24,18 @@ export const isSameLocalDay = (a: Date, b: Date): boolean =>
   a.getMonth() === b.getMonth() &&
   a.getDate() === b.getDate();
 
+export const STRIP_WINDOW_DAYS = 7;
+
+/** startDateKey부터 count일 연속 Date를 반환한다. */
+export const getStripDates = (startDateKey: string, count: number = STRIP_WINDOW_DAYS): Date[] => {
+  const start = parseLocalDateOnly(startDateKey);
+  return Array.from({ length: count }, (_, i) => {
+    const d = new Date(start);
+    d.setDate(start.getDate() + i);
+    return d;
+  });
+};
+
 /** selectedDate가 속한 주(일~토)의 7개 Date를 반환한다. */
 export const getWeekDates = (selectedDate: string): Date[] => {
   const target = parseLocalDateOnly(selectedDate);


### PR DESCRIPTION
## Summary

- 날짜 스트립을 일~토 고정 주 단위 → 오늘 기준 7일 슬라이딩 윈도우 방식으로 변경
- 좌우 화살표 버튼으로 7일씩 날짜 이동 가능
- 현재 윈도우에 오늘이 없을 때 "오늘" 버튼 표시 (클릭 시 오늘로 리셋)
- 날짜 셀이 스트립 너비를 균등하게 채우도록 `flex: 1` 적용
- 완료된 할 일이 danger 마커로 오분류되던 버그 수정

## Changed Files

- `shared/utils/date.ts` — `getStripDates`, `STRIP_WINDOW_DAYS` 추가
- `features/today/hooks/useTodayTodos.ts` — `windowStart` 파라미터 추가, done 항목 danger 마커 제외
- `features/today/pages/todayPage.tsx` — 윈도우 상태 및 핸들러 추가
- `features/today/components/weekStrip.tsx` — 화살표/오늘 버튼 렌더링
- `features/today/components/weekStrip.styles.tsx` — StripScroll, ArrowButton, TodayChip 추가
- `features/today/hooks/__tests__/useTodayTodos.test.tsx` — 테스트 업데이트 및 케이스 추가

## Test plan

- [ ] 초기 진입 시 오늘부터 +6일이 표시되는지 확인
- [ ] → 버튼: 7일 후 윈도우로 이동하는지 확인
- [ ] ← 버튼: 7일 전 윈도우로 이동하는지 확인
- [ ] 오늘이 윈도우에 없을 때 "오늘" 버튼 표시 확인
- [ ] "오늘" 버튼 클릭 시 오늘 날짜로 선택 및 윈도우 리셋 확인
- [ ] 날짜 셀 클릭 시 아래 할 일 목록 업데이트 확인
- [ ] 완료된 할 일의 날짜에 danger 마커가 표시되지 않는지 확인
- [ ] 유닛 테스트 108개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)