### PR TITLE
feat: 모바일 칸반보드에 상태 변경 액션시트 추가

### DIFF
--- a/client/src/features/kanban/components/__tests__/kanbanCardMenu.test.tsx
+++ b/client/src/features/kanban/components/__tests__/kanbanCardMenu.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import KanbanCardMenu from "../kanbanCardMenu";
+
+describe("KanbanCardMenu 컴포넌트", () => {
+  it("버튼 클릭 시 상태 변경 바텀시트가 열려야 한다", async () => {
+    const user = userEvent.setup();
+    render(<KanbanCardMenu status="todo" onSelect={vi.fn()} />);
+
+    await user.click(screen.getByLabelText("상태 변경 메뉴 열기"));
+
+    expect(screen.getByText("상태 변경")).toBeInTheDocument();
+  });
+
+  it("현재 상태(todo)는 선택지에서 제외되고 나머지 상태만 노출되어야 한다", async () => {
+    const user = userEvent.setup();
+    render(<KanbanCardMenu status="todo" onSelect={vi.fn()} />);
+
+    await user.click(screen.getByLabelText("상태 변경 메뉴 열기"));
+
+    expect(screen.queryByText("할 일")).not.toBeInTheDocument();
+    expect(screen.getByText("진행 중")).toBeInTheDocument();
+    expect(screen.getByText("완료")).toBeInTheDocument();
+  });
+
+  it("상태 선택 시 onSelect가 선택한 값과 함께 호출되어야 한다", async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+    render(<KanbanCardMenu status="doing" onSelect={onSelect} />);
+
+    await user.click(screen.getByLabelText("상태 변경 메뉴 열기"));
+    await user.click(screen.getByText("완료"));
+
+    expect(onSelect).toHaveBeenCalledWith("done");
+  });
+
+  it("버튼 클릭 이벤트는 상위 요소로 전파되지 않아야 한다 (카드 네비게이션과 충돌 방지)", async () => {
+    const onCardClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <div onClick={onCardClick}>
+        <KanbanCardMenu status="todo" onSelect={vi.fn()} />
+      </div>,
+    );
+
+    await user.click(screen.getByLabelText("상태 변경 메뉴 열기"));
+
+    expect(onCardClick).not.toHaveBeenCalled();
+  });
+
+  it("백드롭(오버레이) 클릭 시 카드의 onClick(네비게이션)이 발동하지 않아야 한다", async () => {
+    // BottomSheet는 createPortal로 document.body에 렌더링되지만 React 포털은
+    // DOM 트리가 아닌 React 컴포넌트 트리로 이벤트가 버블링된다. 배경(overlay)을
+    // 탭해서 시트를 닫을 때 클릭 이벤트가 상위 카드의 onClick(상세 페이지 이동)까지
+    // 전파되면 안 된다.
+    const onCardClick = vi.fn();
+    const user = userEvent.setup();
+    const { container } = render(
+      <div onClick={onCardClick}>
+        <KanbanCardMenu status="todo" onSelect={vi.fn()} />
+      </div>,
+    );
+
+    await user.click(screen.getByLabelText("상태 변경 메뉴 열기"));
+    expect(screen.getByText("상태 변경")).toBeInTheDocument();
+
+    // 포털로 document.body에 직접 추가된 오버레이 엘리먼트를 찾는다
+    // (RTL이 렌더링에 사용한 container와는 다른 body의 자식 노드).
+    const overlay = Array.from(document.body.children).find(
+      (el) => el !== container,
+    ) as HTMLElement | undefined;
+    expect(overlay).toBeTruthy();
+
+    await user.click(overlay!);
+
+    expect(onCardClick).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/features/kanban/components/kanbanBoard.styles.tsx
+++ b/client/src/features/kanban/components/kanbanBoard.styles.tsx
@@ -79,6 +79,15 @@ const ItemTitleRow = styled.div`
   gap: 6px;
 `;
 
+// 제목/배지 영역과 모바일 전용 "..." 액션시트 버튼을 한 줄에 배치한다.
+// 버튼은 항상 우측 상단에 고정되도록 align-items: flex-start.
+const ItemContentRow = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 4px;
+`;
+
 const DragOverlayItem = styled.div`
   background: #fff;
   border-radius: 8px;
@@ -156,6 +165,7 @@ export {
   ParentLabel,
   ItemTitle,
   ItemTitleRow,
+  ItemContentRow,
   DragOverlayItem,
   MobileTabContainer,
   MobileTabButton,

--- a/client/src/features/kanban/components/kanbanBoard.tsx
+++ b/client/src/features/kanban/components/kanbanBoard.tsx
@@ -1,9 +1,9 @@
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { DndContext, DragOverlay, closestCenter } from "@dnd-kit/core";
-import { useTodo } from "@/features/todo";
+import { useTodo, type Todo } from "@/features/todo";
 import { useMediaQuery, KanbanSkeleton } from "@/shared";
-import KanbanColumn from "./kanbanColumn";
+import KanbanColumn, { type Status } from "./kanbanColumn";
 import { useKanbanDrag } from "../hooks/useKanbanDrag";
 import { isVisibleInKanban } from "../utils/kanbanFilters";
 import { collapseRecurringInstances } from "@/features/todo";
@@ -69,39 +69,33 @@ const KanbanBoard = () => {
     }
   };
 
+  // 모바일(태블릿 이하)에서는 활성 탭 컬럼 1개만 DOM에 존재해 dnd-kit 드래그로
+  // 다른 상태로 옮길 수 없다. 카드의 "..." 액션시트에서 상태를 선택하면 기존
+  // 드래그와 동일한 useUpdateTodo mutation을 재사용해 상태를 변경한다.
+  const handleStatusChange = (todo: Todo, status: Status) => {
+    if (todo.status === status) return;
+    useUpdateTodo.mutate({ ...todo, status });
+  };
+
+  const tabColumnMap: Record<KanbanTab, { title: string; todos: Todo[] }> = {
+    todo: { title: "To Do", todos: todoList },
+    doing: { title: "Doing", todos: doingList },
+    done: { title: "Done", todos: doneList },
+  };
+
   const renderActiveColumn = () => {
-    switch (activeTab) {
-      case "todo":
-        return (
-          <KanbanColumn
-            title="To Do"
-            status="todo"
-            todos={todoList}
-            allTodos={todos ?? []}
-            onNavigate={handleNavigate}
-          />
-        );
-      case "doing":
-        return (
-          <KanbanColumn
-            title="Doing"
-            status="doing"
-            todos={doingList}
-            allTodos={todos ?? []}
-            onNavigate={handleNavigate}
-          />
-        );
-      case "done":
-        return (
-          <KanbanColumn
-            title="Done"
-            status="done"
-            todos={doneList}
-            allTodos={todos ?? []}
-            onNavigate={handleNavigate}
-          />
-        );
-    }
+    const { title, todos: activeTodos } = tabColumnMap[activeTab];
+    return (
+      <KanbanColumn
+        title={title}
+        status={activeTab}
+        todos={activeTodos}
+        allTodos={todos ?? []}
+        onNavigate={handleNavigate}
+        isMobile={isTablet}
+        onStatusChange={handleStatusChange}
+      />
+    );
   };
 
   if (isLoading) {

--- a/client/src/features/kanban/components/kanbanCardMenu.styles.tsx
+++ b/client/src/features/kanban/components/kanbanCardMenu.styles.tsx
@@ -1,0 +1,32 @@
+import { styled } from "styled-components";
+
+// 카드 우측 상단 "..." 액션시트 트리거. 인터랙티브 요소 터치 타겟 최소 44px 확보를
+// 위해 버튼 자체 크기를 44x44로 잡되, 아이콘은 시각적으로 작게 유지한다.
+// 상단 마진은 ParentLabel의 margin-bottom(4px)과 정확히 맞춰, 하위 할 일 카드에서
+// 버튼의 히트 영역이 ParentLabel 쪽으로 침범하지 않도록 한다.
+const MenuButton = styled.button`
+  flex-shrink: 0;
+  width: 44px;
+  height: 44px;
+  margin: -4px -10px 0 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  border-radius: 8px;
+  color: #5e6c84;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+
+  &:hover {
+    background-color: #eceff3;
+    color: #172b4d;
+  }
+
+  &:active {
+    background-color: #e3e6ea;
+  }
+`;
+
+export { MenuButton };

--- a/client/src/features/kanban/components/kanbanCardMenu.tsx
+++ b/client/src/features/kanban/components/kanbanCardMenu.tsx
@@ -1,0 +1,67 @@
+import { useState, useCallback } from "react";
+import { MoreVertical } from "lucide-react";
+import { BottomSheet, type BottomSheetOption } from "@/shared";
+import { statusMeta, ALL_STATUSES } from "@/styles/statusMeta";
+import { MenuButton } from "./kanbanCardMenu.styles";
+import type { Status } from "./kanbanColumn";
+
+interface KanbanCardMenuProps {
+  status: Status;
+  onSelect: (status: Status) => void;
+}
+
+// 모바일 칸반 카드용 상태 변경 액션시트. 태블릿 이하 뷰포트에서는 컬럼이 1개만
+// 렌더링되어 dnd-kit 드래그로 상태를 옮길 수 없기 때문에(kanbanBoard.tsx), 카드
+// 자체에 "..." 버튼을 노출해 바텀시트에서 상태를 고를 수 있게 한다.
+const KanbanCardMenu = ({ status, onSelect }: KanbanCardMenuProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const options: BottomSheetOption<Status>[] = ALL_STATUSES.filter(
+    (candidate) => candidate !== status,
+  ).map((candidate) => ({
+    value: candidate,
+    label: statusMeta[candidate].label,
+    icon: statusMeta[candidate].icon,
+  }));
+
+  const handleOpen = (event: React.MouseEvent) => {
+    // 카드 자체의 onClick(상세 페이지 이동)으로 버블링되는 것을 막는다.
+    event.stopPropagation();
+    setIsOpen(true);
+  };
+
+  // onClose가 매 렌더마다 새로 생성되면 BottomSheet 내부의 handleClose와 그에
+  // 의존하는 ESC keydown 이펙트가 렌더마다 재실행된다. setIsOpen은 안정적인
+  // setter이므로 빈 deps로 고정한다.
+  const handleClose = useCallback(() => setIsOpen(false), []);
+
+  // dnd-kit의 드래그 리스너(onPointerDown/onTouchStart)가 카드 루트 엘리먼트에
+  // 걸려 있어, 버튼을 누르는 시점에 드래그가 함께 시작되지 않도록 전파를 막는다.
+  const stopDndPropagation = (event: React.SyntheticEvent) => {
+    event.stopPropagation();
+  };
+
+  return (
+    <>
+      <MenuButton
+        type="button"
+        aria-label="상태 변경 메뉴 열기"
+        onClick={handleOpen}
+        onPointerDown={stopDndPropagation}
+        onTouchStart={stopDndPropagation}
+      >
+        <MoreVertical size={18} />
+      </MenuButton>
+
+      <BottomSheet
+        isOpen={isOpen}
+        onClose={handleClose}
+        title="상태 변경"
+        options={options}
+        onSelect={onSelect}
+      />
+    </>
+  );
+};
+
+export default KanbanCardMenu;

--- a/client/src/features/kanban/components/kanbanColumn.tsx
+++ b/client/src/features/kanban/components/kanbanColumn.tsx
@@ -20,6 +20,8 @@ interface KanbanColumnProps {
   todos: Todo[];
   allTodos: Todo[];
   onNavigate: (id: string) => void;
+  isMobile?: boolean;
+  onStatusChange?: (todo: Todo, status: Status) => void;
 }
 
 const getEmptyMessage = (status: Status) => {
@@ -50,6 +52,8 @@ const KanbanColumn = ({
   todos,
   allTodos,
   onNavigate,
+  isMobile = false,
+  onStatusChange,
 }: KanbanColumnProps) => {
   const { setNodeRef, isOver } = useDroppable({
     id: status,
@@ -86,6 +90,8 @@ const KanbanColumn = ({
                 todo={todo}
                 parentTitle={getParentTitle(todo.parentId)}
                 onNavigate={onNavigate}
+                isMobile={isMobile}
+                onStatusChange={onStatusChange}
               />
             ))
           )}

--- a/client/src/features/kanban/components/kanbanItem.tsx
+++ b/client/src/features/kanban/components/kanbanItem.tsx
@@ -1,16 +1,33 @@
+import { useCallback } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type { Todo } from "@/features/todo";
 import { RecurrenceBadge } from "@/shared";
-import { KanbanItemStyled, ParentLabel, ItemTitle, ItemTitleRow } from "./kanbanBoard.styles";
+import KanbanCardMenu from "./kanbanCardMenu";
+import type { Status } from "./kanbanColumn";
+import {
+  KanbanItemStyled,
+  ParentLabel,
+  ItemTitle,
+  ItemTitleRow,
+  ItemContentRow,
+} from "./kanbanBoard.styles";
 
 interface KanbanItemProps {
   todo: Todo;
   parentTitle?: string;
   onNavigate: (id: string) => void;
+  isMobile?: boolean;
+  onStatusChange?: (todo: Todo, status: Status) => void;
 }
 
-const KanbanItem = ({ todo, parentTitle, onNavigate }: KanbanItemProps) => {
+const KanbanItem = ({
+  todo,
+  parentTitle,
+  onNavigate,
+  isMobile = false,
+  onStatusChange,
+}: KanbanItemProps) => {
   const {
     attributes,
     listeners,
@@ -25,20 +42,40 @@ const KanbanItem = ({ todo, parentTitle, onNavigate }: KanbanItemProps) => {
     transition,
   };
 
+  // 모바일(태블릿 이하)에서는 탭 하나의 컬럼만 DOM에 존재해 드래그로 상태를 옮길 수
+  // 없다(kanbanBoard.tsx). 드래그 리스너를 그대로 붙여두면 사용자가 드래그를
+  // 시도해도 아무 것도 저장되지 않고 스냅백만 되므로, 카드의 "..." 액션시트로
+  // 대체된 모바일에서는 리스너 자체를 적용하지 않는다.
+  const dragListeners = isMobile ? undefined : listeners;
+
+  // BottomSheet의 onSelect deps로 흘러들어가는 콜백을 안정화한다(카드마다 별도로
+  // 마운트되는 BottomSheet가 렌더마다 내부 이펙트를 재실행하지 않도록).
+  const handleStatusSelect = useCallback(
+    (status: Status) => {
+      onStatusChange?.(todo, status);
+    },
+    [onStatusChange, todo],
+  );
+
   return (
     <KanbanItemStyled
       ref={setNodeRef}
       style={style}
       $isDragging={isDragging}
       {...attributes}
-      {...listeners}
+      {...dragListeners}
       onClick={() => onNavigate(todo.id)}
     >
       {parentTitle && <ParentLabel>{parentTitle}</ParentLabel>}
-      <ItemTitleRow>
-        <ItemTitle>{todo.title}</ItemTitle>
-        {todo.recurrenceId != null && <RecurrenceBadge />}
-      </ItemTitleRow>
+      <ItemContentRow>
+        <ItemTitleRow>
+          <ItemTitle>{todo.title}</ItemTitle>
+          {todo.recurrenceId != null && <RecurrenceBadge />}
+        </ItemTitleRow>
+        {isMobile && onStatusChange && (
+          <KanbanCardMenu status={todo.status} onSelect={handleStatusSelect} />
+        )}
+      </ItemContentRow>
     </KanbanItemStyled>
   );
 };

--- a/client/src/features/todo/components/todoListItem/statusSelect.tsx
+++ b/client/src/features/todo/components/todoListItem/statusSelect.tsx
@@ -3,29 +3,18 @@ import { Circle, Loader, CheckCircle, ChevronDown } from "lucide-react";
 import { BottomSheet, type BottomSheetOption } from "@/shared";
 import { StatusButton, StatusIcon, StatusLabel } from "./statusSelect.styles";
 import { statusColors, type Status } from "../../../../styles/statusColors";
+import { statusMeta, ALL_STATUSES } from "../../../../styles/statusMeta";
 
 interface StatusSelectProps {
   value: Status;
   onChange: (value: Status) => void;
 }
 
-const statusOptions: BottomSheetOption<Status>[] = [
-  {
-    value: "todo",
-    label: "할 일",
-    icon: <Circle size={18} color={statusColors.todo.main} />,
-  },
-  {
-    value: "doing",
-    label: "진행 중",
-    icon: <Loader size={18} color={statusColors.doing.main} />,
-  },
-  {
-    value: "done",
-    label: "완료",
-    icon: <CheckCircle size={18} color={statusColors.done.main} />,
-  },
-];
+const statusOptions: BottomSheetOption<Status>[] = ALL_STATUSES.map((status) => ({
+  value: status,
+  label: statusMeta[status].label,
+  icon: statusMeta[status].icon,
+}));
 
 const getStatusInfo = (status: Status) => {
   const colors = statusColors[status];

--- a/client/src/shared/ui/bottomSheet/bottomSheet.styles.tsx
+++ b/client/src/shared/ui/bottomSheet/bottomSheet.styles.tsx
@@ -48,6 +48,8 @@ const Container = styled.div<{ $isClosing: boolean }>`
   display: flex;
   flex-direction: column;
   animation: ${({ $isClosing }) => ($isClosing ? slideDown : slideUp)} 0.3s ease forwards;
+  /* 닫힘 애니메이션 중 옵션을 연타해서 onSelect가 중복 호출되지 않도록 방지 */
+  pointer-events: ${({ $isClosing }) => ($isClosing ? "none" : "auto")};
 
   @media (min-width: 481px) {
     width: 400px;

--- a/client/src/shared/ui/bottomSheet/bottomSheet.tsx
+++ b/client/src/shared/ui/bottomSheet/bottomSheet.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { Check } from "lucide-react";
 import {
@@ -40,25 +40,44 @@ const BottomSheet = <T extends string>({
   children,
 }: BottomSheetProps<T>) => {
   const [isClosing, setIsClosing] = useState(false);
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleClose = useCallback(() => {
     setIsClosing(true);
-    setTimeout(() => {
+    closeTimeoutRef.current = setTimeout(() => {
       setIsClosing(false);
       onClose();
     }, 200);
   }, [onClose]);
 
+  // 언마운트 시(예: 낙관적 업데이트로 카드가 목록에서 즉시 사라지는 경우) 타이머가
+  // 정리되지 않고 누수되는 것을 방지한다.
+  useEffect(() => {
+    return () => {
+      if (closeTimeoutRef.current) {
+        clearTimeout(closeTimeoutRef.current);
+      }
+    };
+  }, []);
+
   const handleSelect = useCallback(
     (value: T) => {
+      // 닫힘 애니메이션(200ms) 도중에는 옵션 클릭을 무시해 onSelect가 중복 호출되는
+      // 것을 막는다.
+      if (isClosing) return;
       onSelect?.(value);
       handleClose();
     },
-    [onSelect, handleClose]
+    [onSelect, handleClose, isClosing]
   );
 
   const handleOverlayClick = useCallback(
     (e: React.MouseEvent) => {
+      // BottomSheet는 createPortal로 document.body에 렌더링되지만 React 포털은
+      // DOM 트리가 아닌 React 컴포넌트 트리로 이벤트가 버블링된다. stopPropagation을
+      // 호출하지 않으면 배경(overlay) 클릭이 BottomSheet를 사용하는 컴포넌트의 상위
+      // 요소(예: 칸반 카드의 onClick 네비게이션)까지 계속 전파된다.
+      e.stopPropagation();
       if (e.target === e.currentTarget) {
         handleClose();
       }

--- a/client/src/styles/statusMeta.tsx
+++ b/client/src/styles/statusMeta.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+import { Circle, Loader, CheckCircle } from "lucide-react";
+import { statusColors, type Status } from "./statusColors";
+
+export interface StatusMeta {
+  label: string;
+  icon: ReactNode;
+}
+
+// 상태값 → 라벨/아이콘(18px) 매핑. kanbanCardMenu(상태 변경 액션시트)와
+// statusSelect(할 일 상세 상태 선택)에서 동일한 옵션 목록을 표시하기 위해 공유한다.
+export const statusMeta: Record<Status, StatusMeta> = {
+  todo: {
+    label: "할 일",
+    icon: <Circle size={18} color={statusColors.todo.main} />,
+  },
+  doing: {
+    label: "진행 중",
+    icon: <Loader size={18} color={statusColors.doing.main} />,
+  },
+  done: {
+    label: "완료",
+    icon: <CheckCircle size={18} color={statusColors.done.main} />,
+  },
+};
+
+export const ALL_STATUSES = Object.keys(statusMeta) as Status[];


### PR DESCRIPTION
## Summary
- 모바일에서는 활성 탭 컬럼 1개만 DOM에 존재해 dnd-kit 드래그로 다른 상태로 카드를 옮길 수 없었습니다. 카드에 "..." 버튼을 추가해 바텀시트에서 상태(할 일/진행 중/완료)를 직접 선택할 수 있게 했고, 모바일에서는 어차피 동작하지 않던 드래그 리스너를 비활성화했습니다.
- 8개 앵글 병렬 코드 리뷰(+검증) 과정에서 발견된 이슈를 함께 수정했습니다:
  - BottomSheet 백드롭 클릭 시 포털 이벤트가 카드 onClick으로 전파되어 의도치 않게 상세페이지로 이동하던 버그
  - 닫힘 애니메이션(200ms) 중 연속 선택 시 상태 변경 mutation이 두 번 발생하던 버그
  - 언마운트 시 BottomSheet 닫힘 타이머 누수
  - 하위 할 일 카드에서 메뉴 버튼과 부모 라벨의 탭 영역이 겹치던 문제
  - kanbanCardMenu / statusSelect에 중복돼있던 상태 라벨·아이콘 맵을 `statusMeta.tsx`로 통합

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test -- --run` (194개 테스트 통과, 백드롭 회귀 테스트 포함)
- [x] `npm run build`
- [ ] 실제 계정으로 모바일 뷰포트에서 육안 확인 (로그인 필요해 자동화 확인은 못함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)