### PR TITLE
feat: 투두 상세페이지에 삭제 버튼 추가

### DIFF
--- a/client/src/features/todo/components/todoDetail/todoDetail.styles.tsx
+++ b/client/src/features/todo/components/todoDetail/todoDetail.styles.tsx
@@ -213,23 +213,35 @@ const InfoValue = styled.span`
 
 const PanelFooter = styled.div`
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
+  align-items: center;
   gap: 12px;
   padding: 16px 24px;
   border-top: 1px solid ${colors.border.tertiary};
 
   ${media.mobile} {
     padding: 12px 16px;
-    flex-direction: column-reverse;
   }
 `;
 
-const Button = styled.button<{ $variant?: "primary" | "secondary" }>`
+const PanelFooterActions = styled.div`
+  display: flex;
+  gap: 12px;
+  margin-left: auto;
+
+  ${media.mobile} {
+    flex-direction: column-reverse;
+    width: 100%;
+  }
+`;
+
+const Button = styled.button<{ $variant?: "primary" | "secondary" | "danger" }>`
   padding: 10px 20px;
   font-size: 14px;
   font-weight: 500;
   border-radius: 8px;
   cursor: pointer;
+  min-height: 44px;
   transition: background-color 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
 
   &:focus-visible {
@@ -255,7 +267,24 @@ const Button = styled.button<{ $variant?: "primary" | "secondary" }>`
       box-shadow: 0 1px 2px rgba(15, 110, 86, 0.15);
     }
   `
-      : `
+      : $variant === "danger"
+        ? `
+    background-color: white;
+    color: ${colors.danger.text};
+    border: 1px solid ${colors.border.danger};
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+
+    &:hover {
+      background-color: ${colors.danger.background};
+    }
+
+    &:active {
+      background-color: ${colors.danger.subtle};
+    }
+  `
+        : `
     background-color: white;
     color: ${colors.text.secondary};
     border: 1px solid ${colors.border.secondary};
@@ -334,6 +363,7 @@ export {
   InfoLabel,
   InfoValue,
   PanelFooter,
+  PanelFooterActions,
   Button,
   StatusBadge,
   PriorityBadge,

--- a/client/src/features/todo/components/todoDetail/todoDetail.tsx
+++ b/client/src/features/todo/components/todoDetail/todoDetail.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { useTodoDetail, useTodo } from "../../hooks";
 import type { Todo } from "../../types";
-import { X } from "lucide-react";
+import { X, Trash2 } from "lucide-react";
 import { useToast, ConfirmModal, toDatetimeLocalValue } from "@/shared";
 import RecurrenceFields from "../recurrence/recurrenceFields";
 import { getRecurrenceValidationError } from "../recurrence/recurrenceValidation";
@@ -16,6 +16,7 @@ import {
   PanelTitle,
   PanelContent,
   PanelFooter,
+  PanelFooterActions,
   CloseButton,
   FormContainer,
   InfoRow,
@@ -62,6 +63,7 @@ const TodoDetail = () => {
     useCreateRecurringTodo,
     useEditRecurringSeries,
     useDeleteTodo,
+    useDeleteRecurringSeries,
     useGetTodos,
   } = useTodo();
   const { data: allTodos } = useGetTodos;
@@ -121,6 +123,7 @@ const TodoDetail = () => {
 
   const [isSeriesConfirmOpen, setIsSeriesConfirmOpen] = useState(false);
   const [pendingSeriesUpdate, setPendingSeriesUpdate] = useState<Todo | null>(null);
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
 
   const handleClose = () => {
     if (window.history.state?.idx > 0) {
@@ -133,6 +136,40 @@ const TodoDetail = () => {
   const closeSeriesConfirm = () => {
     setIsSeriesConfirmOpen(false);
     setPendingSeriesUpdate(null);
+  };
+
+  const handleConfirmDelete = () => {
+    if (!todo) return;
+    const title = todo.title;
+
+    // todoList.tsx의 삭제 분기와 동일하게, 반복 시리즈면 recurrenceId 기준으로 전체
+    // 시리즈를 지우고, 아니면 단일 문서만 지운다.
+    if (todo.recurrenceId) {
+      useDeleteRecurringSeries.mutate(todo.recurrenceId, {
+        onSuccess: () => {
+          toast.success("삭제 완료", `"${title}" 반복 일정이 모두 삭제되었습니다`);
+          setIsDeleteConfirmOpen(false);
+          handleClose();
+        },
+        onError: () => {
+          toast.error("삭제 실패", "삭제 중 오류가 발생했습니다");
+          setIsDeleteConfirmOpen(false);
+        },
+      });
+      return;
+    }
+
+    useDeleteTodo.mutate(todo.id, {
+      onSuccess: () => {
+        toast.success("삭제 완료", `"${title}"이(가) 삭제되었습니다`);
+        setIsDeleteConfirmOpen(false);
+        handleClose();
+      },
+      onError: () => {
+        toast.error("삭제 실패", "삭제 중 오류가 발생했습니다");
+        setIsDeleteConfirmOpen(false);
+      },
+    });
   };
 
   const handleConfirmSeriesEdit = () => {
@@ -349,12 +386,23 @@ const TodoDetail = () => {
         </PanelContent>
 
         <PanelFooter>
-          <Button type="button" onClick={handleClose}>
-            취소
+          <Button
+            type="button"
+            $variant="danger"
+            onClick={() => setIsDeleteConfirmOpen(true)}
+            aria-label="할 일 삭제"
+          >
+            <Trash2 size={16} />
+            삭제
           </Button>
-          <Button type="submit" form="todo-detail-form" $variant="primary">
-            저장
-          </Button>
+          <PanelFooterActions>
+            <Button type="button" onClick={handleClose}>
+              취소
+            </Button>
+            <Button type="submit" form="todo-detail-form" $variant="primary">
+              저장
+            </Button>
+          </PanelFooterActions>
         </PanelFooter>
       </Panel>
 
@@ -369,6 +417,21 @@ const TodoDetail = () => {
         confirmDisabled={useEditRecurringSeries.isPending}
         onConfirm={handleConfirmSeriesEdit}
         onCancel={closeSeriesConfirm}
+      />
+
+      <ConfirmModal
+        isOpen={isDeleteConfirmOpen}
+        title="할 일 삭제"
+        message={
+          todo.recurrenceId
+            ? `"${todo.title}"은(는) 반복 일정입니다.\n\n삭제하면 이 반복 시리즈의 모든 일정이 함께 삭제됩니다.`
+            : `"${todo.title}"을(를) 삭제하시겠습니까?`
+        }
+        confirmText="삭제"
+        cancelText="취소"
+        confirmDisabled={useDeleteTodo.isPending || useDeleteRecurringSeries.isPending}
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setIsDeleteConfirmOpen(false)}
       />
     </>
   );


### PR DESCRIPTION
## Summary
- 상세페이지에서도 할 일을 삭제할 수 있도록 `PanelFooter`에 삭제 버튼 추가
- 반복 시리즈 삭제 시 `useDeleteRecurringSeries`, 단일 삭제 시 `useDeleteTodo`로 분기 (목록 화면 `todoList.tsx`의 기존 분기 로직 재사용, 신규 로직 없음)
- 확인 모달은 기존 `ConfirmModal` 컴포넌트와 안내 문구를 재사용
- 삭제 버튼은 왼쪽, 취소/저장은 오른쪽으로 분리 배치(`space-between`)해 오조작 방지
- danger 버튼은 기존 `colors.danger.*` 토큰 재사용 (신규 색상 정의 없음)

## Test plan
- [x] `npm run lint` 통과
- [x] `npm run test -- --run` 189개 테스트 전부 통과
- [x] `npm run build` 타입체크/빌드 정상
- [ ] 브라우저에서 단일 삭제 / 반복 시리즈 삭제 시나리오 수동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)