### PR TITLE
feat: 목록 페이지 프로젝트 카드 뷰 리디자인

### DIFF
--- a/client/src/features/todo/components/childTodoCard.tsx
+++ b/client/src/features/todo/components/childTodoCard.tsx
@@ -1,0 +1,126 @@
+import { useState } from "react";
+import { PencilIcon, TrashIcon } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { ConfirmModal, useToast } from "@/shared";
+import { useTodo } from "../hooks";
+import type { Todo } from "../types";
+import type { Status } from "@/styles/statusColors";
+import {
+  ChildCardWrapper,
+  ChildCardContainer,
+  ChildCardLeft,
+  ChildCardStatusDot,
+  ChildCardTitle,
+  ChildCardRight,
+  IconButton,
+  InlineStatusRow,
+  StatusPill,
+  StatusDotTrigger,
+} from "./projectCard.styles";
+
+const STATUS_LABELS: Record<Status, string> = {
+  todo: "할 일",
+  doing: "진행 중",
+  done: "완료",
+};
+
+const ChildTodoCard = ({
+  todo,
+  onEdit,
+}: {
+  todo: Todo;
+  onEdit: (todo: Todo) => void;
+}) => {
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [isStatusOpen, setIsStatusOpen] = useState(false);
+  const { useDeleteTodo, useUpdateTodo } = useTodo();
+  const navigate = useNavigate();
+  const toast = useToast();
+
+  const handleDelete = () => {
+    useDeleteTodo.mutate(todo.id, {
+      onSuccess: () => {
+        setIsDeleteOpen(false);
+        toast.success("삭제 완료", `"${todo.title}" 할 일이 삭제되었습니다`);
+      },
+      onError: () => {
+        setIsDeleteOpen(false);
+        toast.error("삭제 실패", "할 일 삭제 중 오류가 발생했습니다");
+      },
+    });
+  };
+
+  const handleStatusChange = (newStatus: Status) => {
+    useUpdateTodo.mutate(
+      { ...todo, status: newStatus },
+      {
+        onSuccess: () =>
+          toast.success("상태 변경", `"${todo.title}" 상태가 변경되었습니다`),
+        onError: () =>
+          toast.error("변경 실패", "상태 변경 중 오류가 발생했습니다"),
+      }
+    );
+    setIsStatusOpen(false);
+  };
+
+  return (
+    <>
+      <ConfirmModal
+        isOpen={isDeleteOpen}
+        title="할 일 삭제"
+        message={`"${todo.title}"을(를) 삭제하시겠습니까?`}
+        confirmText="삭제"
+        cancelText="취소"
+        onConfirm={handleDelete}
+        onCancel={() => setIsDeleteOpen(false)}
+      />
+      <ChildCardWrapper $status={todo.status}>
+        <ChildCardContainer>
+          <ChildCardLeft>
+            <StatusDotTrigger
+              onClick={(e) => {
+                e.stopPropagation();
+                setIsStatusOpen(!isStatusOpen);
+              }}
+              aria-label="상태 변경"
+            >
+              <ChildCardStatusDot $status={todo.status} />
+            </StatusDotTrigger>
+            <ChildCardTitle onClick={() => navigate(`/todo/${todo.id}`)}>
+              {todo.title}
+            </ChildCardTitle>
+          </ChildCardLeft>
+          <ChildCardRight>
+            <IconButton onClick={() => onEdit(todo)} aria-label="할 일 편집">
+              <PencilIcon size={14} />
+            </IconButton>
+            <IconButton
+              $variant="danger"
+              onClick={() => setIsDeleteOpen(true)}
+              aria-label="할 일 삭제"
+            >
+              <TrashIcon size={14} />
+            </IconButton>
+          </ChildCardRight>
+        </ChildCardContainer>
+        {isStatusOpen && (
+          <InlineStatusRow>
+            {(["todo", "doing", "done"] as Status[]).map((status) => (
+              <StatusPill
+                key={status}
+                $status={status}
+                $isActive={status === todo.status}
+                onClick={() => handleStatusChange(status)}
+              >
+                <ChildCardStatusDot $status={status} />
+                {STATUS_LABELS[status]}
+              </StatusPill>
+            ))}
+          </InlineStatusRow>
+        )}
+      </ChildCardWrapper>
+    </>
+  );
+};
+
+export default ChildTodoCard;

--- a/client/src/features/todo/components/projectCard.styles.tsx
+++ b/client/src/features/todo/components/projectCard.styles.tsx
@@ -1,0 +1,261 @@
+import { styled } from "styled-components";
+import { colors } from "@/styles/colors";
+import type { Status } from "@/styles/statusColors";
+import { statusColors } from "@/styles/statusColors";
+
+export const CardContainer = styled.div<{ $isOverdue?: boolean }>`
+  border-radius: 12px;
+  overflow: hidden;
+  border: 0.5px solid
+    ${({ $isOverdue }) =>
+      $isOverdue ? colors.danger.subtle : "var(--color-border-tertiary, #E5E7EB)"};
+`;
+
+export const CardHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  cursor: pointer;
+`;
+
+export const CardLeft = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  flex: 1;
+`;
+
+export const ColorDot = styled.span<{ $isOverdue?: boolean }>`
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: ${({ $isOverdue }) =>
+    $isOverdue ? colors.danger.main : colors.brand.secondary};
+  flex-shrink: 0;
+`;
+
+export const CardTitleGroup = styled.div`
+  min-width: 0;
+`;
+
+export const CardTitle = styled.p`
+  font-size: 14px;
+  font-weight: 500;
+  margin: 0;
+  color: var(--color-text-primary, ${colors.text.primary});
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const CardSubtitle = styled.p`
+  font-size: 11px;
+  color: var(--color-text-tertiary, ${colors.text.tertiary});
+  margin: 2px 0 0;
+`;
+
+export const CardRight = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+`;
+
+export const OverdueBadge = styled.span`
+  font-size: 11px;
+  padding: 3px 8px;
+  border-radius: var(--border-radius-md, 6px);
+  background: var(--color-background-danger, ${colors.danger.background});
+  color: var(--color-text-danger, ${colors.danger.text});
+  white-space: nowrap;
+`;
+
+export const IconButton = styled.button<{
+  $variant?: "default" | "danger" | "expand";
+}>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 15px;
+  padding: 0;
+  color: ${({ $variant }) =>
+    $variant === "danger"
+      ? colors.danger.main
+      : $variant === "expand"
+        ? colors.text.secondary
+        : colors.text.tertiary};
+
+  &:hover {
+    color: ${({ $variant }) =>
+      $variant === "danger"
+        ? colors.danger.text
+        : $variant === "expand"
+          ? colors.text.primary
+          : colors.text.secondary};
+  }
+
+`;
+
+export const ProgressBar = styled.div`
+  height: 3px;
+  background: var(--color-background-secondary, ${colors.background.secondary});
+`;
+
+export const ProgressFill = styled.div<{
+  $progress: number;
+  $isOverdue?: boolean;
+}>`
+  width: ${({ $progress }) => $progress}%;
+  height: 100%;
+  background-color: ${({ $isOverdue }) =>
+    $isOverdue ? colors.danger.main : colors.brand.secondary};
+  transition: width 0.3s ease;
+`;
+
+export const ExpandedArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  border-top: 0.5px solid var(--color-border-tertiary, #e5e7eb);
+  background: ${colors.background.secondary};
+  max-height: 260px;
+  overflow-y: auto;
+`;
+
+export const ChildTodoCardList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 16px;
+`;
+
+export const EmptyChildMessage = styled.p`
+  margin: 0;
+  padding: 8px 4px;
+  font-size: 12px;
+  color: ${colors.text.tertiary};
+  text-align: center;
+`;
+
+export const ChildCardWrapper = styled.div<{ $status: Status }>`
+  border-radius: 10px;
+  border: 0.5px solid ${({ $status }) => statusColors[$status].border};
+  overflow: hidden;
+  background: ${colors.background.primary};
+`;
+
+export const ChildCardContainer = styled.div`
+  padding: 10px 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const InlineStatusRow = styled.div`
+  display: flex;
+  gap: 6px;
+  padding: 8px 12px;
+  border-top: 0.5px solid var(--color-border-tertiary, ${colors.border.tertiary});
+  background: ${colors.background.secondary};
+`;
+
+export const StatusPill = styled.button<{ $status: Status; $isActive: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 20px;
+  border: 1px solid ${({ $status }) => statusColors[$status].border};
+  background: ${({ $isActive, $status }) =>
+    $isActive ? statusColors[$status].light : "transparent"};
+  color: ${({ $status }) => statusColors[$status].main};
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  &:hover {
+    background: ${({ $status }) => statusColors[$status].light};
+  }
+`;
+
+export const StatusDotTrigger = styled.button`
+  background: none;
+  border: none;
+  padding: 2px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  border-radius: 50%;
+`;
+
+export const StatusDotButton = styled.button`
+  background: none;
+  border: none;
+  padding: 2px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  border-radius: 50%;
+`;
+
+export const ChildCardLeft = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  flex: 1;
+`;
+
+export const ChildCardStatusDot = styled.span<{ $status: Status }>`
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: ${({ $status }) => statusColors[$status].main};
+  flex-shrink: 0;
+`;
+
+export const ChildCardTitle = styled.p`
+  font-size: 13px;
+  font-weight: 400;
+  margin: 0;
+  color: ${colors.text.primary};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+`;
+
+export const ChildCardRight = styled.div`
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+`;
+
+export const SheetDeleteButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  padding: 14px 16px;
+  background: none;
+  border: none;
+  border-top: 0.5px solid var(--color-border-tertiary, ${colors.border.tertiary});
+  color: ${colors.danger.main};
+  font-size: 14px;
+  cursor: pointer;
+  &:hover {
+    color: ${colors.danger.text};
+  }
+`;
+

--- a/client/src/features/todo/components/projectCard.tsx
+++ b/client/src/features/todo/components/projectCard.tsx
@@ -1,0 +1,201 @@
+import { useState } from "react";
+import type { Todo } from "../types";
+import type { ProjectCardData } from "../utils/projectUtils";
+import ChildTodoCard from "./childTodoCard";
+import { TrashIcon, ChevronRight, ChevronDown, Plus, Circle, Loader, CheckCircle } from "lucide-react";
+import BottomSheet from "@/shared/ui/bottomSheet/bottomSheet";
+import type { BottomSheetOption } from "@/shared/ui/bottomSheet/bottomSheet";
+import useMediaQuery from "@/shared/hooks/useMediaQuery";
+import { useTodo } from "../hooks";
+import { useToast } from "@/shared";
+import { statusColors, type Status } from "@/styles/statusColors";
+import {
+  CardContainer,
+  CardHeader,
+  CardLeft,
+  CardRight,
+  ColorDot,
+  CardTitleGroup,
+  CardTitle,
+  CardSubtitle,
+  OverdueBadge,
+  IconButton,
+  ProgressBar,
+  ProgressFill,
+  ExpandedArea,
+  ChildTodoCardList,
+  EmptyChildMessage,
+  SheetDeleteButton,
+  StatusDotButton,
+} from "./projectCard.styles";
+
+interface ProjectCardProps {
+  data: ProjectCardData;
+  onCardClick: (todo: Todo) => void;
+  onToggleExpand: (id: string) => void;
+  onEdit: (todo: Todo) => void;
+  onDelete: (id: string) => void;
+  onAddChild: (parentId: string) => void;
+}
+
+const ProjectCard = ({
+  data,
+  onCardClick,
+  onToggleExpand,
+  onEdit,
+  onDelete,
+  onAddChild,
+}: ProjectCardProps) => {
+  const { todo, childTodos, progress, subtaskInfo, overdueInfo, isExpanded } =
+    data;
+
+  const { isOverdue, daysOver } = overdueInfo;
+  const isMobile = useMediaQuery("tablet");
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [isStatusOpen, setIsStatusOpen] = useState(false);
+
+  const { useUpdateTodo } = useTodo();
+  const toast = useToast();
+
+  const subtitleText =
+    subtaskInfo.total > 0
+      ? `${subtaskInfo.total}개 할일 · ${subtaskInfo.statusText}`
+      : subtaskInfo.statusText;
+
+  const STATUS_OPTIONS: BottomSheetOption<Status>[] = [
+    { value: "todo", label: "할 일", icon: <Circle size={18} color={statusColors.todo.main} /> },
+    { value: "doing", label: "진행 중", icon: <Loader size={18} color={statusColors.doing.main} /> },
+    { value: "done", label: "완료", icon: <CheckCircle size={18} color={statusColors.done.main} /> },
+  ];
+
+  const handleStatusChange = (newStatus: Status) => {
+    useUpdateTodo.mutate(
+      { ...todo, status: newStatus },
+      {
+        onSuccess: () =>
+          toast.success("상태 변경", `"${todo.title}" 상태가 변경되었습니다`),
+        onError: () =>
+          toast.error("변경 실패", "상태 변경 중 오류가 발생했습니다"),
+      }
+    );
+    setIsStatusOpen(false);
+  };
+
+  const handleChevronClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (isMobile) setIsSheetOpen(true);
+    else onToggleExpand(todo.id);
+  };
+
+  return (
+    <>
+      <CardContainer $isOverdue={isOverdue}>
+        <CardHeader onClick={() => onCardClick(todo)}>
+          <CardLeft>
+            <StatusDotButton
+              onClick={(e) => {
+                e.stopPropagation();
+                setIsStatusOpen(true);
+              }}
+              aria-label="프로젝트 상태 변경"
+            >
+              <ColorDot $isOverdue={isOverdue} />
+            </StatusDotButton>
+            <CardTitleGroup>
+              <CardTitle>{todo.title}</CardTitle>
+              <CardSubtitle>{subtitleText}</CardSubtitle>
+            </CardTitleGroup>
+            {isOverdue && <OverdueBadge>{daysOver}일 초과</OverdueBadge>}
+          </CardLeft>
+          <CardRight>
+            {!isMobile && (
+              <IconButton
+                $variant="danger"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete(todo.id);
+                }}
+                aria-label="프로젝트 삭제"
+              >
+                <TrashIcon size={15} />
+              </IconButton>
+            )}
+            <IconButton
+              $variant="expand"
+              onClick={(e) => { e.stopPropagation(); onAddChild(todo.id); }}
+              aria-label="하위 작업 추가"
+            >
+              <Plus size={15} />
+            </IconButton>
+            <IconButton
+              $variant="expand"
+              onClick={handleChevronClick}
+              aria-label={isExpanded ? "프로젝트 접기" : "프로젝트 펼치기"}
+            >
+              {isExpanded ? <ChevronDown size={15} /> : <ChevronRight size={15} />}
+            </IconButton>
+          </CardRight>
+        </CardHeader>
+        <ProgressBar>
+          <ProgressFill $progress={progress} $isOverdue={isOverdue} />
+        </ProgressBar>
+        {!isMobile && isExpanded && (
+          <ExpandedArea>
+            {childTodos.length === 0 ? (
+              <EmptyChildMessage>하위 항목이 없습니다</EmptyChildMessage>
+            ) : (
+              childTodos.map((childTodo) => (
+                <ChildTodoCard
+                  key={childTodo.id}
+                  todo={childTodo}
+                  onEdit={onEdit}
+                />
+              ))
+            )}
+          </ExpandedArea>
+        )}
+      </CardContainer>
+
+      {isMobile && isSheetOpen && (
+        <BottomSheet
+          isOpen={true}
+          onClose={() => setIsSheetOpen(false)}
+          title={todo.title}
+        >
+          <ChildTodoCardList>
+            {childTodos.length === 0 ? (
+              <EmptyChildMessage>하위 항목이 없습니다</EmptyChildMessage>
+            ) : (
+              childTodos.map((childTodo) => (
+                <ChildTodoCard
+                  key={childTodo.id}
+                  todo={childTodo}
+                  onEdit={onEdit}
+                />
+              ))
+            )}
+          </ChildTodoCardList>
+          <SheetDeleteButton
+            onClick={() => {
+              setIsSheetOpen(false);
+              onDelete(todo.id);
+            }}
+          >
+            <TrashIcon size={15} /> 프로젝트 삭제
+          </SheetDeleteButton>
+        </BottomSheet>
+      )}
+
+      <BottomSheet
+        isOpen={isStatusOpen}
+        onClose={() => setIsStatusOpen(false)}
+        title="상태 변경"
+        options={STATUS_OPTIONS}
+        selectedValue={todo.status}
+        onSelect={handleStatusChange}
+      />
+    </>
+  );
+};
+
+export default ProjectCard;

--- a/client/src/features/todo/components/todoList.styles.tsx
+++ b/client/src/features/todo/components/todoList.styles.tsx
@@ -16,29 +16,59 @@ const TodoListContainer = styled.div`
 
 const AddButton = styled.button`
   width: 100%;
-  height: 40px;
+  height: 48px;
   flex-shrink: 0;
-  background-color: ${colors.brand.secondary};
+  background-color: ${colors.brand.primary};
   color: white;
-  font-size: 16px;
-  font-weight: 600;
+  font-size: 14px;
+  font-weight: 500;
   border: none;
-  border-radius: 8px;
+  border-radius: var(--border-radius-lg, 10px);
   cursor: pointer;
-  margin-bottom: 8px;
+  margin: 0 0 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: 8px;
   transition: background-color 0.2s ease;
 
   &:hover {
-    background-color: ${colors.brand.primary};
+    background-color: #0d5e49;
   }
 
   ${media.mobile} {
-    height: 36px;
-    font-size: 14px;
+    height: 44px;
+  }
+`;
+
+const ProjectListToolbar = styled.div`
+  padding: 0 0 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-shrink: 0;
+`;
+
+const ProjectCountText = styled.span`
+  font-size: 12px;
+  color: var(--color-text-tertiary, #9aa0a6);
+  font-weight: 500;
+`;
+
+const NewProjectLink = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: ${colors.brand.secondary};
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+
+  &:hover {
+    opacity: 0.8;
   }
 `;
 
@@ -47,7 +77,15 @@ const ListWrapper = styled.div`
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 8px;
+  margin-bottom: 8px;
 `;
 
-export { TodoListContainer, AddButton, ListWrapper };
+export {
+  TodoListContainer,
+  AddButton,
+  ListWrapper,
+  ProjectListToolbar,
+  ProjectCountText,
+  NewProjectLink,
+};

--- a/client/src/features/todo/components/todoList.tsx
+++ b/client/src/features/todo/components/todoList.tsx
@@ -1,23 +1,49 @@
-import TodoListItem from "./todoListItem/todoListItem";
+import ProjectCard from "./projectCard";
+import ChildTodoCard from "./childTodoCard";
 import type { Todo } from "../types";
+import type { ProjectCardData } from "../utils/projectUtils";
+import {
+  getProjectProgress,
+  getProjectSubtaskInfo,
+  getProjectOverdue,
+} from "../utils/projectUtils";
 import { useMemo, useState, useCallback } from "react";
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import useModal from "@/shared/hooks/useModal";
 import Modal from "@/shared/ui/modal/modal";
 import TodoForm from "./todoForm/todoForm";
-import { TodoListContainer, AddButton, ListWrapper } from "./todoList.styles";
+import { useTodo } from "../hooks";
+import {
+  TodoListContainer,
+  AddButton,
+  ListWrapper,
+  ProjectListToolbar,
+  ProjectCountText,
+  NewProjectLink,
+} from "./todoList.styles";
 import { Plus, ClipboardList, SearchX } from "lucide-react";
 import { EmptyState } from "@/shared";
 import { TodoSearch } from "./todoSearch";
 import { useSearchTodo } from "../hooks";
+import { ConfirmModal, useToast } from "@/shared";
 
 const TodoList = ({ todos }: { todos: Todo[] }) => {
+  const navigate = useNavigate();
   const { isOpen, setIsOpen } = useModal();
   const { isOpen: isEditOpen, setIsOpen: setIsEditOpen } = useModal();
   const { isOpen: isAddChildOpen, setIsOpen: setIsAddChildOpen } = useModal();
   const [editingTodo, setEditingTodo] = React.useState<Todo | null>(null);
   const [parentTodoId, setParentTodoId] = React.useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
+  const [expandedProjectIds, setExpandedProjectIds] = useState<Set<string>>(
+    new Set()
+  );
+  const [deleteTargetId, setDeleteTargetId] = React.useState<string | null>(
+    null
+  );
+  const { useDeleteTodo } = useTodo();
+  const toast = useToast();
 
   const { data: searchResults, isLoading: isSearchLoading } =
     useSearchTodo(searchQuery);
@@ -37,25 +63,21 @@ const TodoList = ({ todos }: { todos: Todo[] }) => {
     });
   }, [todos]);
 
-  // 검색 결과를 트리 구조로 변환
   const searchResultTree = useMemo(() => {
     if (!searchResults) return [];
     return searchResults.map((todo: Todo) => ({
       ...todo,
-      childTodos: [],
+      childTodos: todo.parentId === null
+        ? todos.filter((t) => t.parentId === todo.id)
+        : [],
     }));
-  }, [searchResults]);
+  }, [searchResults, todos]);
 
   const displayTodos = isSearching ? searchResultTree : todoTree;
 
   const handleEdit = (todo: Todo) => {
     setEditingTodo(todo);
     setIsEditOpen(true);
-  };
-
-  const handleAddChild = (parentId: string) => {
-    setParentTodoId(parentId);
-    setIsAddChildOpen(true);
   };
 
   const handleSearch = useCallback((query: string) => {
@@ -65,6 +87,46 @@ const TodoList = ({ todos }: { todos: Todo[] }) => {
   const handleClearSearch = useCallback(() => {
     setSearchQuery("");
   }, []);
+
+  const handleToggleExpand = (id: string) => {
+    setExpandedProjectIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const handleCardClick = (todo: Todo) => {
+    navigate(`/todo/${todo.id}`);
+  };
+
+  const handleDeleteProject = (id: string) => {
+    setDeleteTargetId(id);
+  };
+
+  const handleAddChild = (parentId: string) => {
+    setParentTodoId(parentId);
+    setIsAddChildOpen(true);
+  };
+
+  const projectCards = useMemo<ProjectCardData[]>(() => {
+    return todoTree.map((rootTodo) => ({
+      todo: rootTodo,
+      childTodos: rootTodo.childTodos,
+      progress: getProjectProgress(todos, rootTodo.id),
+      subtaskInfo: getProjectSubtaskInfo(todos, rootTodo.id),
+      overdueInfo: getProjectOverdue(todos, rootTodo.id),
+      isExpanded: expandedProjectIds.has(rootTodo.id),
+    }));
+  }, [todoTree, todos, expandedProjectIds]);
+
+  const deleteTargetTodo = deleteTargetId
+    ? todos.find((t) => t.id === deleteTargetId)
+    : null;
 
   return (
     <TodoListContainer>
@@ -83,20 +145,34 @@ const TodoList = ({ todos }: { todos: Todo[] }) => {
           />
         }
       />
+      <ConfirmModal
+        isOpen={deleteTargetId !== null}
+        title="프로젝트 삭제"
+        message={`"${deleteTargetTodo?.title ?? ""}"을(를) 삭제하시겠습니까?`}
+        confirmText="삭제"
+        cancelText="취소"
+        onConfirm={() => {
+          if (deleteTargetId) {
+            const title = deleteTargetTodo?.title ?? "";
+            useDeleteTodo.mutate(deleteTargetId, {
+              onSuccess: () => toast.success("삭제 완료", `"${title}" 프로젝트가 삭제되었습니다`),
+              onError: () => toast.error("삭제 실패", "삭제 중 오류가 발생했습니다"),
+            });
+          }
+          setDeleteTargetId(null);
+        }}
+        onCancel={() => setDeleteTargetId(null)}
+      />
       <Modal
         isOpen={isAddChildOpen}
         setIsOpen={setIsAddChildOpen}
         children={
           <TodoForm
-            parentId={parentTodoId || undefined}
-            onClose={() => setIsAddChildOpen(false)}
+            parentId={parentTodoId ?? undefined}
+            onClose={() => { setIsAddChildOpen(false); setParentTodoId(null); }}
           />
         }
       />
-
-      <AddButton onClick={() => setIsOpen(true)}>
-        <Plus size={18} /> 새 할일
-      </AddButton>
 
       <TodoSearch
         onSearch={handleSearch}
@@ -107,8 +183,8 @@ const TodoList = ({ todos }: { todos: Todo[] }) => {
       />
 
       <ListWrapper>
-        {displayTodos.length === 0 ? (
-          isSearching ? (
+        {isSearching ? (
+          displayTodos.length === 0 ? (
             <EmptyState
               icon={SearchX}
               title="검색 결과가 없습니다"
@@ -117,27 +193,79 @@ const TodoList = ({ todos }: { todos: Todo[] }) => {
               onAction={handleClearSearch}
             />
           ) : (
-            <EmptyState
-              icon={ClipboardList}
-              title="할 일이 없습니다"
-              description="새로운 할 일을 추가하고 생산적인 하루를 시작해보세요!"
-              actionLabel="새 할일 추가"
-              actionIcon={Plus}
-              onAction={() => setIsOpen(true)}
-            />
+            displayTodos.map((todo) => {
+              if (todo.parentId === null) {
+                const projectData: ProjectCardData = {
+                  todo,
+                  childTodos: todo.childTodos,
+                  progress: getProjectProgress(todos, todo.id),
+                  subtaskInfo: getProjectSubtaskInfo(todos, todo.id),
+                  overdueInfo: getProjectOverdue(todos, todo.id),
+                  isExpanded: expandedProjectIds.has(todo.id),
+                };
+                return (
+                  <ProjectCard
+                    key={todo.id}
+                    data={projectData}
+                    onCardClick={handleCardClick}
+                    onToggleExpand={handleToggleExpand}
+                    onEdit={handleEdit}
+                    onDelete={handleDeleteProject}
+                    onAddChild={handleAddChild}
+                  />
+                );
+              }
+              return (
+                <ChildTodoCard
+                  key={todo.id}
+                  todo={todo}
+                  onEdit={handleEdit}
+                />
+              );
+            })
           )
+        ) : projectCards.length === 0 ? (
+          <EmptyState
+            icon={ClipboardList}
+            title="할 일이 없습니다"
+            description="새로운 할 일을 추가하고 생산적인 하루를 시작해보세요!"
+            actionLabel="새 할일 추가"
+            actionIcon={Plus}
+            onAction={() => setIsOpen(true)}
+          />
         ) : (
-          displayTodos.map((todo) => (
-            <TodoListItem
-              key={todo.id}
-              todo={todo}
-              childTodos={todo.childTodos}
-              onEdit={handleEdit}
-              onAddChild={handleAddChild}
-            />
-          ))
+          <>
+            <ProjectListToolbar>
+              <ProjectCountText>
+                프로젝트 {projectCards.length}개
+              </ProjectCountText>
+              <NewProjectLink
+                onClick={() => setIsOpen(true)}
+                aria-label="새 프로젝트 추가"
+              >
+                <Plus size={14} />
+                새 프로젝트
+              </NewProjectLink>
+            </ProjectListToolbar>
+            {projectCards.map((card) => (
+              <ProjectCard
+                key={card.todo.id}
+                data={card}
+                onCardClick={handleCardClick}
+                onToggleExpand={handleToggleExpand}
+                onEdit={handleEdit}
+                onDelete={handleDeleteProject}
+                onAddChild={handleAddChild}
+              />
+            ))}
+          </>
         )}
       </ListWrapper>
+
+      <AddButton onClick={() => setIsOpen(true)}>
+        <Plus size={16} />
+        새 할일
+      </AddButton>
     </TodoListContainer>
   );
 };

--- a/client/src/features/todo/types/index.ts
+++ b/client/src/features/todo/types/index.ts
@@ -1,1 +1,2 @@
 export type { Todo } from "./todo.type";
+export type { ProjectCardData } from "../utils/projectUtils";

--- a/client/src/features/todo/utils/projectUtils.ts
+++ b/client/src/features/todo/utils/projectUtils.ts
@@ -1,0 +1,90 @@
+import type { Todo } from "../types";
+
+export interface ProjectCardData {
+  todo: Todo;
+  childTodos: Todo[];
+  progress: number;
+  subtaskInfo: { total: number; statusText: string };
+  overdueInfo: { isOverdue: boolean; daysOver: number };
+  isExpanded: boolean;
+}
+
+// 서브태스크 중 done 비율 (0~100). 서브태스크가 없으면 0 반환
+export function getProjectProgress(
+  allTodos: Todo[],
+  projectId: string
+): number {
+  const subtasks = allTodos.filter((t) => t.parentId === projectId);
+  if (subtasks.length === 0) return 0;
+  const doneCount = subtasks.filter((t) => t.status === "done").length;
+  return Math.round((doneCount / subtasks.length) * 100);
+}
+
+// "N개 할일 · 진행 중" 형태 정보 반환
+// statusText: 모두 done → "완료", done이 하나도 없으면 "시작 전", 그 외 "진행 중"
+export function getProjectSubtaskInfo(
+  allTodos: Todo[],
+  projectId: string
+): { total: number; statusText: string } {
+  const subtasks = allTodos.filter((t) => t.parentId === projectId);
+  const total = subtasks.length;
+
+  if (total === 0) {
+    return { total, statusText: "시작 전" };
+  }
+
+  const doneCount = subtasks.filter((t) => t.status === "done").length;
+
+  let statusText: string;
+  if (doneCount === total) {
+    statusText = "완료";
+  } else if (doneCount === 0) {
+    statusText = "시작 전";
+  } else {
+    statusText = "진행 중";
+  }
+
+  return { total, statusText };
+}
+
+// 서브태스크 중 dueAt이 오늘보다 이전인 것 감지
+// 가장 오래된 초과 서브태스크 기준으로 daysOver 계산
+export function getProjectOverdue(
+  allTodos: Todo[],
+  projectId: string
+): { isOverdue: boolean; daysOver: number } {
+  const subtasks = allTodos.filter((t) => t.parentId === projectId);
+
+  if (subtasks.length === 0) {
+    return { isOverdue: false, daysOver: 0 };
+  }
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const overdueSubtasks = subtasks.filter((t) => {
+    if (!t.dueAt || t.status === "done") return false;
+    const dueDate = new Date(t.dueAt);
+    dueDate.setHours(0, 0, 0, 0);
+    return dueDate < today;
+  });
+
+  if (overdueSubtasks.length === 0) {
+    return { isOverdue: false, daysOver: 0 };
+  }
+
+  // 가장 오래된 초과 서브태스크 기준
+  const oldestDue = overdueSubtasks.reduce((oldest, t) => {
+    const tDate = new Date(t.dueAt!);
+    const oldestDate = new Date(oldest.dueAt!);
+    return tDate < oldestDate ? t : oldest;
+  });
+
+  const oldestDueDate = new Date(oldestDue.dueAt!);
+  oldestDueDate.setHours(0, 0, 0, 0);
+  const daysOver = Math.floor(
+    (today.getTime() - oldestDueDate.getTime()) / (1000 * 60 * 60 * 24)
+  );
+
+  return { isOverdue: true, daysOver };
+}

--- a/client/src/shared/ui/modal/modal.styles.tsx
+++ b/client/src/shared/ui/modal/modal.styles.tsx
@@ -12,7 +12,7 @@ const ModalBackground = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 999;
+  z-index: 10000;
 
   ${media.mobile} {
     align-items: flex-end;

--- a/client/src/shared/ui/modal/modal.tsx
+++ b/client/src/shared/ui/modal/modal.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from "react-dom";
 import {
   ModalBackground,
   ModalContainer,
@@ -21,7 +22,7 @@ const Modal = ({
   const handleClose = () => {
     setIsOpen(false);
   };
-  return (
+  return createPortal(
     <>
       <ModalBackground onClick={handleClose}>
         <ModalContainer onClick={(e) => e.stopPropagation()}>
@@ -34,7 +35,8 @@ const Modal = ({
           </ModalFooter>
         </ModalContainer>
       </ModalBackground>
-    </>
+    </>,
+    document.body
   );
 };
 

--- a/client/src/styles/colors.ts
+++ b/client/src/styles/colors.ts
@@ -5,6 +5,7 @@ export const colors = {
   },
   danger: {
     main: "#E24B4A",
+    subtle: "#F5C2C1",
     background: "#FBEAEA",
     text: "#C53A39",
   },


### PR DESCRIPTION
## Summary

- 루트 투두를 프로젝트 카드 뷰로 리디자인 (진행률 바, 초과 배지, 상태 변경)
- 하위 투두는 데스크톱 인라인 펼치기 / 모바일 BottomSheet로 표시
- 인라인 상태 선택기(ChildTodoCard) + BottomSheet 상태 선택(ProjectCard) 추가
- Modal z-index 수정 (createPortal + 10000) — BottomSheet 위에 표시 보장
- 모바일 헤더 버튼 최적화: 삭제 버튼은 BottomSheet 내 배치

## Changes

### 신규 컴포넌트
- `ProjectCard` — 프로젝트 카드 (진행률, 초과, 상태, 하위 목록)
- `ChildTodoCard` — 하위 투두 카드 (상태 색상, 인라인 상태 선택기)
- `projectUtils.ts` — getProjectProgress / getProjectSubtaskInfo / getProjectOverdue

### 수정
- `todoList.tsx` — ProjectCard 기반 렌더링, 검색 결과 동일 UI 적용
- `modal.tsx` — createPortal 추가, z-index 10000
- `colors.ts` — danger.subtle 토큰 추가

## Test plan

- [ ] 목록 페이지에서 프로젝트 카드 정상 표시 확인
- [ ] 진행률 바 / 초과 배지 동작 확인
- [ ] 데스크톱 chevron 클릭 → 인라인 펼치기
- [ ] 모바일 chevron 클릭 → BottomSheet
- [ ] 상태 변경 (ProjectCard dot / ChildTodoCard dot)
- [ ] 하위 작업 추가 버튼 (헤더 + 모달)
- [ ] 검색 결과 카드 UI 확인
- [ ] 모바일 삭제 버튼 BottomSheet 내 위치

🤖 Generated with [Claude Code](https://claude.com/claude-code)