### PR TITLE
feat: 반복 할 일(recurring todo) 기능 추가

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,7 +3,7 @@ import Header from "@/layouts/header/header";
 import Footer from "@/layouts/footer/footer";
 import { Outlet } from "react-router-dom";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Container, Main } from "@/App.styles";
 import SNB from "@/layouts/snb/snb";
 import MobileDrawer from "@/layouts/snb/mobileDrawer";
@@ -12,11 +12,24 @@ import BottomTabBar from "@/layouts/bottomTabBar/bottomTabBar";
 import { BOTTOM_TAB_BAR_HEIGHT } from "@/layouts/bottomTabBar/bottomTabBar.styles";
 import styled from "styled-components";
 import { useMediaQuery } from "@/shared/hooks";
+import { useTodo } from "@/features/todo";
 
 const App = () => {
   const [isopen, setIsOpen] = useState(true);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const isMobile = useMediaQuery("tablet");
+  const { useExtendIndefiniteRecurringSeries } = useTodo();
+  const hasExtendedRef = useRef(false);
+
+  // 인증된 레이아웃(App) 마운트 시 1회, 무기한 반복 시리즈들의 남은 인스턴스를
+  // 오늘 기준으로 이어서 채운다. 세션 중 재마운트되어도 다시 실행되지 않도록
+  // ref로 막는다(라우트 이동으로는 App이 재마운트되지 않지만 방어적으로 둔다).
+  useEffect(() => {
+    if (hasExtendedRef.current) return;
+    hasExtendedRef.current = true;
+    useExtendIndefiniteRecurringSeries.mutate();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <Container>

--- a/client/src/features/dashboard/components/calendar.styles.tsx
+++ b/client/src/features/dashboard/components/calendar.styles.tsx
@@ -100,6 +100,13 @@ const DayDetailItem = styled.li<{ $color: string; $overdue?: boolean }>`
   border-radius: 0 8px 8px 0;
 `;
 
+const DayDetailTitleRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+`;
+
 const DayDetailTitle = styled.p`
   margin: 0;
   font-size: 14px;
@@ -111,6 +118,22 @@ const DayDetailDate = styled.p`
   margin: 4px 0 0;
   font-size: 12px;
   color: #666;
+`;
+
+const DayDetailRecurrenceCaption = styled.p`
+  margin: 2px 0 0;
+  font-size: 11px;
+  color: ${colors.brand.primary};
+`;
+
+// eventContent 콜백에서 반복 아이콘 + 제목을 함께 배치하기 위한 래퍼
+const EventContentWrapper = styled.span`
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 `;
 
 const EmptyMessage = styled.p`
@@ -189,8 +212,11 @@ export {
   CalendarContainer,
   DayDetailList,
   DayDetailItem,
+  DayDetailTitleRow,
   DayDetailTitle,
   DayDetailDate,
+  DayDetailRecurrenceCaption,
+  EventContentWrapper,
   EmptyMessage,
   ViewToggleRow,
   ViewButton,

--- a/client/src/features/dashboard/components/calendar.tsx
+++ b/client/src/features/dashboard/components/calendar.tsx
@@ -5,26 +5,30 @@ import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTodo, TodoForm } from "@/features/todo";
 import type { Todo } from "@/features/todo";
-import type { EventInput, EventClickArg } from "@fullcalendar/core/index.js";
+import type { EventInput, EventClickArg, EventContentArg } from "@fullcalendar/core/index.js";
 import type { DateClickArg } from "@fullcalendar/interaction";
 import type { EventDropArg } from "@fullcalendar/core";
 import {
   CalendarContainer,
   DayDetailList,
   DayDetailItem,
+  DayDetailTitleRow,
   DayDetailTitle,
   DayDetailDate,
+  DayDetailRecurrenceCaption,
+  EventContentWrapper,
   EmptyMessage,
   ViewToggleRow,
   ViewButton,
   AddButton,
 } from "./calendar.styles";
 import { statusColors, type Status } from "../../../styles/statusColors";
-import { BottomSheet, EmptyState, Modal, useToast } from "@/shared";
-import { AlertCircle, Plus } from "lucide-react";
+import { BottomSheet, EmptyState, Modal, RecurrenceBadge, useToast } from "@/shared";
+import { AlertCircle, Plus, Repeat } from "lucide-react";
 import styled, { keyframes } from "styled-components";
 import { colors } from "@/styles/colors";
 import { isOverdue } from "../utils/calendarUtils";
+import { formatRecurrenceSummary } from "@/features/todo/utils/recurrenceSummary";
 
 const statusLabels: Record<Status, string> = {
   todo: "할 일",
@@ -81,13 +85,27 @@ const Calendar = () => {
           color: overdue
             ? colors.danger.main
             : (statusColors[todo.status as Status]?.main ?? statusColors.todo.main),
+          // 반복 인스턴스는 드래그로 dueAt을 바꾸면 "시리즈 전체 수정" 정책(확인 모달,
+          // 날짜 중복 방지)을 모두 우회해 단일 문서만 어긋나게 되므로 드래그를 막는다.
+          // 날짜를 바꾸려면 반드시 폼을 통한 시리즈 수정 플로우를 거쳐야 한다.
+          editable: todo.recurrenceId == null,
           extendedProps: {
             status: todo.status,
             overdue,
+            isRecurring: todo.recurrenceId != null,
           },
         };
       });
   }, [todos]);
+
+  const renderEventContent = useCallback((arg: EventContentArg) => (
+    <EventContentWrapper>
+      {arg.event.extendedProps.isRecurring && (
+        <Repeat size={10} color="#ffffff" aria-hidden="true" />
+      )}
+      <span>{arg.event.title}</span>
+    </EventContentWrapper>
+  ), []);
 
   const selectedDateTodos = useMemo(() => {
     if (!selectedDate || !todos) return [];
@@ -123,6 +141,18 @@ const Calendar = () => {
     const todo = todos?.find((t: Todo) => t.id === info.event.id);
     if (!todo) {
       info.revert();
+      return;
+    }
+
+    // 이벤트 자체에 editable: false를 부여해 두었지만, 방어적으로 한 번 더 막는다.
+    // 반복 인스턴스는 단일 문서 드래그로 dueAt을 바꾸면 시리즈 수정 정책(확인 모달,
+    // 날짜 중복 방지)을 우회하게 된다.
+    if (todo.recurrenceId) {
+      info.revert();
+      toast.error(
+        "변경 불가",
+        "반복 할 일의 날짜는 드래그로 바꿀 수 없습니다. 수정 화면에서 변경해주세요",
+      );
       return;
     }
 
@@ -230,6 +260,7 @@ const Calendar = () => {
           displayEventTime={false}
           dateClick={handleDateClick}
           eventClick={handleEventClick}
+          eventContent={renderEventContent}
           editable={true}
           eventDrop={handleEventDrop}
           longPressDelay={1000}
@@ -253,12 +284,20 @@ const Calendar = () => {
                 $color={isOverdue(todo) ? colors.danger.main : (statusColors[todo.status as Status]?.main ?? statusColors.todo.main)}
                 $overdue={isOverdue(todo)}
               >
-                <DayDetailTitle>{todo.title}</DayDetailTitle>
+                <DayDetailTitleRow>
+                  <DayDetailTitle>{todo.title}</DayDetailTitle>
+                  {todo.recurrenceId != null && <RecurrenceBadge />}
+                </DayDetailTitleRow>
                 <DayDetailDate>
                   {statusLabels[todo.status as Status]}
                   {todo.startAt && ` · 시작: ${formatDate(todo.startAt)}`}
                   {todo.dueAt && ` · 마감: ${formatDate(todo.dueAt)}`}
                 </DayDetailDate>
+                {todo.recurrenceId != null && todo.recurrence && (
+                  <DayDetailRecurrenceCaption>
+                    {formatRecurrenceSummary(todo.recurrence, todo.dueAt)}
+                  </DayDetailRecurrenceCaption>
+                )}
               </DayDetailItem>
             ))}
           </DayDetailList>

--- a/client/src/features/kanban/components/kanbanBoard.styles.tsx
+++ b/client/src/features/kanban/components/kanbanBoard.styles.tsx
@@ -70,6 +70,15 @@ const ItemTitle = styled.h3`
   margin: 0;
 `;
 
+// 배지가 제목을 가리지 않도록 wrap 허용(recurringTodo.spec.md 1-3절, 8-5절 —
+// ItemTitle에는 의도적으로 text-overflow: ellipsis를 적용하지 않는다).
+const ItemTitleRow = styled.div`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+`;
+
 const DragOverlayItem = styled.div`
   background: #fff;
   border-radius: 8px;
@@ -146,6 +155,7 @@ export {
   KanbanItemStyled,
   ParentLabel,
   ItemTitle,
+  ItemTitleRow,
   DragOverlayItem,
   MobileTabContainer,
   MobileTabButton,

--- a/client/src/features/kanban/components/kanbanBoard.tsx
+++ b/client/src/features/kanban/components/kanbanBoard.tsx
@@ -5,6 +5,8 @@ import { useTodo } from "@/features/todo";
 import { useMediaQuery, KanbanSkeleton } from "@/shared";
 import KanbanColumn from "./kanbanColumn";
 import { useKanbanDrag } from "../hooks/useKanbanDrag";
+import { isVisibleInKanban } from "../utils/kanbanFilters";
+import { collapseRecurringInstances } from "@/features/todo";
 import { Circle, Loader, CheckCircle } from "lucide-react";
 import {
   KanbanBoardContainer,
@@ -31,16 +33,34 @@ const KanbanBoard = () => {
       onUpdateTodo: (todo) => useUpdateTodo.mutate(todo),
     });
 
+  // 반복 인스턴스는 며칠 방치되면 같은 recurrenceId의 인스턴스가 여러 개 노출 조건을
+  // 만족할 수 있다(예: 매일 반복을 3일간 열어보지 않은 경우). 시리즈당 대표 1건(가장
+  // 이른 dueAt)만 카드로 보여준다 — todoList.tsx와 동일한 원칙.
   const todoList = useMemo(() => {
-    return todos?.filter((todo) => todo.status === "todo") ?? [];
+    const today = new Date();
+    return collapseRecurringInstances(
+      todos?.filter(
+        (todo) => todo.status === "todo" && isVisibleInKanban(todo, today),
+      ) ?? [],
+    );
   }, [todos]);
 
   const doingList = useMemo(() => {
-    return todos?.filter((todo) => todo.status === "doing") ?? [];
+    const today = new Date();
+    return collapseRecurringInstances(
+      todos?.filter(
+        (todo) => todo.status === "doing" && isVisibleInKanban(todo, today),
+      ) ?? [],
+    );
   }, [todos]);
 
   const doneList = useMemo(() => {
-    return todos?.filter((todo) => todo.status === "done") ?? [];
+    const today = new Date();
+    return collapseRecurringInstances(
+      todos?.filter(
+        (todo) => todo.status === "done" && isVisibleInKanban(todo, today),
+      ) ?? [],
+    );
   }, [todos]);
 
   const handleNavigate = (id: string) => {

--- a/client/src/features/kanban/components/kanbanItem.tsx
+++ b/client/src/features/kanban/components/kanbanItem.tsx
@@ -1,7 +1,8 @@
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type { Todo } from "@/features/todo";
-import { KanbanItemStyled, ParentLabel, ItemTitle } from "./kanbanBoard.styles";
+import { RecurrenceBadge } from "@/shared";
+import { KanbanItemStyled, ParentLabel, ItemTitle, ItemTitleRow } from "./kanbanBoard.styles";
 
 interface KanbanItemProps {
   todo: Todo;
@@ -34,7 +35,10 @@ const KanbanItem = ({ todo, parentTitle, onNavigate }: KanbanItemProps) => {
       onClick={() => onNavigate(todo.id)}
     >
       {parentTitle && <ParentLabel>{parentTitle}</ParentLabel>}
-      <ItemTitle>{todo.title}</ItemTitle>
+      <ItemTitleRow>
+        <ItemTitle>{todo.title}</ItemTitle>
+        {todo.recurrenceId != null && <RecurrenceBadge />}
+      </ItemTitleRow>
     </KanbanItemStyled>
   );
 };

--- a/client/src/features/kanban/utils/__tests__/kanbanFilters.test.ts
+++ b/client/src/features/kanban/utils/__tests__/kanbanFilters.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { isVisibleInKanban } from "../kanbanFilters";
+import type { Todo } from "@/features/todo";
+
+const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
+  id: "todo-1",
+  userId: "user-1",
+  title: "테스트 할 일",
+  status: "todo",
+  priority: "medium",
+  startAt: null,
+  dueAt: null,
+  doneAt: null,
+  parentId: null,
+  order: 0,
+  recurrence: null,
+  recurrenceId: null,
+  createdAt: "2026-07-01T00:00:00.000Z",
+  updatedAt: "2026-07-01T00:00:00.000Z",
+  ...overrides,
+});
+
+describe("isVisibleInKanban", () => {
+  const today = new Date("2026-07-10T12:00:00");
+
+  it("반복이 아닌 todo는 dueAt과 무관하게 항상 true를 반환한다 (기존 로직에 영향 없음)", () => {
+    const futureTodo = makeTodo({
+      recurrence: null,
+      dueAt: "2026-12-31T00:00:00",
+    });
+    expect(isVisibleInKanban(futureTodo, today)).toBe(true);
+
+    const noDueTodo = makeTodo({ recurrence: null, dueAt: null });
+    expect(isVisibleInKanban(noDueTodo, today)).toBe(true);
+  });
+
+  it("반복 인스턴스이고 dueAt <= 오늘이면 true를 반환한다", () => {
+    const todoOnToday = makeTodo({
+      recurrence: { type: "daily", endType: "indefinite" },
+      recurrenceId: "series-1",
+      dueAt: "2026-07-10T09:00:00",
+    });
+    expect(isVisibleInKanban(todoOnToday, today)).toBe(true);
+
+    const todoInPast = makeTodo({
+      recurrence: { type: "daily", endType: "indefinite" },
+      recurrenceId: "series-1",
+      dueAt: "2026-07-01T09:00:00",
+    });
+    expect(isVisibleInKanban(todoInPast, today)).toBe(true);
+  });
+
+  it("반복 인스턴스이고 dueAt > 오늘이면 false를 반환한다", () => {
+    const futureInstance = makeTodo({
+      recurrence: { type: "daily", endType: "indefinite" },
+      recurrenceId: "series-1",
+      dueAt: "2026-07-11T09:00:00",
+    });
+    expect(isVisibleInKanban(futureInstance, today)).toBe(false);
+  });
+});

--- a/client/src/features/kanban/utils/kanbanFilters.ts
+++ b/client/src/features/kanban/utils/kanbanFilters.ts
@@ -1,0 +1,20 @@
+import type { Todo } from "@/features/todo";
+
+/**
+ * kanban 보드에 노출할지 여부를 판단하는 반복 인스턴스 전용 필터.
+ *
+ * 정책(스펙 4-5절): 반복 인스턴스는 dueAt <= 오늘 인 것만 kanban에 노출하고,
+ * 미래 인스턴스는 캘린더 전용으로 남긴다. 일반(비반복) 할 일은 이 필터의 영향을
+ * 받지 않고 항상 true를 반환한다 — 기존 kanban 노출 로직(status 기준 컬럼 분류)에
+ * 얹어 추가로 적용하는 필터이며, 기존 필터를 대체하지 않는다.
+ */
+export const isVisibleInKanban = (todo: Todo, today: Date): boolean => {
+  if (!todo.recurrence) return true;
+  if (!todo.dueAt) return true; // 반복인데 dueAt이 없는 비정상 상태는 방어적으로 노출 유지
+
+  const due = new Date(todo.dueAt);
+  const endOfToday = new Date(today);
+  endOfToday.setHours(23, 59, 59, 999);
+
+  return due.getTime() <= endOfToday.getTime();
+};

--- a/client/src/features/today/hooks/__tests__/useTodayTodos.test.tsx
+++ b/client/src/features/today/hooks/__tests__/useTodayTodos.test.tsx
@@ -36,6 +36,8 @@ const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
   doneAt: null,
   parentId: null,
   order: 0,
+  recurrence: null,
+  recurrenceId: null,
   createdAt: '2026-06-14T00:00:00.000Z',
   updatedAt: '2026-06-14T00:00:00.000Z',
   ...overrides,

--- a/client/src/features/todo/api/__tests__/recurringTodoApi.test.ts
+++ b/client/src/features/todo/api/__tests__/recurringTodoApi.test.ts
@@ -1,0 +1,524 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Todo, RecurrenceRule } from "../../types/todo.type";
+
+// Firebase 모킹 - 실제 Firebase에 연결하지 않도록 처리
+vi.mock("@/shared/lib/firebase", () => ({
+  db: {},
+  auth: {
+    currentUser: { uid: "test-user-id" },
+  },
+  googleProvider: {},
+}));
+
+let autoIdCounter = 0;
+
+vi.mock("firebase/firestore", () => ({
+  collection: vi.fn(() => ({})),
+  addDoc: vi.fn(),
+  getDocs: vi.fn(),
+  // doc(collectionRef) -> 자동 생성 id / doc(db, "todos", id) -> 지정된 id
+  doc: vi.fn((...args: unknown[]) => {
+    if (args.length <= 1) {
+      autoIdCounter += 1;
+      return { id: `auto-${autoIdCounter}` };
+    }
+    return { id: args[2] };
+  }),
+  updateDoc: vi.fn(),
+  deleteDoc: vi.fn(),
+  query: vi.fn(() => ({})),
+  where: vi.fn(() => ({})),
+  getDoc: vi.fn(),
+  writeBatch: vi.fn(),
+}));
+
+// `vi.clearAllMocks()`은 mock 호출 이력만 지울 뿐 `mockResolvedValueOnce` 등으로 쌓인
+// "once" 큐는 비우지 않는다(vitest 동작). 이전 테스트에서 큐가 다 소비되지 않으면 다음
+// 테스트로 leak되어 예기치 못한 반환값을 받게 되므로, getDocs/addDoc/writeBatch 등
+// once 패턴을 쓰는 mock들은 매 테스트마다 완전히 mockReset()한다.
+const resetFirestoreMocks = async () => {
+  autoIdCounter = 0;
+  const { getDocs, addDoc, updateDoc, deleteDoc, getDoc, writeBatch } = await import(
+    "firebase/firestore"
+  );
+  vi.mocked(getDocs).mockReset();
+  vi.mocked(addDoc).mockReset();
+  vi.mocked(updateDoc).mockReset();
+  vi.mocked(deleteDoc).mockReset();
+  vi.mocked(getDoc).mockReset();
+  vi.mocked(writeBatch).mockReset();
+};
+
+const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
+  id: "todo-1",
+  userId: "test-user-id",
+  title: "테스트 할 일",
+  status: "todo",
+  priority: "medium",
+  startAt: null,
+  dueAt: null,
+  doneAt: null,
+  parentId: null,
+  order: 0,
+  recurrence: null,
+  recurrenceId: null,
+  createdAt: "2026-06-14T00:00:00.000Z",
+  updatedAt: "2026-06-14T00:00:00.000Z",
+  ...overrides,
+});
+
+const dailyRule: RecurrenceRule = { type: "daily", endType: "indefinite" };
+
+const emptyDocsSnapshot: { docs: { id: string; data: () => Record<string, unknown> }[] } = {
+  docs: [],
+};
+
+const makeBatch = () => ({
+  set: vi.fn(),
+  delete: vi.fn(),
+  commit: vi.fn().mockResolvedValue(undefined),
+});
+
+describe("parentId ↔ recurrence 상호 배제 가드", () => {
+  beforeEach(async () => {
+    await resetFirestoreMocks();
+  });
+
+  it("createTodo: parentId와 recurrence가 함께 설정되면 에러를 던진다", async () => {
+    const { createTodo } = await import("../todoApi");
+    const todo = makeTodo({ parentId: "parent-1", recurrence: dailyRule });
+
+    await expect(createTodo(todo)).rejects.toThrow();
+  });
+
+  it("editTodo: parentId와 recurrence가 함께 설정되면 에러를 던진다", async () => {
+    const { editTodo } = await import("../todoApi");
+    const todo = makeTodo({
+      id: "todo-1",
+      parentId: "parent-1",
+      recurrence: dailyRule,
+    });
+
+    await expect(editTodo(todo, [todo])).rejects.toThrow();
+  });
+
+  it("createChildTodo: 전달된 recurrence를 무시하고 항상 null로 강제한다", async () => {
+    const { getDocs, addDoc } = await import("firebase/firestore");
+    vi.mocked(getDocs).mockResolvedValueOnce(
+      emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+    );
+    vi.mocked(addDoc).mockResolvedValueOnce({ id: "child-1" } as Awaited<
+      ReturnType<typeof addDoc>
+    >);
+
+    const { createChildTodo } = await import("../todoApi");
+
+    await createChildTodo(
+      "parent-1",
+      { title: "하위 할 일", recurrence: dailyRule, recurrenceId: "leaked-series" },
+      [],
+    );
+
+    expect(vi.mocked(addDoc)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ recurrence: null, recurrenceId: null }),
+    );
+  });
+});
+
+describe("createRecurringTodo", () => {
+  beforeEach(async () => {
+    await resetFirestoreMocks();
+  });
+
+  it("생성할 dueDates 개수만큼 Todo 문서를 batch 생성하고 동일한 recurrenceId를 부여한다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    vi.mocked(getDocs).mockResolvedValueOnce(
+      emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+    );
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { createRecurringTodo } = await import("../todoApi");
+
+    const todo = makeTodo({
+      dueAt: "2026-07-10T09:00:00",
+      recurrence: dailyRule,
+    });
+    const horizonEnd = new Date("2026-07-13T00:00:00");
+
+    const created = await createRecurringTodo(todo, horizonEnd);
+
+    expect(created).toHaveLength(4); // 7/10, 11, 12, 13
+    const recurrenceIds = new Set(created.map((t) => t.recurrenceId));
+    expect(recurrenceIds.size).toBe(1);
+    expect(batch.set).toHaveBeenCalledTimes(4);
+    expect(batch.commit).toHaveBeenCalledTimes(1);
+    created.forEach((t) => {
+      expect(t.status).toBe("todo");
+    });
+  });
+
+  it("recurrence가 없으면 에러를 던진다", async () => {
+    const { createRecurringTodo } = await import("../todoApi");
+    const todo = makeTodo({ dueAt: "2026-07-10T09:00:00", recurrence: null });
+
+    await expect(createRecurringTodo(todo, new Date("2026-07-13T00:00:00"))).rejects.toThrow();
+  });
+
+  it("dueAt이 없으면 에러를 던진다", async () => {
+    const { createRecurringTodo } = await import("../todoApi");
+    const todo = makeTodo({ dueAt: null, recurrence: dailyRule });
+
+    await expect(createRecurringTodo(todo, new Date("2026-07-13T00:00:00"))).rejects.toThrow();
+  });
+});
+
+describe("editRecurringSeries", () => {
+  beforeEach(async () => {
+    await resetFirestoreMocks();
+  });
+
+  const toDocSnapshot = (todos: Todo[]) => ({
+    docs: todos.map((t) => ({
+      id: t.id,
+      data: () => {
+        const { id: _id, ...rest } = t;
+        return rest;
+      },
+    })),
+  });
+
+  it("done 인스턴스는 삭제하지 않고 필드도 건드리지 않는다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const doneInstance = makeTodo({
+      id: "done-1",
+      status: "done",
+      dueAt: "2026-07-01T09:00:00",
+      title: "옛날 제목",
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(
+        toDocSnapshot([doneInstance]) as ReturnType<typeof getDocs> extends Promise<infer T>
+          ? T
+          : never,
+      )
+      // 반복이 유지되므로(recurrence non-null) 재생성용 order 조회가 한 번 더 발생한다
+      .mockResolvedValueOnce(
+        emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+      );
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { editRecurringSeries } = await import("../todoApi");
+
+    const seriesTodo = makeTodo({
+      id: "done-1",
+      status: "done",
+      dueAt: "2026-07-01T09:00:00",
+      title: "새 제목",
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+
+    await editRecurringSeries(seriesTodo, new Date("2026-08-01T00:00:00"));
+
+    expect(batch.delete).not.toHaveBeenCalled();
+  });
+
+  it("doing 인스턴스는 삭제하지 않는다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const doingInstance = makeTodo({
+      id: "doing-1",
+      status: "doing",
+      dueAt: "2026-07-05T09:00:00",
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(
+        toDocSnapshot([doingInstance]) as ReturnType<typeof getDocs> extends Promise<infer T>
+          ? T
+          : never,
+      )
+      // 반복이 유지되므로(recurrence non-null) 재생성용 order 조회가 한 번 더 발생한다
+      .mockResolvedValueOnce(
+        emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+      );
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { editRecurringSeries } = await import("../todoApi");
+
+    const seriesTodo = makeTodo({
+      id: "doing-1",
+      status: "doing",
+      dueAt: "2026-07-05T09:00:00",
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+
+    await editRecurringSeries(seriesTodo, new Date("2026-08-01T00:00:00"));
+
+    expect(batch.delete).not.toHaveBeenCalled();
+  });
+
+  it("지난 미완료(overdue) todo 인스턴스는 삭제하지 않는다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const pastIso = "2020-01-01T09:00:00"; // 확실히 과거
+    const overdueInstance = makeTodo({
+      id: "overdue-1",
+      status: "todo",
+      dueAt: pastIso,
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(
+        toDocSnapshot([overdueInstance]) as ReturnType<typeof getDocs> extends Promise<infer T>
+          ? T
+          : never,
+      )
+      // 반복이 유지되므로(recurrence non-null) 재생성용 order 조회가 한 번 더 발생한다
+      .mockResolvedValueOnce(
+        emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+      );
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { editRecurringSeries } = await import("../todoApi");
+
+    const seriesTodo = makeTodo({
+      id: "overdue-1",
+      status: "todo",
+      dueAt: pastIso,
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+
+    await editRecurringSeries(seriesTodo, new Date("2026-08-01T00:00:00"));
+
+    expect(batch.delete).not.toHaveBeenCalled();
+  });
+
+  it("미래 todo 인스턴스는 삭제 후 새 규칙으로 재생성한다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const now = new Date();
+    const futureIso = new Date(now.getTime() + 1000 * 60 * 60 * 24 * 3).toISOString();
+    const futureInstance = makeTodo({
+      id: "future-1",
+      status: "todo",
+      dueAt: futureIso,
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(
+        toDocSnapshot([futureInstance]) as ReturnType<typeof getDocs> extends Promise<infer T>
+          ? T
+          : never,
+      )
+      .mockResolvedValueOnce(
+        emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+      );
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { editRecurringSeries } = await import("../todoApi");
+
+    const horizonEnd = new Date(now.getTime() + 1000 * 60 * 60 * 24 * 10);
+    const seriesTodo = makeTodo({
+      id: "future-1",
+      status: "todo",
+      dueAt: futureIso,
+      title: "바뀐 제목",
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+
+    await editRecurringSeries(seriesTodo, horizonEnd);
+
+    expect(batch.delete).toHaveBeenCalledTimes(1);
+    expect(batch.set).toHaveBeenCalled();
+    expect(batch.commit).toHaveBeenCalledTimes(1);
+  });
+
+  it("반복 OFF 전환(recurrence: null) 시 미래 todo 인스턴스만 삭제하고 재생성하지 않는다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const now = new Date();
+    const futureIso = new Date(now.getTime() + 1000 * 60 * 60 * 24 * 3).toISOString();
+    const pastIso = "2020-01-01T09:00:00";
+
+    const futureInstance = makeTodo({
+      id: "future-1",
+      status: "todo",
+      dueAt: futureIso,
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+    const overdueInstance = makeTodo({
+      id: "overdue-1",
+      status: "todo",
+      dueAt: pastIso,
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+    const doneInstance = makeTodo({
+      id: "done-1",
+      status: "done",
+      dueAt: pastIso,
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+
+    vi.mocked(getDocs).mockResolvedValueOnce(
+      toDocSnapshot([futureInstance, overdueInstance, doneInstance]) as ReturnType<
+        typeof getDocs
+      > extends Promise<infer T>
+        ? T
+        : never,
+    );
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { editRecurringSeries } = await import("../todoApi");
+
+    const seriesTodo = makeTodo({
+      id: "future-1",
+      status: "todo",
+      dueAt: futureIso,
+      recurrenceId: "series-1",
+      recurrence: null, // 반복 OFF
+    });
+
+    await editRecurringSeries(seriesTodo, new Date(now.getTime() + 1000 * 60 * 60 * 24 * 30));
+
+    // 미래 인스턴스 1개만 삭제, done/overdue는 보존
+    expect(batch.delete).toHaveBeenCalledTimes(1);
+    // OFF 전환이므로 재생성 없음 (getDocs가 재생성용 order 조회를 위해 2번째로 호출되지 않음)
+    expect(batch.set).not.toHaveBeenCalled();
+    expect(vi.mocked(getDocs)).toHaveBeenCalledTimes(1);
+  });
+
+  it("recurrenceId가 없으면 에러를 던진다", async () => {
+    const { editRecurringSeries } = await import("../todoApi");
+    const todo = makeTodo({ recurrenceId: null });
+
+    await expect(editRecurringSeries(todo, new Date())).rejects.toThrow();
+  });
+
+  it("doing 인스턴스 자체를 수정해도 같은 날짜에 새 todo 인스턴스를 중복 생성하지 않는다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const now = new Date();
+    const todayIso = now.toISOString();
+    const todayDateStr = todayIso.split("T")[0];
+
+    // 시리즈에는 오늘 날짜의 doing 인스턴스 하나만 존재한다(예: 사용자가 진행 중으로 표시).
+    const doingInstance = makeTodo({
+      id: "doing-1",
+      status: "doing",
+      dueAt: todayIso,
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(
+        toDocSnapshot([doingInstance]) as ReturnType<typeof getDocs> extends Promise<infer T>
+          ? T
+          : never,
+      )
+      .mockResolvedValueOnce(
+        emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+      );
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { editRecurringSeries } = await import("../todoApi");
+
+    const horizonEnd = new Date(now.getTime() + 1000 * 60 * 60 * 24 * 10);
+    // 사용자가 그 doing 인스턴스 자체를 열어 제목만 바꾸고 저장 (dueAt/recurrence는 그대로).
+    const seriesTodo = makeTodo({
+      id: "doing-1",
+      status: "doing",
+      dueAt: todayIso,
+      title: "수정된 제목",
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+
+    await editRecurringSeries(seriesTodo, horizonEnd);
+
+    // doing 인스턴스는 삭제되지 않아야 하고
+    expect(batch.delete).not.toHaveBeenCalled();
+
+    // 재생성 과정에서 이미 doing 인스턴스가 점유한 오늘 날짜에 새 todo 인스턴스가
+    // 또 생성되면 캘린더/목록에 같은 날짜가 두 건으로 표시된다 — 이는 발생하면 안 된다.
+    const createdDueDates = batch.set.mock.calls.map(
+      (call) => (call[1] as { dueAt: string }).dueAt,
+    );
+    const duplicatesForToday = createdDueDates.filter((d) => d.startsWith(todayDateStr));
+    expect(duplicatesForToday).toHaveLength(0);
+  });
+});
+
+describe("deleteRecurringSeries", () => {
+  beforeEach(async () => {
+    await resetFirestoreMocks();
+  });
+
+  const toDocSnapshot = (todos: Todo[]) => ({
+    docs: todos.map((t) => ({
+      id: t.id,
+      ref: { id: t.id },
+      data: () => {
+        const { id: _id, ...rest } = t;
+        return rest;
+      },
+    })),
+  });
+
+  it("editRecurringSeries와 달리 done/doing 상태와 무관하게 같은 recurrenceId의 모든 인스턴스를 삭제한다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const doneInstance = makeTodo({ id: "done-1", status: "done", recurrenceId: "series-1", recurrence: dailyRule });
+    const doingInstance = makeTodo({ id: "doing-1", status: "doing", recurrenceId: "series-1", recurrence: dailyRule });
+    const todoInstance = makeTodo({ id: "todo-1", status: "todo", recurrenceId: "series-1", recurrence: dailyRule });
+
+    vi.mocked(getDocs).mockResolvedValueOnce(
+      toDocSnapshot([doneInstance, doingInstance, todoInstance]) as ReturnType<
+        typeof getDocs
+      > extends Promise<infer T>
+        ? T
+        : never,
+    );
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { deleteRecurringSeries } = await import("../todoApi");
+
+    await deleteRecurringSeries("series-1");
+
+    // done/doing 포함 3건 전부 삭제 대상이어야 한다 (editRecurringSeries의 보존 정책과 다름)
+    expect(batch.delete).toHaveBeenCalledTimes(3);
+    expect(batch.commit).toHaveBeenCalledTimes(1);
+  });
+
+  it("삭제 대상 인스턴스가 없으면 아무것도 지우지 않고 commit만 한다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    vi.mocked(getDocs).mockResolvedValueOnce(
+      emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+    );
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { deleteRecurringSeries } = await import("../todoApi");
+
+    await deleteRecurringSeries("series-empty");
+
+    expect(batch.delete).not.toHaveBeenCalled();
+    expect(batch.commit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/features/todo/api/__tests__/recurringTodoApi.test.ts
+++ b/client/src/features/todo/api/__tests__/recurringTodoApi.test.ts
@@ -522,3 +522,126 @@ describe("deleteRecurringSeries", () => {
     expect(batch.commit).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("extendIndefiniteRecurringSeries", () => {
+  beforeEach(async () => {
+    await resetFirestoreMocks();
+  });
+
+  const toDocSnapshot = (todos: Todo[]) => ({
+    docs: todos.map((t) => ({
+      id: t.id,
+      ref: { id: t.id },
+      data: () => {
+        const { id: _id, ...rest } = t;
+        return rest;
+      },
+    })),
+  });
+
+  it("무기한 시리즈의 마지막 인스턴스 이후 빈 구간을 새 호라이즌까지 채운다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const now = new Date("2026-07-10T00:00:00");
+    const latestExisting = makeTodo({
+      id: "latest-1",
+      status: "todo",
+      dueAt: "2026-07-12T09:00:00",
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+    const horizonEnd = new Date("2026-07-15T00:00:00");
+
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(
+        toDocSnapshot([latestExisting]) as ReturnType<typeof getDocs> extends Promise<infer T>
+          ? T
+          : never,
+      )
+      // getNextRootOrder용 조회
+      .mockResolvedValueOnce(
+        emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+      );
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { extendIndefiniteRecurringSeries } = await import("../todoApi");
+    await extendIndefiniteRecurringSeries(horizonEnd);
+    void now;
+
+    // 7/13, 7/14, 7/15 (7/12는 이미 존재하므로 제외) = 3건 생성
+    expect(batch.set).toHaveBeenCalledTimes(3);
+    const createdDueDates = batch.set.mock.calls.map((call) => (call[1] as { dueAt: string }).dueAt);
+    expect(createdDueDates.every((d) => new Date(d).getTime() > new Date(latestExisting.dueAt as string).getTime())).toBe(true);
+    expect(batch.commit).toHaveBeenCalledTimes(1);
+  });
+
+  it("이미 새 호라이즌까지 채워져 있으면 아무것도 생성하지 않는다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const latestExisting = makeTodo({
+      id: "latest-1",
+      status: "todo",
+      dueAt: "2026-08-01T09:00:00",
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+    const horizonEnd = new Date("2026-07-15T00:00:00"); // latest보다 이전
+
+    vi.mocked(getDocs).mockResolvedValueOnce(
+      toDocSnapshot([latestExisting]) as ReturnType<typeof getDocs> extends Promise<infer T>
+        ? T
+        : never,
+    );
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { extendIndefiniteRecurringSeries } = await import("../todoApi");
+    await extendIndefiniteRecurringSeries(horizonEnd);
+
+    expect(batch.set).not.toHaveBeenCalled();
+    expect(batch.commit).not.toHaveBeenCalled();
+    // getNextRootOrder용 추가 조회도 발생하지 않아야 한다
+    expect(vi.mocked(getDocs)).toHaveBeenCalledTimes(1);
+  });
+
+  it("종료 조건이 특정 날짜(untilDate)인 시리즈는 확장 대상에서 제외한다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const untilDateInstance = makeTodo({
+      id: "until-1",
+      status: "todo",
+      dueAt: "2026-07-12T09:00:00",
+      recurrenceId: "series-until",
+      recurrence: { type: "daily", endType: "untilDate", endDate: "2026-07-20" },
+    });
+    const horizonEnd = new Date("2026-08-01T00:00:00");
+
+    vi.mocked(getDocs).mockResolvedValueOnce(
+      toDocSnapshot([untilDateInstance]) as ReturnType<typeof getDocs> extends Promise<infer T>
+        ? T
+        : never,
+    );
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { extendIndefiniteRecurringSeries } = await import("../todoApi");
+    await extendIndefiniteRecurringSeries(horizonEnd);
+
+    expect(batch.set).not.toHaveBeenCalled();
+    expect(vi.mocked(writeBatch)).not.toHaveBeenCalled();
+  });
+
+  it("반복 시리즈가 하나도 없으면 아무 조회/쓰기도 추가로 하지 않는다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const plainTodo = makeTodo({ id: "plain-1", recurrence: null, recurrenceId: null });
+
+    vi.mocked(getDocs).mockResolvedValueOnce(
+      toDocSnapshot([plainTodo]) as ReturnType<typeof getDocs> extends Promise<infer T>
+        ? T
+        : never,
+    );
+
+    const { extendIndefiniteRecurringSeries } = await import("../todoApi");
+    await extendIndefiniteRecurringSeries(new Date("2026-08-01T00:00:00"));
+
+    expect(vi.mocked(writeBatch)).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/features/todo/api/__tests__/todoApi.test.ts
+++ b/client/src/features/todo/api/__tests__/todoApi.test.ts
@@ -34,6 +34,8 @@ const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
   doneAt: null,
   parentId: null,
   order: 0,
+  recurrence: null,
+  recurrenceId: null,
   createdAt: '2026-06-14T00:00:00.000Z',
   updatedAt: '2026-06-14T00:00:00.000Z',
   ...overrides,

--- a/client/src/features/todo/api/todoApi.ts
+++ b/client/src/features/todo/api/todoApi.ts
@@ -8,9 +8,11 @@ import {
   query,
   where,
   getDoc,
+  writeBatch,
 } from "firebase/firestore";
 import { db, auth } from "@/shared/lib/firebase";
-import type { Todo } from "../types/todo.type";
+import type { RecurrenceRule, Todo } from "../types/todo.type";
+import { generateRecurringDueDates, getDefaultHorizonEnd } from "../utils/recurrence";
 
 const todosRef = collection(db, "todos");
 
@@ -22,6 +24,25 @@ const getUserId = () => {
 
 const mapDocToTodo = (id: string, data: Record<string, unknown>): Todo =>
   ({ id, ...data }) as Todo;
+
+/**
+ * 반복(recurrence)과 하위 할 일(parentId)은 상호 배제 관계다 (PM 확정 스코프).
+ * UI에서 이미 막고 있지만, UI 우회(직접 API 호출 등)를 방지하기 위해 데이터 레이어에서도
+ * 방어적으로 막는다. "조용히 무시하고 recurrence를 강제로 null 처리"하는 대신 명시적으로
+ * 에러를 던지는 쪽을 택했다 — 호출부가 두 필드를 동시에 채워 넣었다는 것은 상위 로직에
+ * 버그가 있다는 신호이므로, 값을 조용히 바꿔 저장하기보다 즉시 실패시켜 드러내는 편이
+ * 데이터 정합성을 지키는 데 더 안전하다고 판단했다.
+ */
+const assertNoRecurrenceParentConflict = (todo: {
+  parentId: string | null;
+  recurrence: RecurrenceRule | null;
+}) => {
+  if (todo.parentId && todo.recurrence) {
+    throw new Error(
+      "하위 할 일에는 반복을 설정할 수 없고, 반복 할 일은 하위 할 일이 될 수 없습니다",
+    );
+  }
+};
 
 export const getTodos = async () => {
   const userId = getUserId();
@@ -49,6 +70,7 @@ export const getSearchTodoList = async (queryStr: string) => {
 };
 
 export const createTodo = async (todo: Todo) => {
+  assertNoRecurrenceParentConflict(todo);
   const userId = getUserId();
   const now = new Date().toISOString();
   const { id: _, ...todoData } = todo;
@@ -87,6 +109,7 @@ const calcParentStatus = (
 };
 
 export const editTodo = async (todo: Todo, allTodos: Todo[]) => {
+  assertNoRecurrenceParentConflict(todo);
   const userId = getUserId();
   const { id, ...data } = todo;
   const now = new Date().toISOString();
@@ -190,6 +213,8 @@ export const createChildTodo = async (
     -1,
   );
 
+  // 하위 할 일은 반복 설정 대상이 아니다(상호 배제 원칙). 호출부가 실수로 recurrence를
+  // 채워 넘기더라도 데이터 레이어에서 항상 강제로 null 처리해 방어한다.
   const docRef = await addDoc(todosRef, {
     ...todo,
     parentId,
@@ -198,6 +223,8 @@ export const createChildTodo = async (
     updatedAt: now,
     status: "todo",
     order: maxOrder + 1,
+    recurrence: null,
+    recurrenceId: null,
   });
 
   // 새 하위(todo) 추가 → 상위 상태 재계산
@@ -211,4 +238,201 @@ export const createChildTodo = async (
   });
 
   return { ...todo, id: docRef.id, parentId } as Todo;
+};
+
+/** 인증된 사용자의 루트(parentId === null) 할 일 중 다음에 쓸 order 값을 계산한다. */
+const getNextRootOrder = async (userId: string): Promise<number> => {
+  const rootTodosSnapshot = await getDocs(
+    query(todosRef, where("userId", "==", userId), where("parentId", "==", null)),
+  );
+  const maxOrder = rootTodosSnapshot.docs.reduce(
+    (max, d) => Math.max(max, (d.data().order as number) ?? 0),
+    -1,
+  );
+  return maxOrder + 1;
+};
+
+/**
+ * 반복 규칙이 설정된 할 일을 저장한다. generateRecurringDueDates로 계산한 dueAt마다
+ * 하나씩 Todo 문서를 batch 생성하고, 모두 동일한 recurrenceId(신규 Firestore 문서 id)를
+ * 부여해 같은 시리즈로 묶는다. 개별 인스턴스는 status: "todo"로 시작한다.
+ */
+export const createRecurringTodo = async (
+  todo: Todo,
+  horizonEnd: Date = getDefaultHorizonEnd(),
+): Promise<Todo[]> => {
+  const userId = getUserId();
+  if (todo.parentId) {
+    throw new Error("하위 할 일은 반복 설정을 가질 수 없습니다");
+  }
+  if (!todo.recurrence) {
+    throw new Error("recurrence가 없는 할 일은 createRecurringTodo로 생성할 수 없습니다");
+  }
+  if (!todo.dueAt) {
+    throw new Error("반복 할 일은 dueAt(만료일시)이 필요합니다");
+  }
+
+  const now = new Date().toISOString();
+  const recurrenceId = doc(todosRef).id;
+  const dueDates = generateRecurringDueDates(todo.dueAt, todo.recurrence, horizonEnd);
+
+  let nextOrder = await getNextRootOrder(userId);
+  const { id: _id, ...todoData } = todo;
+
+  const batch = writeBatch(db);
+  const created: Todo[] = [];
+
+  for (const dueAt of dueDates) {
+    const newDocRef = doc(todosRef);
+    const instanceData = {
+      ...todoData,
+      userId,
+      dueAt,
+      status: "todo" as const,
+      doneAt: null,
+      parentId: null,
+      recurrenceId,
+      createdAt: now,
+      updatedAt: now,
+      order: nextOrder,
+    };
+    batch.set(newDocRef, instanceData);
+    created.push({ ...instanceData, id: newDocRef.id });
+    nextOrder += 1;
+  }
+
+  await batch.commit();
+  return created;
+};
+
+/**
+ * 반복 시리즈 전체 수정. 입력은 시리즈 대표 todo(수정 폼에서 편집 중인 인스턴스)의
+ * 새 필드값 + 새 recurrence 규칙이다 (recurrence가 null이면 반복 OFF 전환).
+ *
+ * 같은 recurrenceId를 가진 모든 인스턴스를 조회한 뒤 3단 분기로 처리한다:
+ *  1) status가 "done" 또는 "doing" → 그대로 보존 (필드 값 포함 전혀 건드리지 않음)
+ *  2) status가 "todo"이고 dueAt < 오늘(지난 미완료 = overdue) → 그대로 보존
+ *  3) status가 "todo"이고 dueAt >= 오늘(미래) → 삭제 후, 새 규칙/새 필드값으로 재생성
+ *     (재생성 시작 기준일은 새 dueAt부터 horizonEnd까지, 오늘 이전 발생일은 제외)
+ *
+ * recurrence를 null로 바꿔 반복을 끄는 저장도 동일한 3단 분기를 따른다: done/doing/overdue는
+ * 그대로 두고, 미래 "todo" 인스턴스만 재생성 없이 완전히 삭제한다(문서 자체가 사라지므로
+ * recurrenceId도 함께 사라진다).
+ */
+export const editRecurringSeries = async (
+  seriesTodo: Todo,
+  horizonEnd: Date = getDefaultHorizonEnd(),
+): Promise<void> => {
+  const userId = getUserId();
+  const { recurrenceId } = seriesTodo;
+  if (!recurrenceId) {
+    throw new Error("recurrenceId가 없는 할 일은 시리즈 전체 수정을 할 수 없습니다");
+  }
+  if (seriesTodo.parentId) {
+    throw new Error("하위 할 일은 반복 시리즈를 가질 수 없습니다");
+  }
+
+  const now = new Date().toISOString();
+  const todayStart = new Date();
+  todayStart.setHours(0, 0, 0, 0);
+
+  const seriesSnapshot = await getDocs(
+    query(
+      todosRef,
+      where("userId", "==", userId),
+      where("recurrenceId", "==", recurrenceId),
+    ),
+  );
+  const seriesTodos = seriesSnapshot.docs.map((d) => mapDocToTodo(d.id, d.data()));
+
+  const batch = writeBatch(db);
+
+  // done/doing/overdue(todo && dueAt < 오늘) 인스턴스는 삭제 대상에서 제외(그대로 보존).
+  // todo && dueAt >= 오늘 인 미래 인스턴스만 삭제 대상.
+  const toDelete = seriesTodos.filter((t) => {
+    if (t.status === "done" || t.status === "doing") return false;
+    if (!t.dueAt) return false; // dueAt 없는 todo 상태 인스턴스는 방어적으로 보존
+    return new Date(t.dueAt).getTime() >= todayStart.getTime();
+  });
+
+  toDelete.forEach((t) => {
+    batch.delete(doc(db, "todos", t.id));
+  });
+
+  // toDelete에 포함되지 않아 그대로 남는(done/doing/overdue) 인스턴스가 이미 점유한
+  // 날짜는 재생성 대상에서 제외해야 한다. 그러지 않으면 예를 들어 오늘 인스턴스를
+  // "doing"으로 표시해둔 채 시리즈를 수정할 때, 보존된 오늘자 문서는 그대로 두고
+  // 재생성 로직이 같은 오늘 날짜에 새 todo 문서를 하나 더 만들어 캘린더/목록에
+  // 같은 날짜가 중복으로 표시되는 문제가 생긴다.
+  const toDeleteIds = new Set(toDelete.map((t) => t.id));
+  const preservedDateKeys = new Set(
+    seriesTodos
+      .filter((t) => !toDeleteIds.has(t.id) && t.dueAt)
+      .map((t) => new Date(t.dueAt as string).toDateString()),
+  );
+
+  const newRecurrence = seriesTodo.recurrence;
+
+  if (newRecurrence) {
+    if (!seriesTodo.dueAt) {
+      throw new Error("반복 할 일은 dueAt(만료일시)이 필요합니다");
+    }
+
+    // 오늘 이후 첫 유효 발생일부터 horizonEnd까지 새 규칙으로 재생성하되, 이미 보존된
+    // 인스턴스가 점유한 날짜는 건너뛴다.
+    const dueDates = generateRecurringDueDates(
+      seriesTodo.dueAt,
+      newRecurrence,
+      horizonEnd,
+    )
+      .filter((iso) => new Date(iso).getTime() >= todayStart.getTime())
+      .filter((iso) => !preservedDateKeys.has(new Date(iso).toDateString()));
+
+    let nextOrder = await getNextRootOrder(userId);
+    const { id: _id, recurrenceId: _rid, ...rest } = seriesTodo;
+
+    dueDates.forEach((dueAt) => {
+      const newDocRef = doc(todosRef);
+      batch.set(newDocRef, {
+        ...rest,
+        userId,
+        dueAt,
+        status: "todo",
+        doneAt: null,
+        parentId: null,
+        recurrenceId,
+        createdAt: now,
+        updatedAt: now,
+        order: nextOrder,
+      });
+      nextOrder += 1;
+    });
+  }
+  // newRecurrence === null: 반복 OFF 전환. 미래 인스턴스는 위 toDelete에서 이미 삭제
+  // 대상에 포함되었고, 재생성하지 않는다.
+
+  await batch.commit();
+};
+
+/**
+ * 반복 시리즈 전체 삭제. editRecurringSeries(부분 수정)와 달리, 사용자가 명시적으로
+ * "삭제"를 선택한 경우이므로 done/doing/overdue를 보존하지 않고 같은 recurrenceId를
+ * 가진 모든 인스턴스를 예외 없이 삭제한다.
+ */
+export const deleteRecurringSeries = async (recurrenceId: string): Promise<void> => {
+  const userId = getUserId();
+
+  const seriesSnapshot = await getDocs(
+    query(
+      todosRef,
+      where("userId", "==", userId),
+      where("recurrenceId", "==", recurrenceId),
+    ),
+  );
+
+  const batch = writeBatch(db);
+  seriesSnapshot.docs.forEach((d) => {
+    batch.delete(d.ref);
+  });
+  await batch.commit();
 };

--- a/client/src/features/todo/api/todoApi.ts
+++ b/client/src/features/todo/api/todoApi.ts
@@ -436,3 +436,83 @@ export const deleteRecurringSeries = async (recurrenceId: string): Promise<void>
   });
   await batch.commit();
 };
+
+/**
+ * "무기한(indefinite)" 반복 시리즈들의 남은 인스턴스를, 오늘 기준 새 호라이즌
+ * (getDefaultHorizonEnd)까지 이어서 생성한다. 기존 인스턴스는 전혀 건드리지 않고
+ * 마지막 인스턴스 이후의 빈 구간만 채운다 — 앱 진입 시(App.tsx) 1회 호출해서,
+ * 사용자가 앱을 계속 쓰는 한 "무기한"이 실제로 끊기지 않게 한다.
+ *
+ * 종료 조건이 "특정 날짜까지(untilDate)"인 시리즈는 대상이 아니다(이미 끝이
+ * 정해져 있어 확장이 필요 없음). 종료 조건이 없는(recurrence: null, 반복
+ * OFF) 일반 할 일도 당연히 대상이 아니다.
+ */
+export const extendIndefiniteRecurringSeries = async (
+  horizonEnd: Date = getDefaultHorizonEnd(),
+): Promise<void> => {
+  const userId = getUserId();
+  const q = query(todosRef, where("userId", "==", userId));
+  const snapshot = await getDocs(q);
+  const allTodos = snapshot.docs.map((d) => mapDocToTodo(d.id, d.data()));
+
+  const seriesByRecurrenceId = new Map<string, Todo[]>();
+  for (const todo of allTodos) {
+    if (!todo.recurrenceId || !todo.recurrence) continue;
+    if (todo.recurrence.endType !== "indefinite") continue;
+    if (!todo.dueAt) continue;
+    const list = seriesByRecurrenceId.get(todo.recurrenceId) ?? [];
+    list.push(todo);
+    seriesByRecurrenceId.set(todo.recurrenceId, list);
+  }
+
+  if (seriesByRecurrenceId.size === 0) return;
+
+  const now = new Date().toISOString();
+  const batch = writeBatch(db);
+  let hasWrites = false;
+
+  for (const [recurrenceId, instances] of seriesByRecurrenceId) {
+    const latest = instances.reduce((a, b) =>
+      new Date(a.dueAt as string).getTime() > new Date(b.dueAt as string).getTime() ? a : b,
+    );
+    const latestTime = new Date(latest.dueAt as string).getTime();
+    if (latestTime >= horizonEnd.getTime()) continue; // 이미 새 호라이즌까지 채워져 있음
+
+    const rule = latest.recurrence as RecurrenceRule;
+    // 멀티탭 등에서 이미 존재하는 날짜를 다시 만들지 않도록 최소한의 존재 체크를 한다.
+    const existingDateKeys = new Set(
+      instances.map((t) => new Date(t.dueAt as string).toDateString()),
+    );
+    const newDueDates = generateRecurringDueDates(latest.dueAt as string, rule, horizonEnd)
+      .filter((iso) => new Date(iso).getTime() > latestTime)
+      .filter((iso) => !existingDateKeys.has(new Date(iso).toDateString()));
+
+    if (newDueDates.length === 0) continue;
+
+    let nextOrder = await getNextRootOrder(userId);
+    // 가장 최근 인스턴스의 제목/우선순위 등 필드를 그대로 이어서 사용한다(기존 값 승계).
+    const { id: _id, ...rest } = latest;
+
+    newDueDates.forEach((dueAt) => {
+      const newDocRef = doc(todosRef);
+      batch.set(newDocRef, {
+        ...rest,
+        userId,
+        dueAt,
+        status: "todo",
+        doneAt: null,
+        parentId: null,
+        recurrenceId,
+        createdAt: now,
+        updatedAt: now,
+        order: nextOrder,
+      });
+      nextOrder += 1;
+      hasWrites = true;
+    });
+  }
+
+  if (hasWrites) {
+    await batch.commit();
+  }
+};

--- a/client/src/features/todo/components/__tests__/dueTodo.test.tsx
+++ b/client/src/features/todo/components/__tests__/dueTodo.test.tsx
@@ -21,6 +21,8 @@ const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
   doneAt: null,
   parentId: null,
   order: 0,
+  recurrence: null,
+  recurrenceId: null,
   createdAt: '2026-06-14T00:00:00.000Z',
   updatedAt: '2026-06-14T00:00:00.000Z',
   ...overrides,

--- a/client/src/features/todo/components/projectCard.styles.tsx
+++ b/client/src/features/todo/components/projectCard.styles.tsx
@@ -107,6 +107,10 @@ export const IconButton = styled.button<{
     min-height: 28px;
   }
 
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
 `;
 
 export const ProgressBar = styled.div`

--- a/client/src/features/todo/components/projectCard.tsx
+++ b/client/src/features/todo/components/projectCard.tsx
@@ -7,7 +7,7 @@ import BottomSheet from "@/shared/ui/bottomSheet/bottomSheet";
 import type { BottomSheetOption } from "@/shared/ui/bottomSheet/bottomSheet";
 import useMediaQuery from "@/shared/hooks/useMediaQuery";
 import { useTodo } from "../hooks";
-import { useToast } from "@/shared";
+import { useToast, RecurrenceBadge } from "@/shared";
 import { statusColors, type Status } from "@/styles/statusColors";
 import {
   CardContainer,
@@ -105,6 +105,7 @@ const ProjectCard = ({
               <CardTitle>{todo.title}</CardTitle>
               <CardSubtitle>{subtitleText}</CardSubtitle>
             </CardTitleGroup>
+            {todo.recurrenceId != null && <RecurrenceBadge />}
             {isOverdue && <OverdueBadge>{daysOver}일 초과</OverdueBadge>}
           </CardLeft>
           <CardRight>
@@ -122,7 +123,18 @@ const ProjectCard = ({
             )}
             <IconButton
               $variant="expand"
-              onClick={(e) => { e.stopPropagation(); onAddChild(todo.id); }}
+              onClick={(e) => {
+                if (todo.recurrence) return;
+                e.stopPropagation();
+                onAddChild(todo.id);
+              }}
+              disabled={todo.recurrence != null}
+              aria-disabled={todo.recurrence != null}
+              title={
+                todo.recurrence != null
+                  ? "반복 할 일에는 하위 작업을 추가할 수 없습니다"
+                  : undefined
+              }
               aria-label="하위 작업 추가"
             >
               <Plus size={15} />

--- a/client/src/features/todo/components/recurrence/__tests__/recurrenceTransform.test.ts
+++ b/client/src/features/todo/components/recurrence/__tests__/recurrenceTransform.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { toRecurrenceRule } from "../recurrenceTransform";
+
+// Firestore는 undefined 값을 가진 필드(중첩 객체 내부 포함)를 거부하고 즉시 에러를 던진다.
+// weekdays는 optional 필드이므로 "값이 없다"는 것은 undefined 대입이 아니라
+// 키 자체가 존재하지 않는 것으로 표현되어야 한다.
+describe("toRecurrenceRule", () => {
+  it("daily 타입일 때 weekdays 키를 아예 포함하지 않는다", () => {
+    const result = toRecurrenceRule({ type: "daily", endType: "indefinite" });
+    expect(result).not.toBeNull();
+    expect(Object.prototype.hasOwnProperty.call(result, "weekdays")).toBe(false);
+  });
+
+  it("monthly 타입일 때도 weekdays 키를 포함하지 않는다", () => {
+    const result = toRecurrenceRule({ type: "monthly", endType: "indefinite" });
+    expect(Object.prototype.hasOwnProperty.call(result, "weekdays")).toBe(false);
+  });
+
+  it("weekly 타입일 때는 weekdays 배열을 그대로 포함한다", () => {
+    const result = toRecurrenceRule({
+      type: "weekly",
+      weekdays: [1, 3, 5],
+      endType: "indefinite",
+    });
+    expect(result?.weekdays).toEqual([1, 3, 5]);
+  });
+});

--- a/client/src/features/todo/components/recurrence/__tests__/recurrenceValidation.test.ts
+++ b/client/src/features/todo/components/recurrence/__tests__/recurrenceValidation.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { getRecurrenceValidationError } from "../recurrenceValidation";
+import type { RecurrenceFormValue } from "../recurrenceFields.types";
+
+// dueAt은 시각(HH:mm)을 포함한 datetime-local 문자열(예: 2026-07-01T18:00)이고,
+// endDate는 <input type="date">에서 온 시각 없는 "YYYY-MM-DD" 문자열이다. 두 값을
+// new Date()로 그대로 비교하면 date-only 문자열은 UTC 자정으로 해석되어, 같은
+// 날짜인데도 시각 차이 때문에 "종료일이 마감일보다 이전"으로 잘못 판정될 수 있다.
+describe("getRecurrenceValidationError - 종료일 vs 마감일 같은 날짜 비교", () => {
+  const baseValue: RecurrenceFormValue = {
+    type: "daily",
+    endType: "untilDate",
+    endDate: "2026-07-01",
+  };
+
+  it("마감일시와 종료일이 같은 날짜면 유효하다(에러 없음)", () => {
+    const dueAt = "2026-07-01T18:00"; // datetime-local, 같은 날 저녁 시각
+    const error = getRecurrenceValidationError(baseValue, dueAt);
+    expect(error).toBeNull();
+  });
+
+  it("종료일이 마감일보다 실제로 하루 전이면 에러를 반환한다", () => {
+    const value: RecurrenceFormValue = { ...baseValue, endDate: "2026-06-30" };
+    const dueAt = "2026-07-01T18:00";
+    const error = getRecurrenceValidationError(value, dueAt);
+    expect(error).toBe("종료일은 마감일 이후여야 합니다");
+  });
+
+  it("종료일이 마감일보다 하루 뒤면 유효하다", () => {
+    const value: RecurrenceFormValue = { ...baseValue, endDate: "2026-07-02" };
+    const dueAt = "2026-07-01T18:00";
+    const error = getRecurrenceValidationError(value, dueAt);
+    expect(error).toBeNull();
+  });
+});

--- a/client/src/features/todo/components/recurrence/recurrence.styles.tsx
+++ b/client/src/features/todo/components/recurrence/recurrence.styles.tsx
@@ -1,0 +1,190 @@
+import { styled } from "styled-components";
+import { colors } from "@/styles/colors";
+import { radius } from "@/styles/radius";
+
+export const RecurrenceSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 8px;
+  border-top: 1px solid ${colors.border.tertiary};
+`;
+
+export const CheckboxLabel = styled.label<{ $disabled?: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 44px;
+  font-size: 14px;
+  font-weight: 600;
+  color: ${colors.text.primary};
+  cursor: ${({ $disabled }) => ($disabled ? "not-allowed" : "pointer")};
+  opacity: ${({ $disabled }) => ($disabled ? 0.5 : 1)};
+  user-select: none;
+
+  input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    cursor: inherit;
+  }
+`;
+
+export const DisabledHint = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  font-size: 12px;
+  color: ${colors.text.tertiary};
+  margin-top: -4px;
+`;
+
+// 기존 DetailSection의 grid-template-rows 트랜지션 패턴(todoFrom.styles.tsx) 재사용.
+export const RecurrenceDetailPanel = styled.div<{ $isOpen: boolean }>`
+  display: grid;
+  grid-template-rows: ${({ $isOpen }) => ($isOpen ? "1fr" : "0fr")};
+  transition: grid-template-rows 0.3s ease-in-out;
+  overflow: hidden;
+`;
+
+export const RecurrenceDetailContent = styled.div`
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-top: 4px;
+`;
+
+export const FieldGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+`;
+
+export const FieldLabel = styled.span`
+  font-size: 12px;
+  font-weight: 600;
+  color: ${colors.text.secondary};
+`;
+
+export const MonthlyInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`;
+
+export const InfoLine = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: ${colors.text.secondary};
+`;
+
+export const MonthlySubCaption = styled.span`
+  font-size: 11px;
+  color: ${colors.text.tertiary};
+  padding-left: 20px;
+`;
+
+export const EndOptionRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 36px;
+  font-size: 13px;
+  color: ${colors.text.primary};
+
+  label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+  }
+
+  input[type="radio"] {
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+  }
+
+  input[type="date"] {
+    padding: 6px 8px;
+    font-size: 13px;
+    border: 1px solid ${colors.border.secondary};
+    border-radius: ${radius.sm};
+    outline: none;
+
+    &:focus {
+      border-color: ${colors.brand.secondary};
+    }
+  }
+`;
+
+export const ErrorText = styled.span`
+  font-size: 12px;
+  color: ${colors.danger.text};
+`;
+
+// RecurrenceTypeTabs 전용 — kanbanBoard.styles.tsx의 MobileTabButton 패턴 재사용(재정의).
+export const TabList = styled.div`
+  display: flex;
+  height: 44px;
+  border-bottom: 1px solid ${colors.border.tertiary};
+`;
+
+export const TabButton = styled.button<{ $active: boolean }>`
+  flex: 1;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  color: ${({ $active }) => ($active ? colors.brand.secondary : colors.text.secondary)};
+  border-bottom: 2px solid
+    ${({ $active }) => ($active ? colors.brand.secondary : "transparent")};
+  transition: color 0.15s ease, border-color 0.15s ease;
+
+  &:hover {
+    color: ${colors.brand.secondary};
+  }
+`;
+
+// WeekdayPicker 전용 — weekStrip.styles.tsx의 DayCell 패턴을 축소 재정의(today 피처 비종속).
+export const WeekdayGroup = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+`;
+
+export const DayChip = styled.button`
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  flex-shrink: 0;
+
+  &:focus-visible {
+    outline: 2px solid ${colors.brand.primary};
+    outline-offset: 2px;
+  }
+`;
+
+// 시각 크기는 36px(스펙 2-3절), 실제 히트 영역은 DayChip의 44px로 확보한다.
+export const DayChipCircle = styled.span<{ $selected: boolean }>`
+  width: 36px;
+  height: 36px;
+  border-radius: ${radius.full};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 500;
+  background-color: ${({ $selected }) => ($selected ? colors.brand.primary : "transparent")};
+  color: ${({ $selected }) => ($selected ? "#FFFFFF" : colors.text.tertiary)};
+  transition: background-color 0.15s ease, color 0.15s ease;
+`;

--- a/client/src/features/todo/components/recurrence/recurrenceFields.tsx
+++ b/client/src/features/todo/components/recurrence/recurrenceFields.tsx
@@ -1,0 +1,191 @@
+import { useId } from "react";
+import { Info } from "lucide-react";
+import RecurrenceTypeTabs from "./recurrenceTypeTabs";
+import WeekdayPicker from "./weekdayPicker";
+import { WEEKDAY_REQUIRED_ERROR } from "./weekdayConstants";
+import { getRecurrenceValidationError } from "./recurrenceValidation";
+import type { RecurrenceFormValue } from "./recurrenceFields.types";
+import {
+  RecurrenceSection,
+  CheckboxLabel,
+  DisabledHint,
+  RecurrenceDetailPanel,
+  RecurrenceDetailContent,
+  FieldGroup,
+  FieldLabel,
+  MonthlyInfo,
+  InfoLine,
+  MonthlySubCaption,
+  EndOptionRow,
+  ErrorText,
+} from "./recurrence.styles";
+
+interface RecurrenceFieldsProps {
+  disabled: boolean; // 하위 할 일 존재 또는 dueAt 미입력 시 true
+  disabledReason?: "hasChildren" | "noDueAt";
+  dueAt: string | null; // 매월 반복 시 '일(day)' 유도에 사용 (datetime-local 원본 문자열)
+  value: RecurrenceFormValue | null; // null = 반복 OFF
+  onChange: (value: RecurrenceFormValue | null) => void;
+}
+
+const RecurrenceFields = ({
+  disabled,
+  disabledReason,
+  dueAt,
+  value,
+  onChange,
+}: RecurrenceFieldsProps) => {
+  const hintId = useId();
+  const endTypeName = useId();
+  const checked = value !== null;
+
+  const weekdayError = value?.type === "weekly" && (value.weekdays?.length ?? 0) === 0;
+  const validationError = getRecurrenceValidationError(value, dueAt);
+  const endDateError = validationError && validationError !== WEEKDAY_REQUIRED_ERROR ? validationError : null;
+
+  const handleToggle = () => {
+    if (disabled) return;
+    onChange(checked ? null : { type: "daily", endType: "indefinite" });
+  };
+
+  const handleTypeChange = (type: RecurrenceFormValue["type"]) => {
+    if (!value) return;
+    onChange({
+      ...value,
+      type,
+      weekdays: type === "weekly" ? value.weekdays ?? [] : undefined,
+    });
+  };
+
+  const handleWeekdayToggle = (day: number) => {
+    if (!value) return;
+    const current = value.weekdays ?? [];
+    const next = current.includes(day)
+      ? current.filter((d) => d !== day)
+      : [...current, day].sort((a, b) => a - b);
+    onChange({ ...value, weekdays: next });
+  };
+
+  const handleEndTypeChange = (endType: RecurrenceFormValue["endType"]) => {
+    if (!value) return;
+    onChange({
+      ...value,
+      endType,
+      endDate: endType === "untilDate" ? value.endDate : undefined,
+    });
+  };
+
+  const handleEndDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!value) return;
+    onChange({ ...value, endDate: e.target.value });
+  };
+
+  const dueDay = dueAt ? new Date(dueAt).getDate() : null;
+  const isPanelOpen = checked && !disabled;
+
+  return (
+    <RecurrenceSection>
+      <CheckboxLabel $disabled={disabled}>
+        <input
+          type="checkbox"
+          checked={checked}
+          disabled={disabled}
+          onChange={handleToggle}
+          aria-describedby={disabled ? hintId : undefined}
+        />
+        이 할 일을 반복합니다
+      </CheckboxLabel>
+
+      {disabled && (
+        <DisabledHint id={hintId}>
+          <Info size={14} aria-hidden="true" />
+          <span>
+            {disabledReason === "hasChildren"
+              ? "하위 할 일이 있는 항목은 반복을 설정할 수 없습니다"
+              : "반복 설정은 마감일시를 입력해야 사용할 수 있습니다"}
+          </span>
+        </DisabledHint>
+      )}
+
+      <RecurrenceDetailPanel $isOpen={isPanelOpen}>
+        <RecurrenceDetailContent id="recurrence-detail-panel">
+          {value && (
+            <>
+              <FieldGroup>
+                <FieldLabel>반복 주기</FieldLabel>
+                <RecurrenceTypeTabs value={value.type} onChange={handleTypeChange} />
+              </FieldGroup>
+
+              {value.type === "weekly" && (
+                <FieldGroup>
+                  <FieldLabel>반복 요일</FieldLabel>
+                  <WeekdayPicker
+                    selected={value.weekdays ?? []}
+                    onToggle={handleWeekdayToggle}
+                    error={weekdayError}
+                  />
+                </FieldGroup>
+              )}
+
+              {value.type === "monthly" && dueDay !== null && (
+                <MonthlyInfo>
+                  <InfoLine>
+                    <Info size={14} aria-hidden="true" />
+                    <span>매월 {dueDay}일에 반복됩니다 (마감일시 기준)</span>
+                  </InfoLine>
+                  {dueDay >= 29 && (
+                    <MonthlySubCaption>
+                      31일이 없는 달은 해당 월 마지막 날에 생성됩니다
+                    </MonthlySubCaption>
+                  )}
+                </MonthlyInfo>
+              )}
+
+              <FieldGroup>
+                <FieldLabel>종료 조건</FieldLabel>
+                <InfoLine>
+                  <Info size={14} aria-hidden="true" />
+                  <span>마감일시(언제 반복이 시작될지)와는 별개로, 반복을 언제까지 계속할지 정합니다</span>
+                </InfoLine>
+                <EndOptionRow>
+                  <label>
+                    <input
+                      type="radio"
+                      name={endTypeName}
+                      checked={value.endType === "indefinite"}
+                      onChange={() => handleEndTypeChange("indefinite")}
+                    />
+                    무기한
+                  </label>
+                </EndOptionRow>
+                <EndOptionRow>
+                  <label>
+                    <input
+                      type="radio"
+                      name={endTypeName}
+                      checked={value.endType === "untilDate"}
+                      onChange={() => handleEndTypeChange("untilDate")}
+                    />
+                    특정 날짜까지
+                  </label>
+                  {value.endType === "untilDate" && (
+                    <input
+                      type="date"
+                      value={value.endDate ?? ""}
+                      onChange={handleEndDateChange}
+                      aria-label="반복 종료일"
+                    />
+                  )}
+                </EndOptionRow>
+                {endDateError && <ErrorText role="alert">{endDateError}</ErrorText>}
+              </FieldGroup>
+            </>
+          )}
+        </RecurrenceDetailContent>
+      </RecurrenceDetailPanel>
+    </RecurrenceSection>
+  );
+};
+
+export default RecurrenceFields;
+export type { RecurrenceFieldsProps, RecurrenceFormValue };

--- a/client/src/features/todo/components/recurrence/recurrenceFields.types.ts
+++ b/client/src/features/todo/components/recurrence/recurrenceFields.types.ts
@@ -1,0 +1,8 @@
+interface RecurrenceFormValue {
+  type: "daily" | "weekly" | "monthly";
+  weekdays?: number[]; // 0=일 ~ 6=토, type==="weekly"일 때만 사용, 최소 1개
+  endType: "indefinite" | "untilDate";
+  endDate?: string; // endType==="untilDate"일 때만 사용
+}
+
+export type { RecurrenceFormValue };

--- a/client/src/features/todo/components/recurrence/recurrenceTransform.ts
+++ b/client/src/features/todo/components/recurrence/recurrenceTransform.ts
@@ -1,0 +1,28 @@
+import type { RecurrenceRule } from "../../types";
+import type { RecurrenceFormValue } from "./recurrenceFields.types";
+
+// RecurrenceRule <-> RecurrenceFormValue 변환 (endDate: null <-> undefined 차이만 흡수)
+export const toFormValue = (recurrence: RecurrenceRule | null): RecurrenceFormValue | null =>
+  recurrence
+    ? {
+        type: recurrence.type,
+        weekdays: recurrence.weekdays,
+        endType: recurrence.endType,
+        endDate: recurrence.endDate ?? undefined,
+      }
+    : null;
+
+export const toRecurrenceRule = (value: RecurrenceFormValue | null): RecurrenceRule | null => {
+  if (!value) return null;
+
+  // weekdays는 optional 필드다. Firestore는 undefined 값을 가진 필드(중첩 객체 내부
+  // 포함)를 만나면 즉시 에러를 던지므로, "값 없음"은 `undefined` 대입이 아니라
+  // 키 자체를 생략하는 방식으로 표현해야 한다.
+  const base = {
+    type: value.type,
+    endType: value.endType,
+    endDate: value.endType === "untilDate" ? (value.endDate ?? null) : null,
+  };
+
+  return value.type === "weekly" ? { ...base, weekdays: value.weekdays } : base;
+};

--- a/client/src/features/todo/components/recurrence/recurrenceTypeTabs.tsx
+++ b/client/src/features/todo/components/recurrence/recurrenceTypeTabs.tsx
@@ -1,0 +1,35 @@
+import { TabList, TabButton } from "./recurrence.styles";
+
+interface RecurrenceTypeTabsProps {
+  value: "daily" | "weekly" | "monthly";
+  onChange: (type: "daily" | "weekly" | "monthly") => void;
+}
+
+const TYPES = ["daily", "weekly", "monthly"] as const;
+
+const TYPE_LABELS: Record<(typeof TYPES)[number], string> = {
+  daily: "매일",
+  weekly: "매주",
+  monthly: "매월",
+};
+
+const RecurrenceTypeTabs = ({ value, onChange }: RecurrenceTypeTabsProps) => (
+  <TabList role="tablist" aria-label="반복 주기">
+    {TYPES.map((type) => (
+      <TabButton
+        key={type}
+        type="button"
+        role="tab"
+        aria-selected={value === type}
+        aria-controls="recurrence-detail-panel"
+        $active={value === type}
+        onClick={() => onChange(type)}
+      >
+        {TYPE_LABELS[type]}
+      </TabButton>
+    ))}
+  </TabList>
+);
+
+export default RecurrenceTypeTabs;
+export type { RecurrenceTypeTabsProps };

--- a/client/src/features/todo/components/recurrence/recurrenceValidation.ts
+++ b/client/src/features/todo/components/recurrence/recurrenceValidation.ts
@@ -1,0 +1,44 @@
+import { WEEKDAY_REQUIRED_ERROR } from "./weekdayConstants";
+import type { RecurrenceFormValue } from "./recurrenceFields.types";
+
+/** dueAt(시각 포함 datetime 문자열)에서 로컬 달력 날짜만 "YYYY-MM-DD" 키로 뽑아낸다. */
+function toLocalDateKey(dateTimeStr: string): string | null {
+  const d = new Date(dateTimeStr);
+  if (Number.isNaN(d.getTime())) return null;
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * 반복 규칙 입력값의 유효성을 검사한다. todoForm/todoDetail의 onSubmit에서 제출 차단
+ * 판단에 재사용하기 위해 컴포넌트 파일과 분리했다 (react-refresh/only-export-components
+ * 회피 + 인라인 에러 표시 로직과의 이중 관리 방지).
+ */
+export function getRecurrenceValidationError(
+  value: RecurrenceFormValue | null,
+  dueAt: string | null,
+): string | null {
+  if (!value) return null;
+
+  if (value.type === "weekly" && (value.weekdays?.length ?? 0) === 0) {
+    return WEEKDAY_REQUIRED_ERROR;
+  }
+
+  if (value.endType === "untilDate") {
+    if (!value.endDate) return "종료일을 선택해주세요";
+    if (dueAt) {
+      // dueAt은 시각을 포함하고 endDate는 <input type="date">에서 온 시각 없는
+      // "YYYY-MM-DD" 문자열이라, 그대로 new Date()로 비교하면 date-only 문자열이
+      // UTC 자정으로 해석되어 "같은 날짜"인데도 시각 차이 때문에 종료일이 마감일보다
+      // 이전으로 잘못 판정될 수 있다. 달력 날짜(YYYY-MM-DD) 문자열 비교로 이를 피한다.
+      const dueDateKey = toLocalDateKey(dueAt);
+      if (dueDateKey && value.endDate < dueDateKey) {
+        return "종료일은 마감일 이후여야 합니다";
+      }
+    }
+  }
+
+  return null;
+}

--- a/client/src/features/todo/components/recurrence/weekdayConstants.ts
+++ b/client/src/features/todo/components/recurrence/weekdayConstants.ts
@@ -1,0 +1,4 @@
+// weekdayPicker.tsx / recurrenceFields.tsx가 공유하는 상수. 컴포넌트 파일에서 분리해
+// react-refresh/only-export-components(fast refresh) 경고를 피한다.
+export const WEEKDAY_LABELS = ["일", "월", "화", "수", "목", "금", "토"];
+export const WEEKDAY_REQUIRED_ERROR = "요일을 하나 이상 선택해주세요";

--- a/client/src/features/todo/components/recurrence/weekdayPicker.tsx
+++ b/client/src/features/todo/components/recurrence/weekdayPicker.tsx
@@ -1,0 +1,29 @@
+import { WeekdayGroup, DayChip, DayChipCircle, ErrorText } from "./recurrence.styles";
+import { WEEKDAY_LABELS, WEEKDAY_REQUIRED_ERROR } from "./weekdayConstants";
+
+interface WeekdayPickerProps {
+  selected: number[]; // 0=일 ~ 6=토
+  onToggle: (day: number) => void;
+  error?: boolean; // 0개 선택 시 true
+}
+
+const WeekdayPicker = ({ selected, onToggle, error }: WeekdayPickerProps) => (
+  <div>
+    <WeekdayGroup role="group" aria-label="반복 요일 선택">
+      {WEEKDAY_LABELS.map((label, day) => (
+        <DayChip
+          key={day}
+          type="button"
+          aria-pressed={selected.includes(day)}
+          onClick={() => onToggle(day)}
+        >
+          <DayChipCircle $selected={selected.includes(day)}>{label}</DayChipCircle>
+        </DayChip>
+      ))}
+    </WeekdayGroup>
+    {error && <ErrorText role="alert">{WEEKDAY_REQUIRED_ERROR}</ErrorText>}
+  </div>
+);
+
+export default WeekdayPicker;
+export type { WeekdayPickerProps };

--- a/client/src/features/todo/components/todoDetail/todoDetail.tsx
+++ b/client/src/features/todo/components/todoDetail/todoDetail.tsx
@@ -1,9 +1,14 @@
+import { useEffect, useMemo, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { useTodoDetail, useTodo } from "../../hooks";
 import type { Todo } from "../../types";
 import { X } from "lucide-react";
-import { useToast } from "@/shared";
+import { useToast, ConfirmModal } from "@/shared";
+import RecurrenceFields from "../recurrence/recurrenceFields";
+import { getRecurrenceValidationError } from "../recurrence/recurrenceValidation";
+import { toFormValue, toRecurrenceRule } from "../recurrence/recurrenceTransform";
+import type { RecurrenceFormValue } from "../recurrence/recurrenceFields.types";
 import {
   Overlay,
   Panel,
@@ -51,12 +56,20 @@ const TodoDetail = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { todo } = useTodoDetail({ id: id! });
-  const { useUpdateTodo } = useTodo();
+  const {
+    useUpdateTodo,
+    useCreateRecurringTodo,
+    useEditRecurringSeries,
+    useDeleteTodo,
+    useGetTodos,
+  } = useTodo();
+  const { data: allTodos } = useGetTodos;
   const toast = useToast();
 
   const {
     register,
     handleSubmit,
+    watch,
     formState: { errors },
   } = useForm<TodoFormData>({
     values: todo
@@ -75,6 +88,41 @@ const TodoDetail = () => {
       : undefined,
   });
 
+  const dueAtWatch = watch("dueAt");
+
+  const hasChildren = useMemo(() => {
+    if (!todo) return false;
+    return (allTodos ?? []).some((t) => t.parentId === todo.id);
+  }, [allTodos, todo]);
+
+  const [recurrenceValue, setRecurrenceValue] = useState<RecurrenceFormValue | null>(null);
+
+  // 상세 페이지가 새 todo를 불러올 때(id 변경)만 로컬 recurrence 상태를 동기화한다.
+  useEffect(() => {
+    if (todo) {
+      setRecurrenceValue(toFormValue(todo.recurrence));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [todo?.id]);
+
+  // 4-2절: dueAt이 지워지면(반복이 이미 켜진 상태) 반복 체크박스 강제 OFF + value 리셋
+  useEffect(() => {
+    if (!dueAtWatch && recurrenceValue !== null) {
+      setRecurrenceValue(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dueAtWatch]);
+
+  const recurrenceDisabled = hasChildren || !dueAtWatch;
+  const recurrenceDisabledReason: "hasChildren" | "noDueAt" | undefined = hasChildren
+    ? "hasChildren"
+    : !dueAtWatch
+      ? "noDueAt"
+      : undefined;
+
+  const [isSeriesConfirmOpen, setIsSeriesConfirmOpen] = useState(false);
+  const [pendingSeriesUpdate, setPendingSeriesUpdate] = useState<Todo | null>(null);
+
   const handleClose = () => {
     if (window.history.state?.idx > 0) {
       navigate(-1);
@@ -83,26 +131,89 @@ const TodoDetail = () => {
     }
   };
 
+  const closeSeriesConfirm = () => {
+    setIsSeriesConfirmOpen(false);
+    setPendingSeriesUpdate(null);
+  };
+
+  const handleConfirmSeriesEdit = () => {
+    if (!pendingSeriesUpdate) return;
+    useEditRecurringSeries.mutate(pendingSeriesUpdate, {
+      onSuccess: () => {
+        toast.success("저장 완료", "반복 일정이 성공적으로 저장되었습니다");
+        closeSeriesConfirm();
+        handleClose();
+      },
+      onError: () => {
+        toast.error("저장 실패", "반복 일정 저장 중 오류가 발생했습니다. 다시 시도해주세요");
+        closeSeriesConfirm();
+      },
+    });
+  };
+
   const onSubmit = (data: TodoFormData) => {
     if (!todo) return;
 
-    useUpdateTodo.mutate(
-      {
-        ...todo,
-        ...data,
-        startAt: data.startAt ? new Date(data.startAt).toISOString() : null,
-        dueAt: data.dueAt ? new Date(data.dueAt).toISOString() : null,
-      } as Todo,
-      {
+    const validationError = getRecurrenceValidationError(recurrenceValue, dueAtWatch ?? null);
+    if (validationError) {
+      toast.error("입력 확인", validationError);
+      return;
+    }
+
+    const newRecurrence = toRecurrenceRule(recurrenceValue);
+    const updatedFields = {
+      ...todo,
+      ...data,
+      startAt: data.startAt ? new Date(data.startAt).toISOString() : null,
+      dueAt: data.dueAt ? new Date(data.dueAt).toISOString() : null,
+      recurrence: newRecurrence,
+    } as Todo;
+
+    const wasRecurring = todo.recurrence != null;
+
+    if (wasRecurring) {
+      // 4-4절: 반복 시리즈였던 할 일의 수정(반복 유지든 OFF 전환이든)은 확인 모달을 먼저 띄운다.
+      setPendingSeriesUpdate(updatedFields);
+      setIsSeriesConfirmOpen(true);
+      return;
+    }
+
+    if (!wasRecurring && newRecurrence) {
+      // todoForm.tsx와 동일한 근거: editRecurringSeries는 recurrenceId 없이는 호출할 수
+      // 없으므로(todoApi.ts), 원래 비반복이던 todo를 새로 반복 전환할 때는
+      // createRecurringTodo로 새 인스턴스를 먼저 만들고 성공 후에만 기존 문서를 삭제한다.
+      useCreateRecurringTodo.mutate(updatedFields, {
         onSuccess: () => {
-          toast.success("저장 완료", "할 일이 성공적으로 저장되었습니다");
-          handleClose();
+          useDeleteTodo.mutate(todo.id, {
+            onSuccess: () => {
+              toast.success("반복 설정 완료", "할 일이 반복 일정으로 전환되었습니다");
+              handleClose();
+            },
+            onError: () => {
+              toast.error(
+                "정리 실패",
+                "새 반복 일정은 생성되었지만 기존 항목 정리에 실패했습니다. 목록을 확인해주세요",
+              );
+              handleClose();
+            },
+          });
         },
         onError: () => {
           toast.error("저장 실패", "할 일 저장 중 오류가 발생했습니다. 다시 시도해주세요");
         },
-      }
-    );
+      });
+      return;
+    }
+
+    useUpdateTodo.mutate(updatedFields, {
+      onSuccess: () => {
+        toast.success("저장 완료", "할 일이 성공적으로 저장되었습니다");
+        handleClose();
+      },
+      onError: () => {
+        toast.error("저장 실패", "할 일 저장 중 오류가 발생했습니다. 다시 시도해주세요");
+      },
+    });
   };
 
   if (!todo) {
@@ -221,6 +332,18 @@ const TodoDetail = () => {
                 <Input type="datetime-local" {...register("dueAt")} />
               </FormGroup>
             </InfoRow>
+
+            {!todo.parentId && (
+              <FormGroup>
+                <RecurrenceFields
+                  disabled={recurrenceDisabled}
+                  disabledReason={recurrenceDisabledReason}
+                  dueAt={dueAtWatch ?? null}
+                  value={recurrenceValue}
+                  onChange={setRecurrenceValue}
+                />
+              </FormGroup>
+            )}
           </FormContainer>
         </PanelContent>
 
@@ -233,6 +356,19 @@ const TodoDetail = () => {
           </Button>
         </PanelFooter>
       </Panel>
+
+      <ConfirmModal
+        isOpen={isSeriesConfirmOpen}
+        title="반복 일정 전체 수정"
+        message={
+          "이 변경은 앞으로의 일정에만 적용됩니다.\n\n진행 중이거나 완료된 일정, 이미 지난 미완료 일정은 그대로 유지됩니다."
+        }
+        confirmText="전체 적용"
+        cancelText="취소"
+        confirmDisabled={useEditRecurringSeries.isPending}
+        onConfirm={handleConfirmSeriesEdit}
+        onCancel={closeSeriesConfirm}
+      />
     </>
   );
 };

--- a/client/src/features/todo/components/todoForm/todoForm.tsx
+++ b/client/src/features/todo/components/todoForm/todoForm.tsx
@@ -1,9 +1,13 @@
 import { useForm } from "react-hook-form";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { useTodo } from "../../hooks";
-import { useToast } from "@/shared";
-import type { Todo } from "../../types";
+import { useToast, ConfirmModal } from "@/shared";
+import type { RecurrenceRule, Todo } from "../../types";
+import RecurrenceFields from "../recurrence/recurrenceFields";
+import { getRecurrenceValidationError } from "../recurrence/recurrenceValidation";
+import { toFormValue, toRecurrenceRule } from "../recurrence/recurrenceTransform";
+import type { RecurrenceFormValue } from "../recurrence/recurrenceFields.types";
 import {
   FormContainer,
   InputLabel,
@@ -36,6 +40,7 @@ const TodoForm = ({ todo, parentId, initialDueAt, onClose }: TodoFormProps) => {
   const {
     register,
     handleSubmit,
+    watch,
     formState: { errors },
   } = useForm<TodoFormData>({
     defaultValues: todo
@@ -54,30 +59,147 @@ const TodoForm = ({ todo, parentId, initialDueAt, onClose }: TodoFormProps) => {
         ? { dueAt: initialDueAt }
         : undefined,
   });
-  const { useCreateTodo, useUpdateTodo, useCreateChildTodo } = useTodo();
+  const {
+    useCreateTodo,
+    useUpdateTodo,
+    useCreateChildTodo,
+    useCreateRecurringTodo,
+    useEditRecurringSeries,
+    useDeleteTodo,
+    useGetTodos,
+  } = useTodo();
+  const { data: allTodos } = useGetTodos;
+
+  const dueAtWatch = watch("dueAt");
+
+  // 하위 할 일 생성 폼(parentId 존재, 케이스 D)에서는 반복 섹션 자체를 렌더링하지 않는다.
+  const showRecurrenceSection = !parentId;
+
+  const hasChildren = useMemo(() => {
+    if (!todo) return false;
+    return (allTodos ?? []).some((t) => t.parentId === todo.id);
+  }, [allTodos, todo]);
+
+  const [recurrenceValue, setRecurrenceValue] = useState<RecurrenceFormValue | null>(
+    () => toFormValue(todo?.recurrence ?? null),
+  );
+
+  // 4-2절: dueAt이 지워지면(반복이 이미 켜진 상태) 반복 체크박스 강제 OFF + value 리셋
+  useEffect(() => {
+    if (!dueAtWatch && recurrenceValue !== null) {
+      setRecurrenceValue(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dueAtWatch]);
+
+  const recurrenceDisabled = hasChildren || !dueAtWatch;
+  const recurrenceDisabledReason: "hasChildren" | "noDueAt" | undefined = hasChildren
+    ? "hasChildren"
+    : !dueAtWatch
+      ? "noDueAt"
+      : undefined;
+
+  const [isSeriesConfirmOpen, setIsSeriesConfirmOpen] = useState(false);
+  const [pendingSeriesUpdate, setPendingSeriesUpdate] = useState<Todo | null>(null);
+
+  const closeSeriesConfirm = () => {
+    setIsSeriesConfirmOpen(false);
+    setPendingSeriesUpdate(null);
+  };
+
+  const handleConfirmSeriesEdit = () => {
+    if (!pendingSeriesUpdate) return;
+    useEditRecurringSeries.mutate(pendingSeriesUpdate, {
+      onSuccess: () => {
+        toast.success("수정 완료", `"${pendingSeriesUpdate.title}" 반복 일정이 수정되었습니다`);
+        closeSeriesConfirm();
+        onClose?.();
+      },
+      onError: () => {
+        toast.error("수정 실패", "반복 일정 수정 중 오류가 발생했습니다");
+        // 실패 시 모달만 닫고 폼은 유지(재시도 가능하도록) — pendingSeriesUpdate는 비운다
+        closeSeriesConfirm();
+      },
+    });
+  };
+
   const onSubmit = (data: TodoFormData) => {
+    if (showRecurrenceSection) {
+      const validationError = getRecurrenceValidationError(recurrenceValue, dueAtWatch ?? null);
+      if (validationError) {
+        toast.error("입력 확인", validationError);
+        return;
+      }
+    }
+
     if (todo) {
-      // 수정 시 기존 todo의 모든 필드를 유지하면서 변경된 필드만 덮어씀
-      useUpdateTodo.mutate(
-        {
-          ...todo,
-          ...data,
-          // datetime-local input의 값을 ISO string으로 변환
-          startAt: data.startAt ? new Date(data.startAt).toISOString() : null,
-          dueAt: data.dueAt ? new Date(data.dueAt).toISOString() : null,
-        } as Todo,
-        {
+      const newRecurrence = showRecurrenceSection ? toRecurrenceRule(recurrenceValue) : null;
+      const updatedFields = {
+        ...todo,
+        ...data,
+        // datetime-local input의 값을 ISO string으로 변환
+        startAt: data.startAt ? new Date(data.startAt).toISOString() : null,
+        dueAt: data.dueAt ? new Date(data.dueAt).toISOString() : null,
+        recurrence: newRecurrence,
+      } as Todo;
+
+      const wasRecurring = todo.recurrence != null;
+
+      if (wasRecurring) {
+        // 4-4절: 반복 시리즈였던 할 일의 수정(반복 유지든 OFF 전환이든)은 항상 확인 모달을
+        // 먼저 띄우고, "전체 적용" 클릭 시에만 실제 mutate를 실행한다.
+        setPendingSeriesUpdate(updatedFields);
+        setIsSeriesConfirmOpen(true);
+        return;
+      }
+
+      if (!wasRecurring && newRecurrence) {
+        // 반복이 원래 없던 기존 할 일에 이번 저장에서 새로 반복을 켠 경우.
+        // "신규 반복 설정"이지 시리즈 수정이 아니므로 확인 모달은 띄우지 않는다(4-4절).
+        //
+        // 판단 근거: useEditRecurringSeries(editRecurringSeries API)는 recurrenceId가
+        // 없으면 즉시 에러를 던지도록 구현되어 있어(todoApi.ts), recurrenceId가 아직 null인
+        // 이 기존 단일 todo에는 사용할 수 없다. 대신 useCreateRecurringTodo로 새 반복
+        // 인스턴스들을 먼저 생성하고, 성공한 뒤에만 기존 단일 문서를 삭제한다 — 생성 실패 시
+        // 기존 데이터가 그대로 보존되는 쪽이(반대 순서보다) 더 안전한 실패 모드이기 때문이다.
+        useCreateRecurringTodo.mutate(updatedFields, {
           onSuccess: () => {
-            toast.success("수정 완료", `"${data.title}" 할 일이 수정되었습니다`);
-            onClose?.();
+            useDeleteTodo.mutate(todo.id, {
+              onSuccess: () => {
+                toast.success(
+                  "반복 설정 완료",
+                  `"${data.title}" 할 일이 반복 일정으로 전환되었습니다`,
+                );
+                onClose?.();
+              },
+              onError: () => {
+                toast.error(
+                  "정리 실패",
+                  "새 반복 일정은 생성되었지만 기존 항목 정리에 실패했습니다. 목록을 확인해주세요",
+                );
+                onClose?.();
+              },
+            });
           },
           onError: () => {
             toast.error("수정 실패", "할 일 수정 중 오류가 발생했습니다");
           },
-        }
-      );
+        });
+        return;
+      }
+
+      // 일반(비반복) 수정
+      useUpdateTodo.mutate(updatedFields, {
+        onSuccess: () => {
+          toast.success("수정 완료", `"${data.title}" 할 일이 수정되었습니다`);
+          onClose?.();
+        },
+        onError: () => {
+          toast.error("수정 실패", "할 일 수정 중 오류가 발생했습니다");
+        },
+      });
     } else if (parentId) {
-      // 자식 todo 생성
+      // 자식 todo 생성 (반복 설정 대상 아님)
       useCreateChildTodo.mutate(
         {
           parentId,
@@ -90,6 +212,26 @@ const TodoForm = ({ todo, parentId, initialDueAt, onClose }: TodoFormProps) => {
           },
           onError: () => {
             toast.error("추가 실패", "하위 할 일 추가 중 오류가 발생했습니다");
+          },
+        }
+      );
+    } else if (recurrenceValue) {
+      // 반복 설정된 신규 할 일 생성 — 확인 모달 없음(4-4절)
+      const newRecurrence = toRecurrenceRule(recurrenceValue) as RecurrenceRule;
+      useCreateRecurringTodo.mutate(
+        {
+          ...data,
+          startAt: data.startAt ? new Date(data.startAt).toISOString() : null,
+          dueAt: data.dueAt ? new Date(data.dueAt).toISOString() : null,
+          recurrence: newRecurrence,
+        } as Todo,
+        {
+          onSuccess: () => {
+            toast.success("추가 완료", `"${data.title}" 반복 할 일이 추가되었습니다`);
+            onClose?.();
+          },
+          onError: () => {
+            toast.error("추가 실패", "반복 할 일 추가 중 오류가 발생했습니다");
           },
         }
       );
@@ -108,48 +250,73 @@ const TodoForm = ({ todo, parentId, initialDueAt, onClose }: TodoFormProps) => {
   };
 
   return (
-    <FormContainer id="todo-form" onSubmit={handleSubmit(onSubmit)}>
-      <InputLabel>할 일</InputLabel>
-      <Input
-        {...register("title", { required: "제목을 입력해주세요" })}
-        placeholder="무엇을 해야 하나요?"
-        autoFocus
+    <>
+      <FormContainer id="todo-form" onSubmit={handleSubmit(onSubmit)}>
+        <InputLabel>할 일</InputLabel>
+        <Input
+          {...register("title", { required: "제목을 입력해주세요" })}
+          placeholder="무엇을 해야 하나요?"
+          autoFocus
+        />
+        {errors.title && (
+          <span style={{ color: "red", fontSize: "12px" }}>
+            {errors.title.message}
+          </span>
+        )}
+
+        <DetailSection $isOpen={showMore}>
+          <DetailContent>
+            <InputLabel>설명</InputLabel>
+            <Input
+              {...register("description")}
+              placeholder="상세 설명을 입력하세요"
+            />
+
+            <InputLabel>우선순위</InputLabel>
+            <Select {...register("priority")} defaultValue="medium">
+              <option value="low">낮음</option>
+              <option value="medium">중간</option>
+              <option value="high">높음</option>
+            </Select>
+
+            <InputLabel>시작일시</InputLabel>
+            <Input type="datetime-local" {...register("startAt")} />
+
+            <InputLabel>만료일시</InputLabel>
+            <Input type="datetime-local" {...register("dueAt")} />
+
+            {showRecurrenceSection && (
+              <RecurrenceFields
+                disabled={recurrenceDisabled}
+                disabledReason={recurrenceDisabledReason}
+                dueAt={dueAtWatch ?? null}
+                value={recurrenceValue}
+                onChange={setRecurrenceValue}
+              />
+            )}
+          </DetailContent>
+        </DetailSection>
+
+        <MoreButtonContainer>
+          <MoreButton type="button" onClick={() => setShowMore(!showMore)}>
+            {showMore ? "간단히" : "더보기"}
+          </MoreButton>
+        </MoreButtonContainer>
+      </FormContainer>
+
+      <ConfirmModal
+        isOpen={isSeriesConfirmOpen}
+        title="반복 일정 전체 수정"
+        message={
+          "이 변경은 앞으로의 일정에만 적용됩니다.\n\n진행 중이거나 완료된 일정, 이미 지난 미완료 일정은 그대로 유지됩니다."
+        }
+        confirmText="전체 적용"
+        cancelText="취소"
+        confirmDisabled={useEditRecurringSeries.isPending}
+        onConfirm={handleConfirmSeriesEdit}
+        onCancel={closeSeriesConfirm}
       />
-      {errors.title && (
-        <span style={{ color: "red", fontSize: "12px" }}>
-          {errors.title.message}
-        </span>
-      )}
-
-      <DetailSection $isOpen={showMore}>
-        <DetailContent>
-          <InputLabel>설명</InputLabel>
-          <Input
-            {...register("description")}
-            placeholder="상세 설명을 입력하세요"
-          />
-
-          <InputLabel>우선순위</InputLabel>
-          <Select {...register("priority")} defaultValue="medium">
-            <option value="low">낮음</option>
-            <option value="medium">중간</option>
-            <option value="high">높음</option>
-          </Select>
-
-          <InputLabel>시작일시</InputLabel>
-          <Input type="datetime-local" {...register("startAt")} />
-
-          <InputLabel>만료일시</InputLabel>
-          <Input type="datetime-local" {...register("dueAt")} />
-        </DetailContent>
-      </DetailSection>
-
-      <MoreButtonContainer>
-        <MoreButton type="button" onClick={() => setShowMore(!showMore)}>
-          {showMore ? "간단히" : "더보기"}
-        </MoreButton>
-      </MoreButtonContainer>
-    </FormContainer>
+    </>
   );
 };
 

--- a/client/src/features/todo/components/todoList.tsx
+++ b/client/src/features/todo/components/todoList.tsx
@@ -6,6 +6,7 @@ import {
   getProjectProgress,
   getProjectSubtaskInfo,
   getProjectOverdue,
+  collapseRecurringInstances,
 } from "../utils/projectUtils";
 import { useMemo, useState, useCallback } from "react";
 import React from "react";
@@ -42,7 +43,7 @@ const TodoList = ({ todos }: { todos: Todo[] }) => {
   const [deleteTargetId, setDeleteTargetId] = React.useState<string | null>(
     null
   );
-  const { useDeleteTodo } = useTodo();
+  const { useDeleteTodo, useDeleteRecurringSeries } = useTodo();
   const toast = useToast();
 
   const { data: searchResults, isLoading: isSearchLoading } =
@@ -55,7 +56,11 @@ const TodoList = ({ todos }: { todos: Todo[] }) => {
 
     const activatedTodos = rootTodos.filter((todo) => todo.status !== "done");
 
-    return activatedTodos.map((rootTodo) => {
+    // 반복 할 일은 최대 4주치 인스턴스가 각각 별도 문서로 존재하므로, 이 목록에서는
+    // 시리즈당 대표 1건(지난 미완료 우선, 없으면 다음 예정 건)만 카드로 노출한다.
+    const collapsedTodos = collapseRecurringInstances(activatedTodos);
+
+    return collapsedTodos.map((rootTodo) => {
       return {
         ...rootTodo,
         childTodos: todos.filter((todo) => todo.parentId === rootTodo.id),
@@ -148,16 +153,27 @@ const TodoList = ({ todos }: { todos: Todo[] }) => {
       <ConfirmModal
         isOpen={deleteTargetId !== null}
         title="프로젝트 삭제"
-        message={`"${deleteTargetTodo?.title ?? ""}"을(를) 삭제하시겠습니까?`}
+        message={
+          deleteTargetTodo?.recurrenceId
+            ? `"${deleteTargetTodo?.title ?? ""}"은(는) 반복 일정입니다.\n\n삭제하면 이 반복 시리즈의 모든 일정이 함께 삭제됩니다.`
+            : `"${deleteTargetTodo?.title ?? ""}"을(를) 삭제하시겠습니까?`
+        }
         confirmText="삭제"
         cancelText="취소"
         onConfirm={() => {
           if (deleteTargetId) {
             const title = deleteTargetTodo?.title ?? "";
-            useDeleteTodo.mutate(deleteTargetId, {
-              onSuccess: () => toast.success("삭제 완료", `"${title}" 프로젝트가 삭제되었습니다`),
-              onError: () => toast.error("삭제 실패", "삭제 중 오류가 발생했습니다"),
-            });
+            if (deleteTargetTodo?.recurrenceId) {
+              useDeleteRecurringSeries.mutate(deleteTargetTodo.recurrenceId, {
+                onSuccess: () => toast.success("삭제 완료", `"${title}" 반복 일정이 모두 삭제되었습니다`),
+                onError: () => toast.error("삭제 실패", "삭제 중 오류가 발생했습니다"),
+              });
+            } else {
+              useDeleteTodo.mutate(deleteTargetId, {
+                onSuccess: () => toast.success("삭제 완료", `"${title}" 프로젝트가 삭제되었습니다`),
+                onError: () => toast.error("삭제 실패", "삭제 중 오류가 발생했습니다"),
+              });
+            }
           }
           setDeleteTargetId(null);
         }}

--- a/client/src/features/todo/design/recurringTodo.spec.md
+++ b/client/src/features/todo/design/recurringTodo.spec.md
@@ -1,0 +1,524 @@
+# 반복 할 일(Recurring Todo) — UI/UX 설계 스펙
+
+- 대상 파일: `client/src/features/todo/`, `client/src/features/kanban/`, `client/src/features/dashboard/`
+- 작성일: 2026-07-03
+- 상태: **사용자 검토 대기** — 승인 후 ui-ux-improver가 구현
+- 관련 문서: `client/src/features/dashboard/DESIGN_SPEC.md` (캘린더 개편안, 별도로 검토 대기 중 — 본 스펙은 **현재 라이브 상태의 캘린더 구조**를 기준으로 작성하되 색상 토큰/톤은 해당 문서와 통일)
+
+## 0. PM 확정 스코프 요약 (설계 전제)
+
+| 항목 | 내용 |
+|---|---|
+| 반복 주기 | 매일 / 매주(요일 다중 선택) / 매월(같은 날짜) |
+| 기준 | `dueAt` 기준 반복만 지원 (완료일 기준 없음) |
+| 종료 조건 | 무기한 / 특정 종료일 (N회 반복 없음) |
+| 수정 단위 | 항상 전체 시리즈 (이 인스턴스만 수정 불가) |
+| 자연어 입력 | 스코프 아웃 |
+| 하위 할 일 상호 배제 | 반복 ON ↔ 하위 할 일 기능 비활성 (양방향) |
+| kanban 노출 | 반복 인스턴스는 `dueAt <= 오늘`인 것만 노출, 미래는 캘린더 전용 |
+
+필드명(`recurrence`, `recurrenceId` 등)은 아직 미확정이므로 본 스펙은 필드 스키마를 가정하지 않고 **폼 인터랙션 / 모달 / 배지 / 캘린더 표현**에만 집중한다. 아래 의사코드의 `todo.isRecurring`, `todo.recurrenceSummary` 등은 실제 필드명이 아니라 UI 설계 편의상 사용하는 placeholder 표현이다.
+
+---
+
+## 1. 화면 구조
+
+### 1-1. 반복 규칙 입력 폼 — `todoForm.tsx` "더보기" 영역에 통합
+
+**기본 상태 (반복 OFF, 하위 할 일 없음 — 정상 입력 가능)**
+
+```
+┌────────────────────────────────────────┐
+│ 할 일                                   │
+│ ┌──────────────────────────────────┐   │
+│ │ 무엇을 해야 하나요?               │   │
+│ └──────────────────────────────────┘   │
+│                                          │
+│ [더보기 ▼]                              │
+│  ├ 설명                                 │
+│  ├ 우선순위                             │
+│  ├ 시작일시                             │
+│  ├ 만료일시  [2026-07-10T18:00]         │
+│  │                                       │
+│  ├ ────────────────────────────────    │
+│  │ ☐ 이 할 일을 반복합니다              │  ← 신규: RecurrenceToggle (체크박스)
+│  └ ────────────────────────────────    │
+└────────────────────────────────────────┘
+```
+
+**반복 ON — 매일**
+
+```
+│  ☑ 이 할 일을 반복합니다              │
+│  ┌────────────────────────────────┐  │
+│  │ 반복 주기                        │  │
+│  │ [ 매일 ]  매주    매월           │  │  ← RecurrenceTypeTabs (세그먼트 탭)
+│  │                                  │  │
+│  │ 종료 조건                        │  │
+│  │ ● 무기한                         │  │
+│  │ ○ 특정 날짜까지  [date picker]  │  │
+│  └────────────────────────────────┘  │
+```
+
+**반복 ON — 매주 (요일 다중 선택 노출)**
+
+```
+│  ☑ 이 할 일을 반복합니다              │
+│  ┌────────────────────────────────┐  │
+│  │ 반복 주기                        │  │
+│  │  매일   [ 매주 ]   매월          │  │
+│  │                                  │  │
+│  │ 반복 요일                        │  │
+│  │  일  (월) 화  (수) 목  (금) 토   │  │  ← WeekdayPicker (원형 chip 다중 선택)
+│  │                                  │  │     ※ (월)(수)(금) = 선택됨 표기
+│  │  ⚠ 요일을 하나 이상 선택해주세요  │  │  ← 검증 에러 (0개 선택 시)
+│  │                                  │  │
+│  │ 종료 조건                        │  │
+│  │ ○ 무기한                         │  │
+│  │ ● 특정 날짜까지  [2026-09-30]    │  │
+│  └────────────────────────────────┘  │
+```
+
+**반복 ON — 매월**
+
+```
+│  ☑ 이 할 일을 반복합니다              │
+│  ┌────────────────────────────────┐  │
+│  │ 반복 주기                        │  │
+│  │  매일    매주   [ 매월 ]         │  │
+│  │                                  │  │
+│  │ ℹ 매월 10일에 반복됩니다           │  │  ← 만료일시의 '일(day)'에서 자동 유도, 읽기 전용 안내
+│  │   (마감일시 기준)                 │  │
+│  │                                  │  │
+│  │ 종료 조건                        │  │
+│  │ ● 무기한                         │  │
+│  │ ○ 특정 날짜까지  [date picker]  │  │
+│  └────────────────────────────────┘  │
+```
+
+**차단 상태 A — 만료일시 미입력 시 (반복 토글 자체를 켤 수 없음)**
+
+```
+│  ├ 만료일시  [ 입력되지 않음 ]         │
+│  │                                       │
+│  ☐ 이 할 일을 반복합니다  (비활성)     │  ← disabled, 회색 처리
+│  ℹ 반복 설정은 마감일시를 입력해야      │
+│    사용할 수 있습니다                   │
+```
+
+**차단 상태 B — 하위 할 일이 있는 항목 수정 시 (반복 토글 비활성)**
+
+```
+│  ☐ 이 할 일을 반복합니다  (비활성)     │  ← disabled, 회색 처리, 커서 not-allowed
+│  ℹ 하위 할 일이 있는 항목은 반복을      │
+│    설정할 수 없습니다                   │
+```
+
+**차단 상태 C — 하위 할 일 생성 폼 (parentId가 존재하는 경우)**
+
+반복 섹션 자체를 렌더링하지 않는다 (섹션 자체가 DOM에 없음). 근거는 4-1절 참고.
+
+### 1-2. 시리즈 전체 수정 확인 모달
+
+`shared/ui/confirmModal` 재사용. 반복 중인 할 일(수정 대상이 이미 반복 시리즈인 경우)의 "저장" 클릭 시 노출.
+
+```
+┌──────────────────────────────────────┐
+│                                        │
+│  반복 일정 전체 수정                    │
+│  ──────────────────────────────────  │
+│  이 변경은 앞으로의 일정에만            │
+│  적용됩니다.                           │
+│                                        │
+│  진행 중이거나 완료된 일정, 이미 지난   │
+│  미완료 일정은 그대로 유지됩니다.       │
+│                                        │
+│                     [ 취소 ] [ 전체 적용 ] │
+└──────────────────────────────────────┘
+```
+
+### 1-3. kanban 반복 배지
+
+```
+┌───────────────────────────────┐
+│ 상위 프로젝트명                 │  ← ParentLabel (기존, 있는 경우만)
+│ 정수기 필터 교체        ⟳ 반복 │  ← ItemTitle + RecurrenceBadge (우측)
+└───────────────────────────────┘
+```
+
+제목이 길어 배지와 겹칠 경우 배지가 다음 줄로 wrap:
+
+```
+┌───────────────────────────────┐
+│ 아주 길고 긴 할 일 제목이         │
+│ 여러 줄에 걸쳐 표시되는 경우  ⟳ 반복 │
+└───────────────────────────────┘
+```
+
+### 1-4. 캘린더 반복 시각 표현
+
+**월간/주간 그리드 이벤트 바** — 제목 앞에 반복 아이콘 prefix
+
+```
+┌──────┬──────┬──────┬──────┐
+│  8   │  9   │ 10   │ 11   │
+│      │⟳필터교체│      │      │  ← 흰색 Repeat 아이콘 + 제목 (기존 색상 로직 유지)
+├──────┼──────┼──────┼──────┤
+```
+
+**BottomSheet 날짜 상세 리스트** — 배지 + 반복 요약 캡션
+
+```
+┌─────────────────────────────┐
+│  2026년 7월 10일 금요일        │
+│  ───────────────────────    │
+│  ┌───────────────────────┐  │
+│  │▌ 정수기 필터 교체  ⟳ 반복 │  │  ← RecurrenceBadge 동일 재사용
+│  │  할 일 · 마감: 7월 10일   │  │
+│  │  매주 월・수・금 반복      │  │  ← 신규 캡션 라인 (반복 요약)
+│  └───────────────────────┘  │
+└─────────────────────────────┘
+```
+
+---
+
+## 2. 디자인 언어
+
+### 2-1. 색상 매핑
+
+| 용도 | 토큰/값 | 비고 |
+|---|---|---|
+| 반복 아이콘/배지 텍스트 | `#0F6E56` (톤다운 primary) | CLAUDE.md 명시 톤다운 색 재사용 |
+| 반복 배지 배경 | `#E8F5EF` | `dashboard/DESIGN_SPEC.md`에서 이미 "brand.secondary 15% 알파 상당"으로 정의된 값과 동일 — **신규 값 아님, 기존 스펙과 통일** |
+| 반복 요일 선택 chip (선택됨) | `colors.brand.primary` `#0F6E56` | `weekStrip.styles.tsx`의 `DayCell $isSelected` 배경과 동일 패턴 재사용 |
+| 반복 요일 선택 chip (미선택) | `transparent` + 텍스트 `colors.text.tertiary` | `weekStrip.styles.tsx`의 `DayLabel` 비선택 스타일과 동일 |
+| 반복 주기 탭 (활성) | `colors.brand.secondary` `#1D9E75` (하단 보더 2px) | `kanbanBoard.styles.tsx`의 `MobileTabButton $active` 패턴 재사용 |
+| 검증 에러 텍스트 | `colors.danger.text` `#C53A39` | 요일 미선택, 종료일 유효성 에러 |
+| 비활성(disabled) 텍스트/보더 | `colors.text.tertiary` `#9AA0A6` | 반복 토글 비활성 시 |
+| 비활성 안내 문구 아이콘 | `colors.text.tertiary` | `lucide-react`의 `Info` 아이콘, 14px |
+| 확인 모달 | `shared/ui/confirmModal` 기존 스타일 그대로 | 별도 색상 변경 없음 |
+
+**신규 토큰 제안**: `colors.ts`에 `brand.background: "#E8F5EF"` 추가를 권장합니다 — 이미 두 스펙(캘린더 개편안, 본 스펙)에서 동일 값을 참조하므로 리터럴 중복 대신 토큰화하는 것이 유지보수에 유리합니다 (근거: 기존 `colors.danger.background` 패턴과 대칭).
+
+### 2-2. 아이콘
+
+- 반복 표시: `lucide-react`의 `Repeat` 아이콘 (프로젝트 내 아직 미사용 아이콘이나, 기존 아이콘 세트와 동일 라이브러리이므로 새 의존성 없음)
+- 크기: kanban 배지 12px, 캘린더 이벤트 바 prefix 10px, BottomSheet 배지 12px
+- 안내 문구 아이콘: `Info` (14px)
+
+### 2-3. 간격
+
+기존 `FormContainer`의 `gap: 12px` 패턴을 반복 섹션 내부에도 그대로 적용합니다 (8px 그리드보다 기존 폼 관행 우선 — 이미 12px 간격이 프로젝트 전역 폼 표준이므로 이를 따르는 것을 권장).
+
+| 요소 | 값 | 근거 |
+|---|---|---|
+| 반복 섹션 내부 필드 간 gap | `12px` | 기존 `DetailContent` gap과 동일 |
+| RecurrenceTypeTabs 높이 | `44px` | 터치 타겟 기준 |
+| WeekdayPicker chip 크기 | `36px × 36px` (원형) | `weekStrip.styles.tsx`의 `DayCell`은 44px지만 폼 내부 인라인 배치이므로 36px로 축소 권장 — 단, 터치 영역 확보를 위해 chip 사이 `gap: 6px` 필수 |
+| RecurrenceBadge 패딩 | `3px 8px` | `OverdueBadge`와 완전히 동일한 패턴 재사용 |
+| RecurrenceBadge border-radius | `6px` (`radius.md`) | `OverdueBadge`와 동일 |
+| 확인 모달 버튼 그룹 gap | `12px` | `confirmModal.styles.tsx` 기존 값 유지 |
+
+### 2-4. 타이포그래피
+
+신규 폰트 없음. 기존 `Pretendard` 웹폰트 상속. 안내/에러 문구는 `font-size: 12px`, 배지는 `font-size: 11px` (기존 `OverdueBadge` 기준과 동일).
+
+---
+
+## 3. 컴포넌트 설계
+
+### 3-1. 재사용
+
+| 컴포넌트 | 용도 |
+|---|---|
+| `shared/ui/confirmModal` | 시리즈 전체 수정 확인 모달 — 신규 컴포넌트 불필요 |
+| `weekStrip.styles.tsx`의 `DayCell`/`DayLabel` 시각 패턴 | `WeekdayPicker` chip 스타일의 참조 원형 (동일 파일 import는 아니고, 동일 패턴을 `todoForm` 전용 스타일로 재정의 — today 피처 종속성을 todo 피처가 갖지 않도록 분리) |
+| `kanbanBoard.styles.tsx`의 `MobileTabButton` 시각 패턴 | `RecurrenceTypeTabs` 참조 원형 (동일 이유로 별도 파일에 재정의) |
+| `projectCard.styles.tsx`의 `OverdueBadge` 시각 패턴 | `RecurrenceBadge` 참조 원형 |
+
+### 3-2. 신규 컴포넌트
+
+#### `RecurrenceFields` (신규, `todoForm/` 하위)
+
+```ts
+interface RecurrenceFieldsProps {
+  disabled: boolean;              // 하위 할 일 존재 또는 dueAt 미입력 시 true
+  disabledReason?: "hasChildren" | "noDueAt";
+  dueAt: string | null;           // 매월 반복 시 '일(day)' 유도에 사용
+  value: RecurrenceFormValue | null; // null = 반복 OFF
+  onChange: (value: RecurrenceFormValue | null) => void;
+}
+
+interface RecurrenceFormValue {
+  type: "daily" | "weekly" | "monthly";
+  weekdays?: number[];            // 0=일 ~ 6=토, type==="weekly"일 때만 사용, 최소 1개
+  endType: "indefinite" | "untilDate";
+  endDate?: string;               // endType==="untilDate"일 때만 사용
+}
+```
+
+- `RecurrenceFields`는 `todoForm.tsx`의 `DetailContent` 내부, 만료일시 입력 아래에 위치.
+- 내부적으로 체크박스(반복 on/off) + `RecurrenceTypeTabs` + `WeekdayPicker`(조건부) + 종료조건 라디오 그룹을 조합한 복합 컴포넌트.
+- `todoDetail.tsx`(할 일 상세 편집 패널)에도 동일하게 통합 필요 — 현재 `todoDetail.tsx`는 `todoForm.tsx`와 별도 구현(중복 코드)이므로, `RecurrenceFields`를 공용 컴포넌트로 분리해 두 곳에서 import.
+
+#### `RecurrenceTypeTabs` (신규)
+
+```ts
+interface RecurrenceTypeTabsProps {
+  value: "daily" | "weekly" | "monthly";
+  onChange: (type: "daily" | "weekly" | "monthly") => void;
+}
+```
+
+`MobileTabButton` 시각 패턴(하단 보더 2px, 활성 시 `colors.brand.secondary`) 재사용. `role="tablist"` / 각 버튼 `role="tab"` + `aria-selected`.
+
+#### `WeekdayPicker` (신규)
+
+```ts
+interface WeekdayPickerProps {
+  selected: number[];   // 0=일 ~ 6=토
+  onToggle: (day: number) => void;
+  error?: boolean;       // 0개 선택 시 true
+}
+```
+
+원형 chip 7개(일~토), 다중 토글. `weekStrip`의 `DayCell` 패턴을 축소(36px)하여 재정의. `error===true`일 때 하단에 `colors.danger.text` 에러 텍스트 노출.
+
+#### `RecurrenceBadge` (신규, `shared/ui/` 또는 `todo/components/` — 아래 3-3 참고)
+
+```ts
+interface RecurrenceBadgeProps {
+  compact?: boolean; // true면 아이콘만, false(기본)면 "반복" 텍스트 포함
+}
+```
+
+kanban 카드, BottomSheet 날짜 상세 리스트, (필요 시) todoDetail 패널 헤더에서 공통 사용. `OverdueBadge` 패턴 그대로 색상만 교체.
+
+### 3-3. 배치 위치 판단
+
+`RecurrenceBadge`는 `todo`, `kanban`, `dashboard` 세 피처에서 공통으로 쓰이므로 `shared/ui/recurrenceBadge/`에 두는 것을 권장합니다 (근거: `OverdueBadge`는 `todo` 피처 전용이라 `projectCard.styles.tsx`에 있지만, `RecurrenceBadge`는 kanban/dashboard까지 걸치는 교차 피처 컴포넌트이므로 `shared/ui`가 더 적절 — CLAUDE.md의 `shared/` = 공통 컴포넌트 원칙과 일치).
+
+### 3-4. 기존 컴포넌트 수정 지점
+
+| 파일 | 수정 내용 |
+|---|---|
+| `todo/components/todoForm/todoForm.tsx` | `RecurrenceFields` 통합, 저장 시 기존 recurrence 존재 여부에 따라 `ConfirmModal` 분기 |
+| `todo/components/todoDetail/todoDetail.tsx` | 동일하게 `RecurrenceFields` 통합 + 저장 시 `ConfirmModal` 분기 |
+| `todo/components/projectCard.tsx` | `todo.isRecurring`일 때 "하위 작업 추가"(`Plus` 아이콘) `IconButton`에 `disabled` + `aria-disabled` + `title="반복 할 일에는 하위 작업을 추가할 수 없습니다"` 부여 |
+| `todo/components/childTodoCard.tsx` | 변경 없음 (하위 할 일 자체는 반복 설정 대상이 아님 — 4-1절 근거) |
+| `kanban/components/kanbanItem.tsx`, `kanbanBoard.styles.tsx` | `ItemTitleRow`(신규 flex wrapper) 추가, `RecurrenceBadge` 조건부 렌더링 |
+| `dashboard/components/calendar.tsx` | `events` useMemo에서 `eventContent` 콜백 추가(반복 아이콘 prefix), `DayDetailItem`에 `RecurrenceBadge` + 반복 요약 캡션 라인 추가 |
+| `shared/ui/confirmModal/confirmModal.styles.tsx` | `Message`에 `white-space: pre-line;` 추가 (줄바꿈 포함 카피 지원 — 현재 단일 라인 가정) |
+
+---
+
+## 4. 인터랙션 플로우
+
+### 4-1. 하위 할 일 ↔ 반복 상호 배제
+
+```
+[케이스 A] 반복 없는 일반 할 일 수정 화면, 하위 할 일 0개
+  → 반복 체크박스 활성
+
+[케이스 B] 하위 할 일이 1개 이상 있는 할 일 수정 화면
+  → 반복 체크박스 disabled + 안내 문구 노출
+  → (하위 할 일을 모두 삭제하면 다음 진입 시 활성화됨 — 실시간 토글 아님, 폼 재오픈 시 반영으로 충분)
+
+[케이스 C] 이미 반복 중인 할 일의 ProjectCard
+  → "하위 작업 추가" 아이콘 버튼 disabled
+  → 사용자가 버튼에 hover/focus 시 title 툴팁으로 사유 안내
+  → 클릭 이벤트 자체를 막음 (disabled 속성으로 충분, 별도 토스트 불필요)
+
+[케이스 D] 하위 할 일 생성/수정 폼 (parentId 존재)
+  → 반복 섹션 미노출 (조건부 렌더링 안 함)
+```
+
+**케이스 D 근거 및 권장안**: PM 스코프에 하위 할 일 자체의 반복 가능 여부가 명시되어 있지 않으나, "반복 할 일은 하위 할 일을 가질 수 없다"는 상호 배제 원칙과의 일관성, 그리고 반복 인스턴스 생성/삭제 로직이 하위 계층까지 전파될 경우의 복잡도를 고려하면 **하위 할 일에는 반복 설정 자체를 노출하지 않는 것**을 권장합니다. 계층 구조의 최상위(부모/단일 할 일)에서만 반복이 의미를 가지도록 제한하는 것이 MVP 범위에서 가장 단순하고 사고 위험이 적습니다.
+
+### 4-2. 반복 토글 활성 전제조건 — 만료일시 필수
+
+```
+사용자가 만료일시를 입력하지 않은 상태
+  → 반복 체크박스 disabled + "반복 설정은 마감일시를 입력해야 사용할 수 있습니다"
+  ↓
+사용자가 만료일시 입력
+  → 반복 체크박스 활성화 (즉시, 리렌더 시)
+  ↓
+사용자가 만료일시를 다시 지움 (반복이 이미 켜진 상태에서)
+  → 반복 체크박스 강제 OFF + value를 null로 리셋 + 안내 문구 재노출
+  → (조용히 무시하지 않고 명시적으로 리셋 — 반복 규칙만 남고 기준일이 없는 비정상 상태 방지)
+```
+
+### 4-3. 매월 반복의 '일(day)' 유도
+
+```
+반복 주기 = 매월 선택
+  ↓
+dueAt의 day 값을 읽어 "매월 {day}일에 반복됩니다 (마감일시 기준)" 읽기 전용 안내 렌더링
+  ↓
+사용자가 만료일시를 변경
+  ↓
+안내 문구의 {day} 값도 즉시 재계산되어 갱신
+```
+
+31일 등 매월 존재하지 않는 날짜에 대한 처리(예: 2월)는 UI 문구로 사전 안내하는 것을 권장합니다: 만료일시의 `day >= 29`인 경우 안내 문구 하단에 보조 텍스트 추가.
+
+```
+ℹ 매월 31일에 반복됩니다 (마감일시 기준)
+  31일이 없는 달은 해당 월 마지막 날에 생성됩니다   ← day>=29일 때만 노출되는 보조 캡션
+```
+
+(이 보조 문구는 실제 생성 로직이 확정되는 대로 schedule-manager/PM 확인 후 문구 조정 필요 — 로직 자체는 본 스펙 범위 밖)
+
+### 4-4. 시리즈 전체 수정 확인 모달 트리거
+
+```
+사용자가 반복 중인 할 일의 수정 폼(todoForm 또는 todoDetail)에서 "저장" 클릭
+  ↓
+수정 대상 todo가 반복 시리즈에 속하는가? (필드가 무엇이든 무관 — 제목/우선순위만 바꿔도 동일)
+  ├─ No  → 기존과 동일하게 즉시 저장 (변경 없음)
+  └─ Yes → ConfirmModal 오픈 (제출 자체는 아직 실행 안 함)
+              ↓
+        [취소] 클릭 → 모달만 닫힘, 폼은 그대로 유지 (입력값 보존)
+        [전체 적용] 클릭 → 기존 onSubmit 로직 실행 (mutate 호출)
+              → 성공: toast.success + 모달/폼 닫힘
+              → 실패: toast.error, 모달은 닫히고 폼은 유지 (재시도 가능하도록)
+```
+
+**반복 OFF로 전환하는 저장도 동일하게 취급**: 반복 중이던 할 일의 반복 체크박스를 해제하고 저장하는 것도 "시리즈 수정"의 하나로 간주하여 동일한 확인 모달을 노출합니다 (반복 해제 = 향후 인스턴스 생성을 중단하는 시리즈 변경이므로 정책 문구가 그대로 적용됨).
+
+**신규 할 일 생성 시에는 모달 없음**: 처음 반복을 설정해서 "추가"하는 경우는 기존 인스턴스가 없으므로 확인 모달을 띄우지 않습니다. 트리거 조건은 "기존에 반복 시리즈였던 할 일을 수정 저장"하는 경우로 한정합니다.
+
+### 4-5. kanban 노출 필터 + 배지
+
+```
+반복 인스턴스 목록
+  ↓
+dueAt <= 오늘 인 인스턴스만 kanban 컬럼에 렌더링 (일반 할 일 필터링 로직은 변경 없음 — 이 필터는 반복 인스턴스 전용 추가 조건)
+  ↓
+kanban에 노출된 각 반복 인스턴스 카드
+  → RecurrenceBadge 항상 표시 (아이콘 + "반복" 텍스트)
+  ↓
+사용자가 배지를 보고 "이 카드는 반복 시리즈의 일부"임을 인지
+  → 카드 클릭 시 이동하는 상세 화면(todoDetail)에서 전체 시리즈 정보(반복 주기, 종료조건) 확인 가능해야 함 (todoDetail에도 RecurrenceFields 표시 — 읽기/수정 겸용)
+```
+
+### 4-6. 캘린더 시각 표현
+
+```
+캘린더는 kanban과 달리 미래 인스턴스도 전부 렌더링 (필터 없음)
+  ↓
+각 이벤트의 extendedProps.isRecurring 여부에 따라
+  eventContent 콜백에서 제목 앞에 Repeat 아이콘(10px, 흰색) prefix 렌더링
+  ↓
+날짜 클릭 → BottomSheet
+  → 반복 인스턴스인 항목에 RecurrenceBadge + "매주 월・수・금 반복" 같은 요약 캡션 추가
+  → 기한 초과 표시(기존 $overdue 로직)와 독립적으로 동시 표시 가능
+    예: 기한 초과 + 반복 인스턴스인 경우 → 빨간 좌측 보더(기존) + RecurrenceBadge(신규) 동시 노출
+```
+
+---
+
+## 5. 상태 정의
+
+### 5-1. 반복 입력 폼
+
+| 상태 | 표현 |
+|---|---|
+| 기본 (반복 OFF, 입력 가능) | 체크박스 unchecked, 하위 필드 미노출 |
+| 반복 ON | 하위 필드(주기 탭, 요일/월 정보, 종료조건) 노출, `DetailSection`과 동일한 grid-template-rows 트랜지션(0.3s) 적용 권장 — 기존 `더보기` 아코디언과 시각적 일관성 |
+| 비활성 - 만료일시 없음 | 체크박스 disabled, opacity 0.5, `Info` 아이콘 + 안내 문구 |
+| 비활성 - 하위 할 일 존재 | 체크박스 disabled, opacity 0.5, `Info` 아이콘 + 안내 문구 |
+| 요일 미선택 에러 (매주) | `WeekdayPicker` 하단 `colors.danger.text` 에러 텍스트, 폼 제출 차단 |
+| 종료일 유효성 에러 | "종료일은 마감일 이후여야 합니다" 에러 텍스트, 폼 제출 차단 |
+| 제출 중 | 기존 `useUpdateTodo`/`useCreateTodo` mutation의 loading 상태 — 별도 스피너 없이 기존 패턴(제출 버튼 비활성화 등) 유지, 신규 로딩 UI 불필요 |
+
+### 5-2. 시리즈 전체 수정 확인 모달
+
+| 상태 | 표현 |
+|---|---|
+| 닫힘 (기본) | 렌더링 안 함 |
+| 열림 | `Overlay` + `Container`, 배경 클릭 시 취소와 동일 동작(기존 `ConfirmModal` 동작 그대로) |
+| 제출 중 | "전체 적용" 버튼에 기존 mutation의 `isPending` 상태 연동 권장 (중복 클릭 방지) — `disabled` 처리 |
+| 실패 | 모달 닫힘 + `toast.error` (기존 toast 패턴) |
+
+### 5-3. kanban 배지
+
+| 상태 | 표현 |
+|---|---|
+| 반복 아님 | 배지 미노출 (기존과 동일) |
+| 반복 인스턴스 | `RecurrenceBadge` 항상 노출, 로딩/에러 상태 없음(정적 표시) |
+
+### 5-4. 캘린더
+
+| 상태 | 표현 |
+|---|---|
+| 로딩 | 기존 `Spinner` 유지 (변경 없음) |
+| 에러 | 기존 `EmptyState` 유지 (변경 없음) |
+| 반복 이벤트 (월간/주간 그리드) | 아이콘 prefix, 기존 색상 로직(상태별/기한초과) 그대로 유지 |
+| 반복 이벤트 (BottomSheet 상세) | `RecurrenceBadge` + 반복 요약 캡션 |
+| 빈 상태 (해당 날짜 할 일 없음) | 기존 `EmptyMessage` 유지 (변경 없음) |
+
+---
+
+## 6. 디자인 토큰 요약
+
+| 용도 | 토큰/값 |
+|---|---|
+| 반복 배지/아이콘 색상 | `#0F6E56` (신규 토큰 제안: `colors.brand.background` 없음 상태이므로 우선 리터럴 사용, 추후 토큰화 권장) |
+| 반복 배지 배경 | `#E8F5EF` |
+| 요일 chip 선택 배경 | `colors.brand.primary` |
+| 반복 주기 탭 활성 | `colors.brand.secondary` |
+| 에러 텍스트 | `colors.danger.text` |
+| 비활성 텍스트/보더 | `colors.text.tertiary` |
+| 반응형 기준 | `breakpoints.ts`의 mobile(~480px) / tablet(~768px) |
+| 터치 타겟 | 모든 인터랙티브 요소(체크박스, 탭, chip, 배지 클릭 영역이 있다면) 최소 44px — 단 `WeekdayPicker` chip은 36px 시각 크기 + 상하좌우 패딩으로 실질 히트영역 44px 확보 권장 |
+
+---
+
+## 7. 접근성 요구사항
+
+- 반복 체크박스: `<input type="checkbox">` 네이티브 사용, `aria-describedby`로 비활성 사유 안내 문구 연결
+- `RecurrenceTypeTabs`: `role="tablist"` wrapper, 각 버튼 `role="tab"` + `aria-selected` + `aria-controls`(연결된 하위 필드 영역 id)
+- `WeekdayPicker`: 각 chip은 `<button type="button" aria-pressed={selected}>` 사용, 그룹 wrapper에 `role="group"` + `aria-label="반복 요일 선택"`
+- 요일 미선택/종료일 에러: `role="alert"` 또는 `aria-live="polite"` 영역으로 스크린리더에 즉시 안내
+- `RecurrenceBadge`: 아이콘만 있는 `compact` 모드일 경우 반드시 `aria-label="반복 할 일"` 부여 (텍스트 포함 모드는 텍스트 자체로 충분하므로 추가 aria 불필요)
+- 시리즈 수정 확인 모달: 기존 `ConfirmModal` 접근성 패턴(포커스 트랩 등) 그대로 승계 — 별도 추가 요구사항 없음
+- 캘린더 이벤트 바의 반복 아이콘: 시각 전용 요소이므로 `aria-hidden="true"` 처리, 이벤트 자체의 접근성 텍스트는 FullCalendar 기본 title 속성에 의존 (기존과 동일)
+
+---
+
+## 8. ui-ux-improver에게 전달할 사항
+
+1. **`RecurrenceFields` 위치**: `todoForm.tsx`와 `todoDetail.tsx` 양쪽에서 중복 없이 재사용할 수 있도록 별도 파일로 분리해서 구현할 것을 권장합니다(예: `todo/components/recurrence/recurrenceFields.tsx`). 두 폼이 이미 유사 로직을 중복 구현하고 있으므로(예: `startAt`/`dueAt` 변환 로직) 이번 기회에 최소한 반복 관련 로직만이라도 공용화하는 것이 유지보수에 유리합니다.
+
+2. **`ConfirmModal.Message` 개행 지원**: 현재 `confirmModal.styles.tsx`의 `Message`는 개행 미지원(`white-space` 기본값). `\n`이 포함된 문자열을 그대로 렌더링하려면 `white-space: pre-line;` 한 줄 추가가 필요합니다. 다른 `ConfirmModal` 사용처(삭제 확인 등)에 영향 없는 안전한 변경입니다.
+
+3. **트리거 조건 판별 로직**: "수정 대상이 반복 시리즈에 속하는가"의 판별은 실제 필드 스키마 확정 후 `todo.recurrence != null` 또는 `todo.recurrenceId != null` 형태로 구현될 것으로 예상됩니다. 필드명이 확정되면 `onSubmit` 핸들러 내 분기 조건만 교체하면 되도록, UI 컴포넌트는 `isRecurring: boolean` 같은 파생 prop을 받는 형태로 설계해 필드 스키마 변경에 대한 결합도를 낮추는 것을 권장합니다.
+
+4. **kanban 필터링 로직 위치**: "반복 인스턴스는 `dueAt <= 오늘`만 노출"하는 필터는 `kanbanColumn.tsx` 또는 그 상위 `kanbanBoard.tsx`의 todos 필터링 단계에 추가되어야 하며, **일반(비반복) 할 일의 기존 kanban 노출 로직에는 영향이 없어야 합니다.** 조건 분기 시 `todo.isRecurring`(또는 확정된 필드명) 체크를 먼저 하고 참일 때만 추가 날짜 필터를 적용하는 방식을 권장합니다.
+
+5. **`ItemTitleRow`의 텍스트 줄바꿈 정책**: 배지가 제목을 가리지 않도록 `flex-wrap: wrap`을 적용하고 `ItemTitle`에 별도의 `text-overflow: ellipsis`를 적용하지 않는 것을 권장합니다(1-3절 wireframe 참고) — 축약보다 전체 제목 노출이 우선순위가 높다는 판단입니다. 이 판단에 이견이 있다면 구현 전 재확인 바랍니다.
+
+6. **`RecurrenceBadge` 배치 경로**: `shared/ui/recurrenceBadge/`에 신규 생성 권장 (3-3절 근거). `todo`, `kanban`, `dashboard` 세 피처가 모두 import하므로 `shared/ui/index.ts`에 export 추가 필요.
+
+7. **매월 반복 안내 캡션의 최종 문구**: 4-3절의 "31일이 없는 달은 해당 월 마지막 날에 생성됩니다" 문구는 실제 반복 생성 로직(schedule-manager 스프린트 계획)이 확정된 뒤 문구가 로직과 일치하는지 재확인이 필요합니다. 로직이 다르게 확정될 경우(예: 해당 월 생성 스킵) 문구도 함께 수정되어야 합니다.
+
+8. **`dashboard/DESIGN_SPEC.md`와의 관계**: 캘린더 개편안(월간/주간 전환, 드래그 등)이 승인·구현되면 `BottomSheet`의 `DayDetailItem` 구조 자체는 유지되므로 본 스펙의 `RecurrenceBadge`/캡션 추가는 그대로 호환됩니다. 다만 개편안 승인 이전에 본 스펙이 먼저 구현될 경우, 두 스펙 모두 `calendar.tsx`/`calendar.styles.tsx`를 수정하므로 **구현 순서 충돌(병합 충돌) 가능성**을 PM/schedule-manager와 사전 조율할 것을 권장합니다.
+
+9. **애니메이션**: 반복 하위 필드 노출/숨김은 기존 `DetailSection`의 `grid-template-rows` 트랜지션(0.3s ease-in-out) 패턴을 그대로 재사용해 일관성을 유지합니다. 별도의 신규 트랜지션 정의는 불필요합니다.
+
+---
+
+## 9. 미결/추천안 요약 (승인 시 확정)
+
+아래는 스펙 작성 중 발생한 모호 지점에 대해 근거를 곁들여 제시하는 추천안입니다. 별도 이견이 없으면 그대로 승인 처리해 주세요.
+
+| 항목 | 추천안 | 근거 |
+|---|---|---|
+| 하위 할 일 자체의 반복 가능 여부 | 하위 할 일에는 반복 섹션을 아예 노출하지 않음 (4-1절 케이스 D) | 상호 배제 원칙과의 일관성, MVP 복잡도 최소화 |
+| 반복 OFF 전환도 확인 모달 트리거 대상인지 | 포함 (4-4절) | "시리즈 수정"의 한 형태로 보는 것이 정책 문구와 일관됨 |
+| `RecurrenceBadge` 배치 위치 | `shared/ui/recurrenceBadge/` | 3개 피처 교차 사용, CLAUDE.md의 shared 원칙과 일치 |
+| 반복 배지 배경색 | `#E8F5EF` | 캘린더 개편 스펙에서 이미 사용된 값과 통일 |
+| kanban 배지 표기 | 아이콘 + "반복" 텍스트(컴팩트 모드 아님) | `OverdueBadge`가 텍스트 포함 방식이라 시각적 일관성 우선 |
+| 매월 반복 day 유도 UI | 별도 날짜 선택 없이 `dueAt`의 day를 읽기 전용으로 안내 | PM 스코프("매월 같은 날짜")가 이미 dueAt 종속을 전제 |

--- a/client/src/features/todo/hooks/__tests__/useSearchTodo.test.tsx
+++ b/client/src/features/todo/hooks/__tests__/useSearchTodo.test.tsx
@@ -28,6 +28,8 @@ const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
   doneAt: null,
   parentId: null,
   order: 0,
+  recurrence: null,
+  recurrenceId: null,
   createdAt: '2026-06-14T00:00:00.000Z',
   updatedAt: '2026-06-14T00:00:00.000Z',
   ...overrides,

--- a/client/src/features/todo/hooks/__tests__/useTodo.test.tsx
+++ b/client/src/features/todo/hooks/__tests__/useTodo.test.tsx
@@ -27,6 +27,7 @@ vi.mock('../../api', () => ({
   createRecurringTodo: vi.fn(),
   editRecurringSeries: vi.fn(),
   deleteRecurringSeries: vi.fn(),
+  extendIndefiniteRecurringSeries: vi.fn(),
 }))
 
 const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
@@ -312,6 +313,40 @@ describe('useTodo 훅', () => {
       })
 
       expect(vi.mocked(deleteRecurringSeries)).toHaveBeenCalledWith('series-1')
+    })
+  })
+
+  describe('useExtendIndefiniteRecurringSeries', () => {
+    it('무기한 반복 시리즈 확장 mutation이 정의되어 있어야 한다', () => {
+      const { result } = renderHook(() => useTodo(), {
+        wrapper: createWrapper(),
+      })
+
+      expect(result.current.useExtendIndefiniteRecurringSeries).toBeDefined()
+      expect(typeof result.current.useExtendIndefiniteRecurringSeries.mutate).toBe('function')
+    })
+
+    it('성공 시 todos 쿼리를 무효화해야 한다', async () => {
+      const { getTodos, extendIndefiniteRecurringSeries } = await import('../../api')
+
+      vi.mocked(getTodos).mockResolvedValue([])
+      vi.mocked(extendIndefiniteRecurringSeries).mockResolvedValueOnce(undefined)
+
+      const { result } = renderHook(() => useTodo(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.useGetTodos.isSuccess).toBe(true)
+      })
+
+      result.current.useExtendIndefiniteRecurringSeries.mutate()
+
+      await waitFor(() => {
+        expect(result.current.useExtendIndefiniteRecurringSeries.isSuccess).toBe(true)
+      })
+
+      expect(vi.mocked(extendIndefiniteRecurringSeries)).toHaveBeenCalled()
     })
   })
 })

--- a/client/src/features/todo/hooks/__tests__/useTodo.test.tsx
+++ b/client/src/features/todo/hooks/__tests__/useTodo.test.tsx
@@ -22,7 +22,11 @@ vi.mock('../../api', () => ({
   editTodo: vi.fn(),
   deleteTodo: vi.fn(),
   updateToDone: vi.fn(),
+  updateTodoDueAt: vi.fn(),
   createChildTodo: vi.fn(),
+  createRecurringTodo: vi.fn(),
+  editRecurringSeries: vi.fn(),
+  deleteRecurringSeries: vi.fn(),
 }))
 
 const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
@@ -36,6 +40,8 @@ const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
   doneAt: null,
   parentId: null,
   order: 0,
+  recurrence: null,
+  recurrenceId: null,
   createdAt: '2026-06-14T00:00:00.000Z',
   updatedAt: '2026-06-14T00:00:00.000Z',
   ...overrides,
@@ -202,6 +208,110 @@ describe('useTodo 훅', () => {
 
       expect(result.current.useCreateChildTodo).toBeDefined()
       expect(typeof result.current.useCreateChildTodo.mutate).toBe('function')
+    })
+  })
+
+  describe('useCreateRecurringTodo', () => {
+    it('반복 할 일 생성 mutation이 정의되어 있어야 한다', () => {
+      const { result } = renderHook(() => useTodo(), {
+        wrapper: createWrapper(),
+      })
+
+      expect(result.current.useCreateRecurringTodo).toBeDefined()
+      expect(typeof result.current.useCreateRecurringTodo.mutate).toBe('function')
+    })
+
+    it('생성 성공 시 todos 쿼리를 무효화해야 한다', async () => {
+      const { getTodos, createRecurringTodo } = await import('../../api')
+      const newTodo = makeTodo({ id: 'new-todo', title: '반복 할 일', recurrence: { type: 'daily', endType: 'indefinite' }, recurrenceId: 'series-1' })
+
+      vi.mocked(getTodos).mockResolvedValue([])
+      vi.mocked(createRecurringTodo).mockResolvedValueOnce([newTodo])
+
+      const { result } = renderHook(() => useTodo(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.useGetTodos.isSuccess).toBe(true)
+      })
+
+      result.current.useCreateRecurringTodo.mutate(newTodo)
+
+      await waitFor(() => {
+        expect(result.current.useCreateRecurringTodo.isSuccess).toBe(true)
+      })
+
+      expect(vi.mocked(createRecurringTodo)).toHaveBeenCalledWith(newTodo)
+    })
+  })
+
+  describe('useEditRecurringSeries', () => {
+    it('반복 시리즈 수정 mutation이 정의되어 있어야 한다', () => {
+      const { result } = renderHook(() => useTodo(), {
+        wrapper: createWrapper(),
+      })
+
+      expect(result.current.useEditRecurringSeries).toBeDefined()
+      expect(typeof result.current.useEditRecurringSeries.mutate).toBe('function')
+    })
+
+    it('수정 성공 시 todos 쿼리를 무효화해야 한다', async () => {
+      const { getTodos, editRecurringSeries } = await import('../../api')
+      const seriesTodo = makeTodo({ id: 'todo-1', recurrence: { type: 'daily', endType: 'indefinite' }, recurrenceId: 'series-1' })
+
+      vi.mocked(getTodos).mockResolvedValue([])
+      vi.mocked(editRecurringSeries).mockResolvedValueOnce(undefined)
+
+      const { result } = renderHook(() => useTodo(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.useGetTodos.isSuccess).toBe(true)
+      })
+
+      result.current.useEditRecurringSeries.mutate(seriesTodo)
+
+      await waitFor(() => {
+        expect(result.current.useEditRecurringSeries.isSuccess).toBe(true)
+      })
+
+      expect(vi.mocked(editRecurringSeries)).toHaveBeenCalledWith(seriesTodo)
+    })
+  })
+
+  describe('useDeleteRecurringSeries', () => {
+    it('반복 시리즈 삭제 mutation이 정의되어 있어야 한다', () => {
+      const { result } = renderHook(() => useTodo(), {
+        wrapper: createWrapper(),
+      })
+
+      expect(result.current.useDeleteRecurringSeries).toBeDefined()
+      expect(typeof result.current.useDeleteRecurringSeries.mutate).toBe('function')
+    })
+
+    it('삭제 성공 시 todos 쿼리를 무효화해야 한다', async () => {
+      const { getTodos, deleteRecurringSeries } = await import('../../api')
+
+      vi.mocked(getTodos).mockResolvedValue([])
+      vi.mocked(deleteRecurringSeries).mockResolvedValueOnce(undefined)
+
+      const { result } = renderHook(() => useTodo(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.useGetTodos.isSuccess).toBe(true)
+      })
+
+      result.current.useDeleteRecurringSeries.mutate('series-1')
+
+      await waitFor(() => {
+        expect(result.current.useDeleteRecurringSeries.isSuccess).toBe(true)
+      })
+
+      expect(vi.mocked(deleteRecurringSeries)).toHaveBeenCalledWith('series-1')
     })
   })
 })

--- a/client/src/features/todo/hooks/useTodo.ts
+++ b/client/src/features/todo/hooks/useTodo.ts
@@ -12,6 +12,7 @@ import {
   createRecurringTodo,
   editRecurringSeries,
   deleteRecurringSeries,
+  extendIndefiniteRecurringSeries,
 } from "../api";
 
 export const useTodo = () => {
@@ -168,6 +169,16 @@ export const useTodo = () => {
     },
   });
 
+  // 앱 진입 시 1회 호출해 무기한 반복 시리즈들의 남은 인스턴스를 오늘 기준으로
+  // 이어서 채운다(App.tsx). 사용자 액션이 아니라 백그라운드 유지보수 성격이라
+  // 실패해도 조용히 넘어가고(다음 접속 때 다시 시도됨) 성공 시에만 목록을 갱신한다.
+  const useExtendIndefiniteRecurringSeries = useMutation({
+    mutationFn: () => extendIndefiniteRecurringSeries(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["todos"] });
+    },
+  });
+
   return {
     useCreateTodo,
     useUpdateTodo,
@@ -179,6 +190,7 @@ export const useTodo = () => {
     useCreateRecurringTodo,
     useEditRecurringSeries,
     useDeleteRecurringSeries,
+    useExtendIndefiniteRecurringSeries,
   };
 };
 

--- a/client/src/features/todo/hooks/useTodo.ts
+++ b/client/src/features/todo/hooks/useTodo.ts
@@ -9,6 +9,9 @@ import {
   updateTodoDueAt,
   createChildTodo,
   getTodoDetail,
+  createRecurringTodo,
+  editRecurringSeries,
+  deleteRecurringSeries,
 } from "../api";
 
 export const useTodo = () => {
@@ -135,6 +138,36 @@ export const useTodo = () => {
     },
   });
 
+  // 반복(recurrence)이 설정된 할 일 생성은 useCreateTodo와 별도 훅으로 분리했다.
+  // 생성 시점에 이미 N개의 Todo 문서를 batch로 만들어야 해서 성공/무효화 흐름이
+  // 단일 문서 생성(useCreateTodo)과 다르고, 폼(todoForm)에서 recurrence 유무에 따라
+  // 호출할 훅을 명시적으로 분기하는 편이 "이 저장은 여러 문서를 만든다"는 것을
+  // 호출부에서 더 명확히 드러낸다고 판단했다.
+  const useCreateRecurringTodo = useMutation({
+    mutationFn: (todo: Todo) => createRecurringTodo(todo),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["todos"] });
+    },
+  });
+
+  // 반복 시리즈 전체 수정(반복 OFF 전환 포함). 입력은 시리즈 대표 todo(수정 폼에서
+  // 편집 중인 인스턴스)의 새 필드값 + 새 recurrence 규칙.
+  const useEditRecurringSeries = useMutation({
+    mutationFn: (seriesTodo: Todo) => editRecurringSeries(seriesTodo),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["todos"] });
+    },
+  });
+
+  // 반복 시리즈 전체 삭제(할 일 목록에서 반복 할 일 카드 삭제 시 사용). 단일 문서만
+  // 지우는 useDeleteTodo와 달리 같은 recurrenceId의 모든 인스턴스를 지운다.
+  const useDeleteRecurringSeries = useMutation({
+    mutationFn: (recurrenceId: string) => deleteRecurringSeries(recurrenceId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["todos"] });
+    },
+  });
+
   return {
     useCreateTodo,
     useUpdateTodo,
@@ -143,6 +176,9 @@ export const useTodo = () => {
     useUpdateToDone,
     useUpdateTodoDueAt,
     useCreateChildTodo,
+    useCreateRecurringTodo,
+    useEditRecurringSeries,
+    useDeleteRecurringSeries,
   };
 };
 

--- a/client/src/features/todo/index.ts
+++ b/client/src/features/todo/index.ts
@@ -1,5 +1,6 @@
 export { useTodo, useTodoDetail } from "./hooks";
-export type { Todo } from "./types";
+export type { Todo, RecurrenceRule } from "./types";
+export { collapseRecurringInstances } from "./utils/projectUtils";
 export { default as TodoList } from "./components/todoList";
 export { default as TodoDetail } from "./components/todoDetail/todoDetail";
 export { default as TodoForm } from "./components/todoForm/todoForm";

--- a/client/src/features/todo/types/index.ts
+++ b/client/src/features/todo/types/index.ts
@@ -1,2 +1,2 @@
-export type { Todo } from "./todo.type";
+export type { Todo, RecurrenceRule } from "./todo.type";
 export type { ProjectCardData } from "../utils/projectUtils";

--- a/client/src/features/todo/types/todo.type.ts
+++ b/client/src/features/todo/types/todo.type.ts
@@ -1,3 +1,18 @@
+/**
+ * 반복 규칙.
+ * - 모든 인스턴스(Todo 문서)가 동일한 recurrenceId를 공유하고, 이 규칙 값도
+ *   각 인스턴스에 비정규화되어 저장된다 (별도의 "시리즈 루트" 문서 없음).
+ *   따라서 시리즈의 어느 인스턴스를 열어도 규칙을 읽고 전체 수정할 수 있다.
+ */
+interface RecurrenceRule {
+  type: "daily" | "weekly" | "monthly";
+  /** 0=일 ~ 6=토. type==="weekly"일 때만 사용, 최소 1개 이상이어야 한다. */
+  weekdays?: number[];
+  endType: "indefinite" | "untilDate";
+  /** endType==="untilDate"일 때만 사용 (ISO date string) */
+  endDate?: string | null;
+}
+
 interface Todo {
   id: string;
   userId: string;
@@ -12,6 +27,10 @@ interface Todo {
   priority: "low" | "medium" | "high";
   parentId: string | null;
   order: number;
+  /** 반복 규칙. null이면 반복 아님. parentId가 있으면 항상 null이어야 한다(상호 배제). */
+  recurrence: RecurrenceRule | null;
+  /** 같은 반복 시리즈에 속한 인스턴스들을 묶는 그룹 id. 반복 아니면 null. */
+  recurrenceId: string | null;
 }
 
-export type { Todo };
+export type { Todo, RecurrenceRule };

--- a/client/src/features/todo/utils/__tests__/collapseRecurringInstances.test.ts
+++ b/client/src/features/todo/utils/__tests__/collapseRecurringInstances.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { collapseRecurringInstances } from "../projectUtils";
+import type { Todo } from "../../types";
+
+const makeTodo = (overrides: Partial<Todo>): Todo => ({
+  id: "id",
+  userId: "u1",
+  title: "title",
+  status: "todo",
+  priority: "medium",
+  startAt: null,
+  dueAt: null,
+  doneAt: null,
+  parentId: null,
+  order: 0,
+  createdAt: "",
+  updatedAt: "",
+  recurrence: null,
+  recurrenceId: null,
+  ...overrides,
+});
+
+describe("collapseRecurringInstances", () => {
+  it("반복 아닌 할 일은 그대로 통과시킨다", () => {
+    const todos = [makeTodo({ id: "a" }), makeTodo({ id: "b" })];
+    expect(collapseRecurringInstances(todos)).toHaveLength(2);
+  });
+
+  it("같은 recurrenceId를 가진 인스턴스 중 dueAt이 가장 이른 것 하나만 남긴다", () => {
+    const todos = [
+      makeTodo({ id: "future", recurrenceId: "series-1", dueAt: "2026-07-20T00:00:00.000Z" }),
+      makeTodo({ id: "overdue", recurrenceId: "series-1", dueAt: "2026-07-01T00:00:00.000Z" }),
+      makeTodo({ id: "nearer", recurrenceId: "series-1", dueAt: "2026-07-10T00:00:00.000Z" }),
+    ];
+    const result = collapseRecurringInstances(todos);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("overdue");
+  });
+
+  it("서로 다른 recurrenceId는 각각 대표 1건씩 남긴다", () => {
+    const todos = [
+      makeTodo({ id: "a1", recurrenceId: "series-a", dueAt: "2026-07-05T00:00:00.000Z" }),
+      makeTodo({ id: "b1", recurrenceId: "series-b", dueAt: "2026-07-06T00:00:00.000Z" }),
+      makeTodo({ id: "a2", recurrenceId: "series-a", dueAt: "2026-07-01T00:00:00.000Z" }),
+    ];
+    const result = collapseRecurringInstances(todos);
+    expect(result.map((t) => t.id).sort()).toEqual(["a2", "b1"]);
+  });
+});

--- a/client/src/features/todo/utils/__tests__/recurrence.test.ts
+++ b/client/src/features/todo/utils/__tests__/recurrence.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateRecurringDueDates,
+  getDefaultHorizonEnd,
+  RECURRENCE_HORIZON_WEEKS,
+} from "../recurrence";
+import type { RecurrenceRule } from "../../types/todo.type";
+
+// NOTE: 타임존에 따른 날짜 경계 이슈를 피하기 위해 모든 날짜/시각은 로컬 타임 문자열
+// (Z suffix 없음, 예: "2026-07-10T18:00:00")로 표기한다. 이는 실제 dueAt 입력이
+// datetime-local 인풋에서 오는 형태와도 일치한다.
+const toDateKey = (iso: string) => {
+  const d = new Date(iso);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(
+    d.getDate(),
+  ).padStart(2, "0")}`;
+};
+
+describe("generateRecurringDueDates", () => {
+  it("daily: 매일 하나씩, baseDueAt부터 horizonEnd까지 생성한다", () => {
+    const rule: RecurrenceRule = { type: "daily", endType: "indefinite" };
+    const base = "2026-07-10T18:00:00";
+    const horizonEnd = new Date("2026-07-15T00:00:00");
+
+    const result = generateRecurringDueDates(base, rule, horizonEnd);
+
+    expect(result.map(toDateKey)).toEqual([
+      "2026-07-10",
+      "2026-07-11",
+      "2026-07-12",
+      "2026-07-13",
+      "2026-07-14",
+      "2026-07-15",
+    ]);
+    // 모든 인스턴스는 baseDueAt과 동일한 시각(시:분)을 갖는다
+    result.forEach((iso) => {
+      const d = new Date(iso);
+      expect(d.getHours()).toBe(new Date(base).getHours());
+      expect(d.getMinutes()).toBe(new Date(base).getMinutes());
+    });
+  });
+
+  it("weekly: rule.weekdays에 해당하는 요일마다 생성한다", () => {
+    // 2026-07-10은 금요일(5). 월(1)/수(3)/금(5) 반복, baseDueAt의 요일도 포함되도록 구성
+    const rule: RecurrenceRule = {
+      type: "weekly",
+      weekdays: [1, 3, 5],
+      endType: "indefinite",
+    };
+    const base = "2026-07-10T09:00:00"; // 금요일
+    const horizonEnd = new Date("2026-07-20T00:00:00");
+
+    const result = generateRecurringDueDates(base, rule, horizonEnd);
+    const keys = result.map(toDateKey);
+
+    // 2026-07-10(금), 13(월), 15(수), 17(금), 20(월)
+    expect(keys).toEqual([
+      "2026-07-10",
+      "2026-07-13",
+      "2026-07-15",
+      "2026-07-17",
+      "2026-07-20",
+    ]);
+  });
+
+  it("weekly: weekdays가 비어있으면 빈 배열을 반환한다", () => {
+    const rule: RecurrenceRule = {
+      type: "weekly",
+      weekdays: [],
+      endType: "indefinite",
+    };
+    const result = generateRecurringDueDates(
+      "2026-07-10T09:00:00",
+      rule,
+      new Date("2026-07-20T00:00:00"),
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("monthly: baseDueAt의 day를 유지해서 매월 생성한다", () => {
+    const rule: RecurrenceRule = { type: "monthly", endType: "indefinite" };
+    const base = "2026-07-10T18:00:00";
+    const horizonEnd = new Date("2026-10-01T00:00:00");
+
+    const result = generateRecurringDueDates(base, rule, horizonEnd);
+
+    expect(result.map(toDateKey)).toEqual([
+      "2026-07-10",
+      "2026-08-10",
+      "2026-09-10",
+    ]);
+  });
+
+  it("monthly: 31일처럼 존재하지 않는 달은 그 달의 마지막 날로 클램핑한다 (2월 포함)", () => {
+    const rule: RecurrenceRule = { type: "monthly", endType: "indefinite" };
+    const base = "2026-01-31T09:00:00";
+    const horizonEnd = new Date("2026-04-30T00:00:00");
+
+    const result = generateRecurringDueDates(base, rule, horizonEnd);
+
+    // 2026년은 평년 → 2월 마지막 날은 28일
+    expect(result.map(toDateKey)).toEqual([
+      "2026-01-31",
+      "2026-02-28",
+      "2026-03-31",
+      "2026-04-30",
+    ]);
+  });
+
+  it("endType이 untilDate이면 endDate와 horizonEnd 중 더 이른 날짜까지만 생성한다 (endDate가 더 이른 경우)", () => {
+    const rule: RecurrenceRule = {
+      type: "daily",
+      endType: "untilDate",
+      // endDate는 실제로는 <input type="date"> 값(시각 없는 "YYYY-MM-DD")으로 온다.
+      endDate: "2026-07-12",
+    };
+    const base = "2026-07-10T18:00:00";
+    const horizonEnd = new Date("2026-08-10T00:00:00"); // endDate보다 훨씬 뒤
+
+    const result = generateRecurringDueDates(base, rule, horizonEnd);
+
+    expect(result.map(toDateKey)).toEqual([
+      "2026-07-10",
+      "2026-07-11",
+      "2026-07-12",
+    ]);
+  });
+
+  it("endType이 untilDate여도 horizonEnd가 더 이르면 horizonEnd까지만 생성한다", () => {
+    const rule: RecurrenceRule = {
+      type: "daily",
+      endType: "untilDate",
+      endDate: "2026-12-31", // 훨씬 뒤 (date-only)
+    };
+    const base = "2026-07-10T18:00:00";
+    const horizonEnd = new Date("2026-07-12T00:00:00");
+
+    const result = generateRecurringDueDates(base, rule, horizonEnd);
+
+    expect(result.map(toDateKey)).toEqual([
+      "2026-07-10",
+      "2026-07-11",
+      "2026-07-12",
+    ]);
+  });
+
+  it("무기한(indefinite)이면 horizonEnd까지 생성한다", () => {
+    const rule: RecurrenceRule = { type: "daily", endType: "indefinite" };
+    const base = "2026-07-10T18:00:00";
+    const horizonEnd = new Date("2026-07-13T00:00:00");
+
+    const result = generateRecurringDueDates(base, rule, horizonEnd);
+
+    expect(result).toHaveLength(4);
+    expect(toDateKey(result[result.length - 1])).toBe("2026-07-13");
+  });
+
+  // endDate는 <input type="date">에서 온 시각 없는 "YYYY-MM-DD" 문자열이다. 이를
+  // new Date(str)로 바로 파싱하면 UTC 자정으로 해석되므로, UTC보다 시간이 느린
+  // 타임존(예: America/New_York)에서는 로컬 날짜가 하루 당겨져 종료일 당일의
+  // 인스턴스가 누락될 수 있다. 이 회귀를 잡기 위해 TZ를 명시적으로 바꿔서 검증한다.
+  it("UTC보다 시간이 느린 타임존에서도 endDate 당일까지 정확히 생성한다", () => {
+    const originalTz = process.env.TZ;
+    process.env.TZ = "America/New_York";
+    try {
+      const rule: RecurrenceRule = {
+        type: "daily",
+        endType: "untilDate",
+        endDate: "2026-07-12",
+      };
+      const base = "2026-07-10T18:00";
+      const horizonEnd = new Date("2026-08-10T00:00:00");
+
+      const result = generateRecurringDueDates(base, rule, horizonEnd);
+
+      expect(result.map(toDateKey)).toEqual([
+        "2026-07-10",
+        "2026-07-11",
+        "2026-07-12",
+      ]);
+    } finally {
+      process.env.TZ = originalTz;
+    }
+  });
+});
+
+describe("getDefaultHorizonEnd", () => {
+  it(`기준일로부터 ${RECURRENCE_HORIZON_WEEKS}주 뒤 시점을 반환한다`, () => {
+    const from = new Date("2026-07-03T00:00:00");
+    const result = getDefaultHorizonEnd(from);
+    const diffDays = Math.round(
+      (result.getTime() - from.getTime()) / (1000 * 60 * 60 * 24),
+    );
+    expect(diffDays).toBe(RECURRENCE_HORIZON_WEEKS * 7);
+  });
+});

--- a/client/src/features/todo/utils/projectUtils.ts
+++ b/client/src/features/todo/utils/projectUtils.ts
@@ -1,5 +1,40 @@
 import type { Todo } from "../types";
 
+/**
+ * 같은 recurrenceId를 가진 반복 인스턴스 중 dueAt이 가장 이른 것(지난 미완료(overdue)가
+ * 있으면 그것, 없으면 다음 예정 건) 하나만 남기고 나머지는 목록에서 숨긴다. 반복 아닌
+ * 할 일(recurrenceId === null)은 그대로 통과시킨다. 다른 문서를 지우는 게 아니라 이
+ * 목록에 렌더링할 대표만 고르는 순수 함수다 — 실제 삭제는 useDeleteRecurringSeries가 담당.
+ */
+export function collapseRecurringInstances(todos: Todo[]): Todo[] {
+  const representativeByRecurrenceId = new Map<string, Todo>();
+  const result: Todo[] = [];
+
+  for (const todo of todos) {
+    if (!todo.recurrenceId) {
+      result.push(todo);
+      continue;
+    }
+
+    const existing = representativeByRecurrenceId.get(todo.recurrenceId);
+    if (!existing) {
+      representativeByRecurrenceId.set(todo.recurrenceId, todo);
+      result.push(todo);
+      continue;
+    }
+
+    const existingDue = existing.dueAt ? new Date(existing.dueAt).getTime() : Infinity;
+    const currentDue = todo.dueAt ? new Date(todo.dueAt).getTime() : Infinity;
+    if (currentDue < existingDue) {
+      const index = result.indexOf(existing);
+      result[index] = todo;
+      representativeByRecurrenceId.set(todo.recurrenceId, todo);
+    }
+  }
+
+  return result;
+}
+
 export interface ProjectCardData {
   todo: Todo;
   childTodos: Todo[];

--- a/client/src/features/todo/utils/recurrence.ts
+++ b/client/src/features/todo/utils/recurrence.ts
@@ -1,0 +1,137 @@
+import type { RecurrenceRule } from "../types/todo.type";
+
+/** 반복 인스턴스를 미리 생성해두는 기본 기간(주). schedule-manager 스프린트 계획 기준. */
+export const RECURRENCE_HORIZON_WEEKS = 4;
+
+/**
+ * 오늘(또는 지정한 기준일)로부터 RECURRENCE_HORIZON_WEEKS(4주) 뒤 시점을 반환한다.
+ * generateRecurringDueDates의 horizonEnd 기본값으로 사용.
+ */
+export function getDefaultHorizonEnd(from: Date = new Date()): Date {
+  const result = new Date(from);
+  result.setDate(result.getDate() + RECURRENCE_HORIZON_WEEKS * 7);
+  return result;
+}
+
+/** year/month(0-indexed) 기준 마지막 날짜(28~31)를 반환한다. */
+function getLastDayOfMonth(year: number, month: number): number {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+/** 시각(시/분/초/밀리초)만 base 기준으로 맞춰 새 Date를 반환한다. */
+function applyTimeOfDay(date: Date, base: Date): Date {
+  const result = new Date(date);
+  result.setHours(
+    base.getHours(),
+    base.getMinutes(),
+    base.getSeconds(),
+    base.getMilliseconds(),
+  );
+  return result;
+}
+
+/** 날짜의 자정(00:00:00.000)을 반환한다 (날짜 단위 비교용). */
+function startOfDay(date: Date): Date {
+  const result = new Date(date);
+  result.setHours(0, 0, 0, 0);
+  return result;
+}
+
+/** 날짜의 23:59:59.999를 반환한다 (경계 포함 비교용). */
+function endOfDay(date: Date): Date {
+  const result = new Date(date);
+  result.setHours(23, 59, 59, 999);
+  return result;
+}
+
+/**
+ * "YYYY-MM-DD" date-only 문자열(<input type="date"> 값)을 로컬 자정 Date로 만든다.
+ * new Date("YYYY-MM-DD")로 바로 파싱하면 UTC 자정으로 해석되어, UTC보다 시간이
+ * 느린 타임존(예: America/New_York)에서는 하루 전 날짜로 밀리는 문제가 있다.
+ */
+function parseDateOnlyLocal(dateOnlyStr: string): Date {
+  const [y, m, d] = dateOnlyStr.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+/**
+ * 실제 종료 시점을 계산한다: endType이 untilDate이면 endDate와 horizonEnd 중 더 이른 날짜,
+ * 무기한(indefinite)이면 horizonEnd 그대로.
+ */
+function resolveEffectiveEnd(rule: RecurrenceRule, horizonEnd: Date): Date {
+  if (rule.endType === "untilDate" && rule.endDate) {
+    const endDate = parseDateOnlyLocal(rule.endDate);
+    if (!Number.isNaN(endDate.getTime()) && endDate.getTime() < horizonEnd.getTime()) {
+      return endDate;
+    }
+  }
+  return horizonEnd;
+}
+
+/**
+ * baseDueAt(최초 dueAt)과 반복 규칙을 받아 horizonEnd(또는 endDate, 더 이른 쪽)까지
+ * 생성해야 할 인스턴스들의 dueAt(ISO string) 목록을 반환한다. baseDueAt 시각(시:분)은
+ * 모든 인스턴스에 동일하게 적용된다.
+ *
+ * - daily: 매일 하나씩
+ * - weekly: rule.weekdays에 해당하는 요일마다 하나씩 (0=일~6=토). baseDueAt의 요일이
+ *   weekdays에 포함되지 않으면 baseDueAt 자체는 결과에 포함되지 않을 수 있다(요일 규칙이
+ *   최우선 기준이므로) — 시작점은 baseDueAt이지만 실제 발생일은 요일 규칙을 따른다.
+ * - monthly: baseDueAt의 day(일)를 유지. 해당 월에 그 날짜가 없으면(예: 31일, 2월)
+ *   그 달의 마지막 날로 생성한다.
+ */
+export function generateRecurringDueDates(
+  baseDueAt: string,
+  rule: RecurrenceRule,
+  horizonEnd: Date,
+): string[] {
+  const base = new Date(baseDueAt);
+  if (Number.isNaN(base.getTime())) return [];
+
+  const effectiveEnd = endOfDay(resolveEffectiveEnd(rule, horizonEnd));
+  const baseDayStart = startOfDay(base);
+  const results: string[] = [];
+
+  if (rule.type === "daily") {
+    const cursor = new Date(baseDayStart);
+    while (cursor.getTime() <= effectiveEnd.getTime()) {
+      results.push(applyTimeOfDay(cursor, base).toISOString());
+      cursor.setDate(cursor.getDate() + 1);
+    }
+    return results;
+  }
+
+  if (rule.type === "weekly") {
+    const weekdays = rule.weekdays ?? [];
+    if (weekdays.length === 0) return [];
+    const cursor = new Date(baseDayStart);
+    while (cursor.getTime() <= effectiveEnd.getTime()) {
+      if (weekdays.includes(cursor.getDay())) {
+        results.push(applyTimeOfDay(cursor, base).toISOString());
+      }
+      cursor.setDate(cursor.getDate() + 1);
+    }
+    return results;
+  }
+
+  // monthly: baseDueAt의 day를 유지하되, 없는 날짜는 그 달의 마지막 날로 클램핑한다.
+  const day = base.getDate();
+  let year = base.getFullYear();
+  let month = base.getMonth();
+
+  for (;;) {
+    const lastDay = getLastDayOfMonth(year, month);
+    const occurrence = startOfDay(new Date(year, month, Math.min(day, lastDay)));
+    if (occurrence.getTime() > effectiveEnd.getTime()) break;
+    if (occurrence.getTime() >= baseDayStart.getTime()) {
+      results.push(applyTimeOfDay(occurrence, base).toISOString());
+    }
+    month += 1;
+    if (month > 11) {
+      month = 0;
+      year += 1;
+    }
+  }
+
+  return results;
+}

--- a/client/src/features/todo/utils/recurrenceSummary.ts
+++ b/client/src/features/todo/utils/recurrenceSummary.ts
@@ -1,0 +1,38 @@
+import type { RecurrenceRule } from "../types/todo.type";
+
+const WEEKDAY_LABELS = ["일", "월", "화", "수", "목", "금", "토"];
+
+/**
+ * 반복 규칙을 사람이 읽을 수 있는 한 줄 요약으로 변환하는 표시 전용 함수.
+ * (예: "매일 반복", "매주 월・수・금 반복", "매월 10일 반복")
+ *
+ * frontend-developer의 utils/recurrence.ts(인스턴스 생성 로직)와는 별개 파일로 분리했다 —
+ * 병합 충돌을 피하고, "생성 로직"과 "표시 로직"의 관심사를 분리하기 위함이다.
+ *
+ * monthly 요약은 RecurrenceRule 자체에 '일(day)' 정보가 없으므로(day는 dueAt에서 유도되는
+ * 값) 해당 인스턴스의 dueAt을 함께 받아 계산한다.
+ */
+export function formatRecurrenceSummary(
+  rule: RecurrenceRule,
+  dueAt: string | null,
+): string {
+  if (rule.type === "daily") {
+    return "매일 반복";
+  }
+
+  if (rule.type === "weekly") {
+    const days = (rule.weekdays ?? [])
+      .slice()
+      .sort((a, b) => a - b)
+      .map((d) => WEEKDAY_LABELS[d]);
+    if (days.length === 0) return "매주 반복";
+    return `매주 ${days.join("・")} 반복`;
+  }
+
+  // monthly
+  if (dueAt) {
+    const day = new Date(dueAt).getDate();
+    return `매월 ${day}일 반복`;
+  }
+  return "매월 반복";
+}

--- a/client/src/shared/ui/confirmModal/confirmModal.styles.tsx
+++ b/client/src/shared/ui/confirmModal/confirmModal.styles.tsx
@@ -63,6 +63,7 @@ const Message = styled.p`
   font-size: 14px;
   color: #666;
   line-height: 1.5;
+  white-space: pre-line;
 `;
 
 const ButtonGroup = styled.div`
@@ -99,6 +100,11 @@ const Button = styled.button<{ $variant?: "danger" | "cancel" }>`
       background-color: #f5f5f5;
     }
   `}
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
 
   ${media.mobile} {
     flex: 1;

--- a/client/src/shared/ui/confirmModal/confirmModal.tsx
+++ b/client/src/shared/ui/confirmModal/confirmModal.tsx
@@ -15,6 +15,8 @@ interface ConfirmModalProps {
   cancelText?: string;
   onConfirm: () => void;
   onCancel: () => void;
+  /** true면 "확인" 버튼을 disabled 처리 (mutation isPending 연동 등 중복 클릭 방지용) */
+  confirmDisabled?: boolean;
 }
 
 const ConfirmModal = ({
@@ -25,6 +27,7 @@ const ConfirmModal = ({
   cancelText = "취소",
   onConfirm,
   onCancel,
+  confirmDisabled = false,
 }: ConfirmModalProps) => {
   if (!isOpen) return null;
 
@@ -35,7 +38,7 @@ const ConfirmModal = ({
         <Message>{message}</Message>
         <ButtonGroup>
           <Button onClick={onCancel}>{cancelText}</Button>
-          <Button $variant="danger" onClick={onConfirm}>
+          <Button $variant="danger" onClick={onConfirm} disabled={confirmDisabled}>
             {confirmText}
           </Button>
         </ButtonGroup>

--- a/client/src/shared/ui/index.ts
+++ b/client/src/shared/ui/index.ts
@@ -10,3 +10,5 @@ export { ToastProvider } from "./toast/toastContext";
 export { useToast } from "./toast/useToast";
 export { default as BottomSheet } from "./bottomSheet/bottomSheet";
 export type { BottomSheetOption } from "./bottomSheet/bottomSheet";
+export { default as RecurrenceBadge } from "./recurrenceBadge/recurrenceBadge";
+export type { RecurrenceBadgeProps } from "./recurrenceBadge/recurrenceBadge";

--- a/client/src/shared/ui/recurrenceBadge/recurrenceBadge.styles.tsx
+++ b/client/src/shared/ui/recurrenceBadge/recurrenceBadge.styles.tsx
@@ -1,0 +1,19 @@
+import { styled } from "styled-components";
+import { colors } from "@/styles/colors";
+import { radius } from "@/styles/radius";
+
+// projectCard.styles.tsx의 OverdueBadge와 동일한 시각 패턴(padding/폰트/라운딩)을
+// 색상만 교체해 재정의한다 (todo 피처 전용 컴포넌트를 shared에서 직접 import하지 않기 위함).
+export const Badge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border-radius: ${radius.md};
+  background: ${colors.brand.background};
+  color: ${colors.brand.primary};
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+  flex-shrink: 0;
+`;

--- a/client/src/shared/ui/recurrenceBadge/recurrenceBadge.tsx
+++ b/client/src/shared/ui/recurrenceBadge/recurrenceBadge.tsx
@@ -1,0 +1,21 @@
+import { Repeat } from "lucide-react";
+import { Badge } from "./recurrenceBadge.styles";
+
+interface RecurrenceBadgeProps {
+  /** true면 아이콘만(스크린리더용 aria-label 필수), false(기본)면 "반복" 텍스트 포함 */
+  compact?: boolean;
+}
+
+/**
+ * 반복 할 일임을 나타내는 배지. kanban 카드, 캘린더 BottomSheet 등 여러 피처에서
+ * 공통으로 사용하므로 shared/ui에 둔다 (recurringTodo.spec.md 3-3절 근거).
+ */
+const RecurrenceBadge = ({ compact = false }: RecurrenceBadgeProps) => (
+  <Badge aria-label={compact ? "반복 할 일" : undefined}>
+    <Repeat size={12} aria-hidden="true" />
+    {!compact && <span>반복</span>}
+  </Badge>
+);
+
+export default RecurrenceBadge;
+export type { RecurrenceBadgeProps };

--- a/client/src/styles/colors.ts
+++ b/client/src/styles/colors.ts
@@ -2,6 +2,9 @@ export const colors = {
   brand: {
     primary: "#0F6E56",
     secondary: "#1D9E75",
+    // 반복(recurring) 배지/캘린더 하이라이트 배경. 캘린더 개편 스펙(DESIGN_SPEC.md)과
+    // recurringTodo.spec.md 양쪽에서 이미 동일 값을 리터럴로 참조하고 있어 토큰화한다.
+    background: "#E8F5EF",
   },
   danger: {
     main: "#E24B4A",


### PR DESCRIPTION
## Summary
- 매일/매주(요일)/매월 반복, 종료 조건(무기한/특정일), 시리즈 전체 수정·삭제를 지원하는 반복 할 일 기능 추가
- today/kanban/캘린더/할 일 목록 전반에 반복 인스턴스 노출·중복 방지 정책 반영
- 구현 후 발견된 버그 다수(Firestore undefined 저장 실패, 목록/캘린더 중복 노출, 타임존 경계 오판정 등) 회귀 테스트와 함께 수정
- 무기한 반복이 4주 호라이즌 이후 조용히 멈추는 문제를 서버 인프라 없이 클라이언트 lazy-extension으로 해결 (앱 진입 시 1회, 부족분만 이어서 생성)

## Test plan
- [x] `npm run test` — 21개 파일 157개 전부 통과
- [x] `npm run lint` — 에러 0
- [x] `npx tsc -b --noEmit` — 통과
- [x] `npm run build` — 성공
- [ ] 실제 브라우저에서 반복 할 일 생성/수정/삭제, kanban/캘린더/할 일 목록 노출 확인 (수동 QA 권장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)