### PR TITLE
feat: SNB/모바일 메뉴 디자인 개편 — 시맨틱 아이콘 + 활성 상태 border-left accent

### DIFF
--- a/client/src/layouts/bottomTabBar/bottomTabBar.tsx
+++ b/client/src/layouts/bottomTabBar/bottomTabBar.tsx
@@ -1,11 +1,11 @@
-import { Sun, ListChecks, CalendarCheckIcon, KanbanIcon } from "lucide-react";
+import { Sun, ListTodo, CalendarDays, Kanban } from "lucide-react";
 import { TabNavLink, TabBarContainer } from "./bottomTabBar.styles";
 
 const TAB_ITEMS = [
   { path: "/today", icon: Sun, label: "오늘" },
-  { path: "/todo", icon: ListChecks, label: "목록" },
-  { path: "/calendar", icon: CalendarCheckIcon, label: "캘린더" },
-  { path: "/kanban", icon: KanbanIcon, label: "칸반" },
+  { path: "/todo", icon: ListTodo, label: "목록" },
+  { path: "/calendar", icon: CalendarDays, label: "캘린더" },
+  { path: "/kanban", icon: Kanban, label: "칸반" },
 ] as const;
 
 const BottomTabBar = () => {

--- a/client/src/layouts/snb/mobileDrawer.styles.tsx
+++ b/client/src/layouts/snb/mobileDrawer.styles.tsx
@@ -98,7 +98,7 @@ export const NavNavLink = styled(NavLink)`
   cursor: pointer;
   font-size: 16px;
   font-weight: 500;
-  color: #1a1a1a;
+  color: #666;
   background-color: transparent;
   border-radius: 8px;
   text-decoration: none;
@@ -110,7 +110,10 @@ export const NavNavLink = styled(NavLink)`
 
   &.active {
     color: ${colors.brand.secondary};
-    background-color: #E8F5EF;
+    background-color: #E8F4F1;
+    border-left: 3px solid #1D9E75;
+    border-radius: 0 8px 8px 0;
+    padding-left: 7px;
 
     &:hover {
       background-color: #D5EDE4;

--- a/client/src/layouts/snb/mobileDrawer.tsx
+++ b/client/src/layouts/snb/mobileDrawer.tsx
@@ -1,9 +1,9 @@
 import { useState, useCallback, useEffect } from "react";
 import { createPortal } from "react-dom";
 import {
-  ListCheckIcon,
-  CalendarCheckIcon,
-  KanbanIcon,
+  ListTodo,
+  CalendarDays,
+  Kanban,
 } from "lucide-react";
 import { useAuth } from "@/features/auth/context/useAuth";
 import {
@@ -24,9 +24,9 @@ interface MobileDrawerProps {
 }
 
 const NAV_ITEMS = [
-  { path: "/todo", icon: <ListCheckIcon size={20} />, label: "목록" },
-  { path: "/calendar", icon: <CalendarCheckIcon size={20} />, label: "캘린더" },
-  { path: "/kanban", icon: <KanbanIcon size={20} />, label: "칸반" },
+  { path: "/todo", icon: <ListTodo size={20} />, label: "목록" },
+  { path: "/calendar", icon: <CalendarDays size={20} />, label: "캘린더" },
+  { path: "/kanban", icon: <Kanban size={20} />, label: "칸반" },
 ];
 
 const MobileDrawer = ({ isOpen, onClose }: MobileDrawerProps) => {

--- a/client/src/layouts/snb/snb.tsx
+++ b/client/src/layouts/snb/snb.tsx
@@ -1,9 +1,9 @@
 import {
   ArrowLeft,
   ArrowRight,
-  CalendarCheckIcon,
-  KanbanIcon,
-  ListCheckIcon,
+  ListTodo,
+  CalendarDays,
+  Kanban,
 } from "lucide-react";
 import { NavLink } from "react-router-dom";
 import styled from "styled-components";
@@ -11,9 +11,9 @@ import { media } from "@/styles/breakpoints";
 import { colors } from "@/styles/colors";
 
 const NAV_ITEMS = [
-  { path: "/todo", icon: <ListCheckIcon />, label: "목록" },
-  { path: "/calendar", icon: <CalendarCheckIcon />, label: "캘린더" },
-  { path: "/kanban", icon: <KanbanIcon />, label: "칸반" },
+  { path: "/todo", icon: <ListTodo size={16} />, label: "목록" },
+  { path: "/calendar", icon: <CalendarDays size={16} />, label: "캘린더" },
+  { path: "/kanban", icon: <Kanban size={16} />, label: "칸반" },
 ];
 
 const SNB = ({
@@ -76,7 +76,7 @@ const IconWrapper = styled.span<{ $isopen: boolean; $active: boolean }>`
 
   ${({ $isopen, $active }) =>
     !$isopen && $active
-      ? `background-color: #E8F5EF; color: ${colors.brand.secondary};`
+      ? `background-color: #E8F4F1; color: ${colors.brand.secondary};`
       : ""}
 `;
 
@@ -89,19 +89,27 @@ const SidebarNavLink = styled(NavLink)<{ $isopen: boolean }>`
   cursor: pointer;
   font-size: 20px;
   font-weight: 500;
-  color: #1a1a1a;
+  color: #666;
   background-color: transparent;
   border-radius: 8px;
   text-decoration: none;
   transition: background-color 0.15s ease;
 
   &:hover {
-    background-color: #e0e0e0;
+    background-color: #E0EDE8;
   }
 
   &.active {
     color: ${colors.brand.secondary};
-    background-color: ${({ $isopen }) => ($isopen ? "#E8F5EF" : "transparent")};
+    background-color: ${({ $isopen }) => ($isopen ? "#E8F4F1" : "transparent")};
+    ${({ $isopen }) =>
+      $isopen
+        ? `
+      border-left: 3px solid #1D9E75;
+      border-radius: 0 8px 8px 0;
+      padding-left: 7px;
+    `
+        : ""}
 
     &:hover {
       background-color: ${({ $isopen }) => ($isopen ? "#D5EDE4" : "transparent")};


### PR DESCRIPTION
## Summary

- 활성 메뉴 항목에 좌측 초록 border accent(`border-left: 3px solid #1D9E75`) + 연민트 배경(`#E8F4F1`) 하이라이트 추가 — 사용자가 현재 위치를 명확히 파악할 수 있도록 개선
- 비활성 항목 텍스트 색상 `#666`, hover 색상 `#E0EDE8`으로 조정해 계층감 강화
- 모든 메뉴 아이콘을 `Square` 대신 각 기능에 맞는 lucide 아이콘으로 교체: `ListTodo` / `CalendarDays` / `Kanban`
- SNB(데스크탑), 모바일 드로어, 하단 탭바 세 곳 동일하게 적용해 일관성 확보

## Test plan

- [ ] 데스크탑 — SNB 열림 상태: 활성 메뉴에 민트 배경 + 좌측 초록 border 표시 확인
- [ ] 데스크탑 — SNB 닫힘 상태: 활성 아이콘 배경 강조만 적용, border-left 없음 확인
- [ ] 모바일 — 드로어 내 활성 메뉴 동일 스타일 확인
- [ ] 모바일 — 하단 탭바 아이콘 3종(ListTodo, CalendarDays, Kanban) 렌더링 확인
- [ ] hover 색상 및 비활성 텍스트 색상 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)