### PR TITLE
fix: 반복 시리즈 수정 시 캘린더 중복 표시 및 타임존 버그 수정

### DIFF
--- a/client/src/features/todo/api/__tests__/recurringTodoApi.test.ts
+++ b/client/src/features/todo/api/__tests__/recurringTodoApi.test.ts
@@ -75,6 +75,7 @@ const emptyDocsSnapshot: { docs: { id: string; data: () => Record<string, unknow
 
 const makeBatch = () => ({
   set: vi.fn(),
+  update: vi.fn(),
   delete: vi.fn(),
   commit: vi.fn().mockResolvedValue(undefined),
 });
@@ -157,6 +158,33 @@ describe("createRecurringTodo", () => {
     created.forEach((t) => {
       expect(t.status).toBe("todo");
     });
+  });
+
+  it("생성한 인스턴스 문서 ID는 {recurrenceId}_{날짜} 형태로 결정론적이다 (멀티탭/멀티기기 동시 생성 시 중복 방지)", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    vi.mocked(getDocs).mockResolvedValueOnce(
+      emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+    );
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { createRecurringTodo } = await import("../todoApi");
+
+    const todo = makeTodo({
+      dueAt: "2026-07-10T09:00:00",
+      recurrence: dailyRule,
+    });
+    const horizonEnd = new Date("2026-07-12T00:00:00");
+
+    const created = await createRecurringTodo(todo, horizonEnd);
+
+    // recurrenceId는 createRecurringTodoImpl 내부에서 doc(todosRef).id로 딱 한 번 생성되므로
+    // 테스트 환경(autoIdCounter)에서는 "auto-1"로 고정된다.
+    expect(created.map((t) => t.id)).toEqual([
+      "auto-1_2026-07-10",
+      "auto-1_2026-07-11",
+      "auto-1_2026-07-12",
+    ]);
   });
 
   it("recurrence가 없으면 에러를 던진다", async () => {
@@ -303,6 +331,49 @@ describe("editRecurringSeries", () => {
     expect(batch.delete).not.toHaveBeenCalled();
   });
 
+  it("overdue 인스턴스 자신을 수정하면 삭제/재생성이 아니라 그 문서를 직접 갱신해 수정 내용이 반영된다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const pastIso = "2020-01-01T09:00:00";
+    const overdueInstance = makeTodo({
+      id: "overdue-1",
+      status: "todo",
+      description: "원래 설명",
+      dueAt: pastIso,
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(
+        toDocSnapshot([overdueInstance]) as ReturnType<typeof getDocs> extends Promise<infer T>
+          ? T
+          : never,
+      )
+      .mockResolvedValueOnce(
+        emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+      );
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { editRecurringSeries } = await import("../todoApi");
+
+    const seriesTodo = makeTodo({
+      id: "overdue-1",
+      status: "todo",
+      description: "수정된 설명",
+      dueAt: pastIso,
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+
+    await editRecurringSeries(seriesTodo, new Date("2026-08-01T00:00:00"));
+
+    expect(batch.delete).not.toHaveBeenCalled();
+    expect(batch.update).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ description: "수정된 설명" }),
+    );
+  });
+
   it("미래 todo 인스턴스는 삭제 후 새 규칙으로 재생성한다", async () => {
     const { getDocs, writeBatch } = await import("firebase/firestore");
     const now = new Date();
@@ -344,6 +415,50 @@ describe("editRecurringSeries", () => {
     expect(batch.delete).toHaveBeenCalledTimes(1);
     expect(batch.set).toHaveBeenCalled();
     expect(batch.commit).toHaveBeenCalledTimes(1);
+  });
+
+  it("재생성되는 인스턴스 문서 ID도 {recurrenceId}_{날짜} 형태로 결정론적이다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const now = new Date();
+    const futureIso = new Date(now.getTime() + 1000 * 60 * 60 * 24 * 3).toISOString();
+    const futureInstance = makeTodo({
+      id: "future-1",
+      status: "todo",
+      dueAt: futureIso,
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(
+        toDocSnapshot([futureInstance]) as ReturnType<typeof getDocs> extends Promise<infer T>
+          ? T
+          : never,
+      )
+      .mockResolvedValueOnce(
+        emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+      );
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { editRecurringSeries } = await import("../todoApi");
+
+    const seriesTodo = makeTodo({
+      id: "future-1",
+      status: "todo",
+      dueAt: futureIso,
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+
+    await editRecurringSeries(seriesTodo, new Date(now.getTime() + 1000 * 60 * 60 * 24 * 3));
+
+    const setCall = batch.set.mock.calls[0] as [{ id: string }, { dueAt: string }];
+    const [docRef] = setCall;
+    // toDateString()과 동일하게 로컬 타임존 기준 연-월-일로 키를 계산한다(구현과 동일한 방식으로 기대값 산출).
+    const d = new Date(futureIso);
+    const expectedDateKey = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    expect(docRef.id).toBe(`series-1_${expectedDateKey}`);
   });
 
   it("반복 OFF 전환(recurrence: null) 시 미래 todo 인스턴스만 삭제하고 재생성하지 않는다", async () => {
@@ -463,6 +578,151 @@ describe("editRecurringSeries", () => {
     const duplicatesForToday = createdDueDates.filter((d) => d.startsWith(todayDateStr));
     expect(duplicatesForToday).toHaveLength(0);
   });
+
+  it("doing 인스턴스 자신을 수정하면 삭제/재생성이 아니라 그 문서를 직접 갱신해 수정 내용이 반영된다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const now = new Date();
+    const todayIso = now.toISOString();
+
+    const doingInstance = makeTodo({
+      id: "doing-1",
+      status: "doing",
+      description: "원래 설명",
+      dueAt: todayIso,
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(
+        toDocSnapshot([doingInstance]) as ReturnType<typeof getDocs> extends Promise<infer T>
+          ? T
+          : never,
+      )
+      .mockResolvedValueOnce(
+        emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+      );
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { editRecurringSeries } = await import("../todoApi");
+
+    const horizonEnd = new Date(now.getTime() + 1000 * 60 * 60 * 24 * 10);
+    // 사용자가 doing 인스턴스를 열어 설명만 바꾸고 저장 (status/dueAt/recurrence는 그대로).
+    const seriesTodo = makeTodo({
+      id: "doing-1",
+      status: "doing",
+      description: "수정된 설명",
+      dueAt: todayIso,
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+
+    await editRecurringSeries(seriesTodo, horizonEnd);
+
+    // 보존 정책 때문에 삭제되면 안 되고
+    expect(batch.delete).not.toHaveBeenCalled();
+    // 수정 내용은 그 문서에 직접 반영되어야 한다 — 지금은 아무 곳에도 반영되지 않아 실패한다.
+    expect(batch.update).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ description: "수정된 설명" }),
+    );
+  });
+
+  it("보존된 인스턴스를 직접 갱신할 때도 userId는 클라이언트 입력이 아니라 getUserId()로 재계산한 값을 쓴다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const now = new Date();
+    const todayIso = now.toISOString();
+
+    const doingInstance = makeTodo({
+      id: "doing-1",
+      status: "doing",
+      dueAt: todayIso,
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(
+        toDocSnapshot([doingInstance]) as ReturnType<typeof getDocs> extends Promise<infer T>
+          ? T
+          : never,
+      )
+      .mockResolvedValueOnce(
+        emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+      );
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { editRecurringSeries } = await import("../todoApi");
+
+    const horizonEnd = new Date(now.getTime() + 1000 * 60 * 60 * 24 * 10);
+    // 다른 사용자의 userId를 흉내내 보내더라도 반영되면 안 된다.
+    const seriesTodo = makeTodo({
+      id: "doing-1",
+      status: "doing",
+      userId: "다른-사용자-id",
+      dueAt: todayIso,
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+
+    await editRecurringSeries(seriesTodo, horizonEnd);
+
+    expect(batch.update).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ userId: "test-user-id" }),
+    );
+  });
+
+  it("보존된 인스턴스의 마감일을 다른 보존된 인스턴스가 이미 점유한 날짜로 바꾸면 에러를 던진다(중복 재현 방지)", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const now = new Date();
+    const todayIso = now.toISOString();
+    const pastIso = "2020-01-01T09:00:00";
+
+    // 오늘 날짜의 doing 인스턴스와, 지난 overdue 인스턴스가 같은 시리즈에 공존.
+    const doingInstance = makeTodo({
+      id: "doing-1",
+      status: "doing",
+      dueAt: todayIso,
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+    const overdueInstance = makeTodo({
+      id: "overdue-1",
+      status: "todo",
+      dueAt: pastIso,
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+
+    vi.mocked(getDocs).mockResolvedValueOnce(
+      toDocSnapshot([doingInstance, overdueInstance]) as ReturnType<
+        typeof getDocs
+      > extends Promise<infer T>
+        ? T
+        : never,
+    );
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { editRecurringSeries } = await import("../todoApi");
+
+    // overdue-1을 열어 마감일을 doing-1이 이미 점유한 오늘 날짜로 옮기려는 시도.
+    const seriesTodo = makeTodo({
+      id: "overdue-1",
+      status: "todo",
+      dueAt: todayIso,
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+
+    await expect(
+      editRecurringSeries(seriesTodo, new Date(now.getTime() + 1000 * 60 * 60 * 24 * 10)),
+    ).rejects.toThrow();
+    expect(batch.update).not.toHaveBeenCalled();
+  });
 });
 
 describe("deleteRecurringSeries", () => {
@@ -573,6 +833,47 @@ describe("extendIndefiniteRecurringSeries", () => {
     const createdDueDates = batch.set.mock.calls.map((call) => (call[1] as { dueAt: string }).dueAt);
     expect(createdDueDates.every((d) => new Date(d).getTime() > new Date(latestExisting.dueAt as string).getTime())).toBe(true);
     expect(batch.commit).toHaveBeenCalledTimes(1);
+
+    // 생성된 인스턴스 문서 ID도 {recurrenceId}_{날짜} 형태로 결정론적이어야 한다.
+    const setDocRefs = batch.set.mock.calls.map((call) => call[0] as { id: string });
+    expect(setDocRefs.map((ref) => ref.id)).toEqual([
+      "series-1_2026-07-13",
+      "series-1_2026-07-14",
+      "series-1_2026-07-15",
+    ]);
+  });
+
+  it("editRecurringSeries와 동일한 recurrenceId+날짜에 대해 항상 같은 문서 ID를 계산한다 (멀티탭/멀티기기에서 동시에 실행돼도 같은 문서로 수렴)", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const latestExisting = makeTodo({
+      id: "latest-1",
+      status: "todo",
+      dueAt: "2026-07-12T09:00:00",
+      recurrenceId: "series-1",
+      recurrence: dailyRule,
+    });
+    const horizonEnd = new Date("2026-07-15T00:00:00");
+
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(
+        toDocSnapshot([latestExisting]) as ReturnType<typeof getDocs> extends Promise<infer T>
+          ? T
+          : never,
+      )
+      .mockResolvedValueOnce(
+        emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+      );
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { extendIndefiniteRecurringSeries } = await import("../todoApi");
+    await extendIndefiniteRecurringSeries(horizonEnd);
+
+    // editRecurringSeries 쪽 테스트("재생성되는 인스턴스 문서 ID도 ... 결정론적이다")와 별개로 실행되지만,
+    // 같은 recurrenceId("series-1")·같은 날짜(2026-07-13)에 대해 항상 같은 문자열 ID를 계산하므로
+    // 두 함수가 서로 다른 탭/기기에서 이 날짜에 대해 동시에 문서를 만들어도 하나의 문서로 수렴한다.
+    const firstDocRef = batch.set.mock.calls[0][0] as { id: string };
+    expect(firstDocRef.id).toBe("series-1_2026-07-13");
   });
 
   it("이미 새 호라이즌까지 채워져 있으면 아무것도 생성하지 않는다", async () => {

--- a/client/src/features/todo/api/todoApi.ts
+++ b/client/src/features/todo/api/todoApi.ts
@@ -11,6 +11,7 @@ import {
   writeBatch,
 } from "firebase/firestore";
 import { db, auth } from "@/shared/lib/firebase";
+import { toDateKeyFromISO } from "@/shared/utils/date";
 import type { RecurrenceRule, Todo } from "../types/todo.type";
 import { generateRecurringDueDates, getDefaultHorizonEnd } from "../utils/recurrence";
 
@@ -24,6 +25,20 @@ const getUserId = () => {
 
 const mapDocToTodo = (id: string, data: Record<string, unknown>): Todo =>
   ({ id, ...data }) as Todo;
+
+/**
+ * 반복 인스턴스 문서 ID를 {recurrenceId}_{YYYY-MM-DD}로 결정론적으로 만든다(로컬 타임존
+ * 기준 연-월-일 — 코드베이스 전반의 toDateString() 기반 "같은 날짜" 판정과 동일 기준).
+ *
+ * createRecurringTodo/editRecurringSeries/extendIndefiniteRecurringSeries는 서로 다른
+ * 탭·기기에서 겹쳐 실행될 수 있는데(withRecurringSeriesLock은 탭 내부만 직렬화), 인스턴스를
+ * 매번 새 자동생성 ID로 만들면 같은 recurrenceId·같은 날짜에 대해 두 문서가 동시에 생성될 수
+ * 있다. ID 자체를 recurrenceId+날짜로 고정하면 Firestore 문서 ID의 유일성이 곧 "같은
+ * 날짜엔 항상 같은 문서"를 보장하므로, 여러 곳에서 동시에 써도(batch.set은 없으면 생성,
+ * 있으면 덮어쓰는 upsert) 마지막에 커밋된 내용으로 수렴할 뿐 중복 문서가 생기지 않는다.
+ */
+const buildRecurringInstanceId = (recurrenceId: string, dueAt: string): string =>
+  `${recurrenceId}_${toDateKeyFromISO(dueAt)}`;
 
 /**
  * 반복 시리즈를 읽고(getDocs) 판단한 뒤 batch로 쓰는 함수들(createRecurringTodo,
@@ -308,7 +323,7 @@ const createRecurringTodoImpl = async (
   const created: Todo[] = [];
 
   for (const dueAt of dueDates) {
-    const newDocRef = doc(todosRef);
+    const newDocRef = doc(db, "todos", buildRecurringInstanceId(recurrenceId, dueAt));
     const instanceData = {
       ...todoData,
       userId,
@@ -401,6 +416,53 @@ const editRecurringSeriesImpl = async (
       .map((t) => new Date(t.dueAt as string).toDateString()),
   );
 
+  // 지금 수정 중인 인스턴스 자신이 "doing" 또는 overdue(todo && dueAt < 오늘)라서
+  // 위 toDelete에서 보존 대상으로 빠졌다면, 그 문서는 삭제/재생성되지 않아 사용자가
+  // 방금 입력한 수정 내용(제목/설명/마감일 등)이 반영될 곳이 없다. 이 문서만 예외적으로
+  // 직접 갱신한다. status/doneAt은 원본을 그대로 유지해 진행 상태를 잃지 않는다.
+  // done 인스턴스(이미 완료된 과거 기록)는 대상에서 제외 — 완료된 회차는 그대로 보존한다.
+  const editedOriginal = seriesTodos.find((t) => t.id === seriesTodo.id);
+  const editedIsPreserved =
+    !!editedOriginal &&
+    (editedOriginal.status === "doing" ||
+      (editedOriginal.status === "todo" &&
+        !!editedOriginal.dueAt &&
+        new Date(editedOriginal.dueAt).getTime() < todayStart.getTime()));
+
+  if (editedIsPreserved) {
+    if (seriesTodo.dueAt) {
+      // 다른 보존된(done/doing/overdue) 형제 인스턴스가 이미 점유한 날짜로 마감일을
+      // 옮기면, 그 문서와 지금 갱신하는 문서가 같은 날짜에 공존해 캘린더 중복이
+      // 재현되므로 미리 막는다.
+      const newDateKey = new Date(seriesTodo.dueAt).toDateString();
+      const collidesWithOtherPreserved = seriesTodos.some(
+        (t) =>
+          t.id !== seriesTodo.id &&
+          !toDeleteIds.has(t.id) &&
+          !!t.dueAt &&
+          new Date(t.dueAt).toDateString() === newDateKey,
+      );
+      if (collidesWithOtherPreserved) {
+        throw new Error(
+          "이미 다른 인스턴스가 있는 날짜로는 마감일을 변경할 수 없습니다",
+        );
+      }
+    }
+
+    const {
+      id: _editedId,
+      recurrenceId: _editedRid,
+      status: _s,
+      doneAt: _d,
+      userId: _uid,
+      ...editableRest
+    } = seriesTodo;
+    batch.update(doc(db, "todos", seriesTodo.id), { ...editableRest, userId, updatedAt: now });
+    if (seriesTodo.dueAt) {
+      preservedDateKeys.add(new Date(seriesTodo.dueAt).toDateString());
+    }
+  }
+
   const newRecurrence = seriesTodo.recurrence;
 
   if (newRecurrence) {
@@ -422,7 +484,7 @@ const editRecurringSeriesImpl = async (
     const { id: _id, recurrenceId: _rid, ...rest } = seriesTodo;
 
     dueDates.forEach((dueAt) => {
-      const newDocRef = doc(todosRef);
+      const newDocRef = doc(db, "todos", buildRecurringInstanceId(recurrenceId, dueAt));
       batch.set(newDocRef, {
         ...rest,
         userId,
@@ -529,7 +591,7 @@ const extendIndefiniteRecurringSeriesImpl = async (horizonEnd: Date): Promise<vo
     const { id: _id, ...rest } = latest;
 
     newDueDates.forEach((dueAt) => {
-      const newDocRef = doc(todosRef);
+      const newDocRef = doc(db, "todos", buildRecurringInstanceId(recurrenceId, dueAt));
       batch.set(newDocRef, {
         ...rest,
         userId,

--- a/client/src/features/todo/components/todoDetail/todoDetail.tsx
+++ b/client/src/features/todo/components/todoDetail/todoDetail.tsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 import { useTodoDetail, useTodo } from "../../hooks";
 import type { Todo } from "../../types";
 import { X } from "lucide-react";
-import { useToast, ConfirmModal } from "@/shared";
+import { useToast, ConfirmModal, toDatetimeLocalValue } from "@/shared";
 import RecurrenceFields from "../recurrence/recurrenceFields";
 import { getRecurrenceValidationError } from "../recurrence/recurrenceValidation";
 import { toFormValue, toRecurrenceRule } from "../recurrence/recurrenceTransform";
@@ -79,12 +79,8 @@ const TodoDetail = () => {
           description: todo.description || "",
           status: todo.status,
           priority: todo.priority,
-          startAt: todo.startAt
-            ? new Date(todo.startAt).toISOString().slice(0, 16)
-            : "",
-          dueAt: todo.dueAt
-            ? new Date(todo.dueAt).toISOString().slice(0, 16)
-            : "",
+          startAt: todo.startAt ? toDatetimeLocalValue(todo.startAt) : "",
+          dueAt: todo.dueAt ? toDatetimeLocalValue(todo.dueAt) : "",
         }
       : undefined,
   });
@@ -358,7 +354,7 @@ const TodoDetail = () => {
         isOpen={isSeriesConfirmOpen}
         title="반복 일정 전체 수정"
         message={
-          "이 변경은 앞으로의 일정에만 적용됩니다.\n\n진행 중이거나 완료된 일정, 이미 지난 미완료 일정은 그대로 유지됩니다."
+          "이 변경은 앞으로의 일정과 지금 수정 중인 일정에 적용됩니다.\n\n그 외 이미 완료됐거나 진행 중/지난 다른 회차는 그대로 유지됩니다."
         }
         confirmText="전체 적용"
         cancelText="취소"

--- a/client/src/features/todo/components/todoForm/todoForm.tsx
+++ b/client/src/features/todo/components/todoForm/todoForm.tsx
@@ -2,7 +2,7 @@ import { useForm } from "react-hook-form";
 import { useEffect, useMemo, useState } from "react";
 
 import { useTodo } from "../../hooks";
-import { useToast, ConfirmModal } from "@/shared";
+import { useToast, ConfirmModal, toDatetimeLocalValue } from "@/shared";
 import type { RecurrenceRule, Todo } from "../../types";
 import RecurrenceFields from "../recurrence/recurrenceFields";
 import { getRecurrenceValidationError } from "../recurrence/recurrenceValidation";
@@ -48,12 +48,8 @@ const TodoForm = ({ todo, parentId, initialDueAt, onClose }: TodoFormProps) => {
           title: todo.title,
           description: todo.description,
           priority: todo.priority,
-          startAt: todo.startAt
-            ? new Date(todo.startAt).toISOString().slice(0, 16)
-            : undefined,
-          dueAt: todo.dueAt
-            ? new Date(todo.dueAt).toISOString().slice(0, 16)
-            : undefined,
+          startAt: todo.startAt ? toDatetimeLocalValue(todo.startAt) : undefined,
+          dueAt: todo.dueAt ? toDatetimeLocalValue(todo.dueAt) : undefined,
         }
       : initialDueAt
         ? { dueAt: initialDueAt }
@@ -308,7 +304,7 @@ const TodoForm = ({ todo, parentId, initialDueAt, onClose }: TodoFormProps) => {
         isOpen={isSeriesConfirmOpen}
         title="반복 일정 전체 수정"
         message={
-          "이 변경은 앞으로의 일정에만 적용됩니다.\n\n진행 중이거나 완료된 일정, 이미 지난 미완료 일정은 그대로 유지됩니다."
+          "이 변경은 앞으로의 일정과 지금 수정 중인 일정에 적용됩니다.\n\n그 외 이미 완료됐거나 진행 중/지난 다른 회차는 그대로 유지됩니다."
         }
         confirmText="전체 적용"
         cancelText="취소"

--- a/client/src/shared/utils/__tests__/date.test.ts
+++ b/client/src/shared/utils/__tests__/date.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { toDatetimeLocalValue } from "../date";
+
+describe("toDatetimeLocalValue", () => {
+  // CI(ubuntu-latest)는 TZ 미설정 시 UTC로 실행되는데, UTC 환경에서는 로컬 시각과 UTC 시각이
+  // 같아서 new Date(iso).toISOString().slice(0,16)(버그가 있던 예전 구현)도 우연히 같은 값을
+  // 반환해 회귀를 못 잡는다. UTC와 다른 타임존(Asia/Seoul, UTC+9)을 명시적으로 고정해야
+  // 이 테스트가 실제로 의미를 가진다.
+  let originalTz: string | undefined;
+
+  beforeAll(() => {
+    originalTz = process.env.TZ;
+    process.env.TZ = "Asia/Seoul";
+  });
+
+  afterAll(() => {
+    process.env.TZ = originalTz;
+  });
+
+  it("ISO 문자열을 로컬 타임존 기준 'yyyy-MM-ddTHH:mm'으로 되돌린다", () => {
+    // 로컬 2026-07-10 08:30을 저장(UTC ISO 변환)했다가 다시 불러오는 왕복 시나리오.
+    // UTC보다 시간이 빠른 타임존(예: Asia/Seoul, UTC+9)에서 이 시각을 UTC 기준으로 잘못
+    // 읽으면 날짜가 전날(07-09)로 밀린다 — 이 테스트는 그 회귀를 방지한다.
+    const local = new Date(2026, 6, 10, 8, 30);
+    const iso = local.toISOString();
+
+    expect(toDatetimeLocalValue(iso)).toBe("2026-07-10T08:30");
+  });
+
+  it("자정에 가까운 시각도 날짜가 밀리지 않는다", () => {
+    const local = new Date(2026, 6, 10, 0, 5);
+    const iso = local.toISOString();
+
+    expect(toDatetimeLocalValue(iso)).toBe("2026-07-10T00:05");
+  });
+
+  it("한 자리 시/분/월/일도 두 자리로 패딩한다", () => {
+    const local = new Date(2026, 0, 5, 9, 7);
+    const iso = local.toISOString();
+
+    expect(toDatetimeLocalValue(iso)).toBe("2026-01-05T09:07");
+  });
+});

--- a/client/src/shared/utils/date.ts
+++ b/client/src/shared/utils/date.ts
@@ -19,6 +19,19 @@ export const toDateKey = (date: Date): string => {
 /** ISO 문자열을 로컬 타임존 기준 "yyyy-MM-dd" 키로 변환한다. */
 export const toDateKeyFromISO = (iso: string): string => toDateKey(new Date(iso));
 
+/**
+ * ISO 문자열을 <input type="datetime-local">에 넣을 로컬 타임존 기준
+ * "yyyy-MM-ddTHH:mm" 값으로 변환한다. `new Date(iso).toISOString().slice(0, 16)`은
+ * UTC 시각을 반환하므로, UTC보다 시간이 빠른 타임존(예: Asia/Seoul)에서 자정 근처
+ * 시각을 다루면 날짜가 하루 전으로 밀려 보이는 문제가 있다.
+ */
+export const toDatetimeLocalValue = (iso: string): string => {
+  const d = new Date(iso);
+  const hours = `${d.getHours()}`.padStart(2, "0");
+  const minutes = `${d.getMinutes()}`.padStart(2, "0");
+  return `${toDateKey(d)}T${hours}:${minutes}`;
+};
+
 export const isSameLocalDay = (a: Date, b: Date): boolean =>
   a.getFullYear() === b.getFullYear() &&
   a.getMonth() === b.getMonth() &&

--- a/client/src/shared/utils/index.ts
+++ b/client/src/shared/utils/index.ts
@@ -5,6 +5,7 @@ export {
   parseLocalDateOnly,
   toDateKey,
   toDateKeyFromISO,
+  toDatetimeLocalValue,
   isSameLocalDay,
   getWeekDates,
 } from "./date";


### PR DESCRIPTION
## Summary
- 반복 시리즈 수정 시 doing/overdue 인스턴스 자신은 보존 정책에 걸려 갱신되지 않고 그대로 남아, 새로 생성된 인스턴스와 함께 캘린더에 중복 표시되던 버그 수정 (보존 대상이면 삭제 대신 `batch.update`로 직접 갱신)
- 반복 인스턴스 문서 ID를 `{recurrenceId}_{YYYY-MM-DD}` 형태로 결정론적으로 생성해, 멀티탭/멀티기기에서 동시에 시리즈를 수정·확장해도 같은 날짜의 문서가 하나로 수렴하도록 수정 (기존 뮤텍스는 탭 내부만 직렬화해 여러 탭/기기 간 레이스는 막지 못했음)
- 수정 폼의 `datetime-local` 입력이 UTC 기준으로 값을 채워, UTC보다 빠른 타임존(Asia/Seoul 등)에서 마감일이 하루 전으로 보이던 버그 수정
- 코드리뷰 반영: `batch.update` 분기가 `userId`를 클라이언트 입력값 그대로 신뢰하던 문제, 보존된 형제 인스턴스와 날짜가 충돌할 수 있는 엣지케이스 가드, CI(UTC)에서 실제로 검증되지 않던 타임존 회귀 테스트 수정

## Test plan
- [x] 신규/기존 유닛테스트 168개 통과 (`npm run test`)
- [x] `TZ=UTC npm run test`로 CI 환경과 동일한 조건에서도 168개 통과 확인
- [x] `npm run lint` — 0 errors (기존 무관 warning 1건만 존재)
- [x] `npx tsc --noEmit` — 에러 없음
- [ ] 실제 브라우저에서 doing/overdue 반복 인스턴스 수정 후 캘린더에 중복 표시 없는지 수동 확인
- [ ] 실제 브라우저에서 마감일 수정 화면 열었을 때 날짜/시간이 로컬 타임존 기준으로 정확히 표시되는지 수동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)