### PR TITLE
feat: 캘린더 하루 다건 시 +N개 표시 및 바텀시트 연결

### DIFF
--- a/client/src/features/dashboard/components/__tests__/calendar.test.tsx
+++ b/client/src/features/dashboard/components/__tests__/calendar.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeAll } from 'vitest'
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Calendar from '../calendar'
@@ -82,5 +82,48 @@ describe('Calendar 하루 다건 "+N개" 표시', () => {
     expect(screen.getAllByText(/마감:/).length).toBeGreaterThan(0)
     // FullCalendar 기본 팝오버는 열리지 않아야 한다
     expect(document.querySelector('.fc-popover')).toBeNull()
+  })
+})
+
+// dueAt은 UTC Z 문자열로 저장되므로(todoForm이 toISOString 사용), KST에서
+// 자정~오전 9시 마감은 UTC 날짜가 전날이 된다. 캘린더가 UTC 기준으로 날짜를
+// 뽑으면 마감일 전날 셀에 표시되는 회귀를 막는다. CI는 UTC라서 TZ를 비-UTC로
+// 고정해야 실제로 검증된다.
+describe('Calendar 타임존: 자정 마감 할 일', () => {
+  let originalTz: string | undefined
+  let savedTodos: (typeof mockTodos)[number][]
+
+  beforeAll(() => {
+    originalTz = process.env.TZ
+    process.env.TZ = 'Asia/Seoul'
+    savedTodos = [...mockTodos]
+  })
+
+  afterAll(() => {
+    process.env.TZ = originalTz
+    mockTodos.splice(0, mockTodos.length, ...savedTodos)
+  })
+
+  it('KST 자정 마감(UTC로는 전날) 할 일이 마감일 셀에 표시된다', async () => {
+    const now = new Date()
+    const y = now.getFullYear()
+    const m = now.getMonth()
+    const d = now.getDate()
+    const kstMidnight = new Date(y, m, d, 0, 0) // KST 자정
+    const dueDateKey = `${y}-${String(m + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`
+
+    mockTodos.splice(0, mockTodos.length, {
+      ...savedTodos[0],
+      id: 'midnight-todo',
+      title: '자정 마감 할 일',
+      startAt: null,
+      dueAt: kstMidnight.toISOString(), // 전날 15:00Z
+    })
+
+    renderCalendar()
+    await screen.findByText('자정 마감 할 일')
+
+    const dueCell = document.querySelector(`[data-date="${dueDateKey}"]`)
+    expect(dueCell?.textContent).toContain('자정 마감 할 일')
   })
 })

--- a/client/src/features/dashboard/components/__tests__/calendar.test.tsx
+++ b/client/src/features/dashboard/components/__tests__/calendar.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import Calendar from '../calendar'
+
+vi.mock('@/shared/lib/firebase', () => ({
+  db: {},
+  auth: { currentUser: null },
+  googleProvider: {},
+}))
+
+const { mockTodos } = vi.hoisted(() => {
+  const d = new Date()
+  const todayStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
+    d.getDate(),
+  ).padStart(2, '0')}`
+  const makeTodo = (i: number) => ({
+    id: `todo-${i}`,
+    userId: 'user-1',
+    title: `할 일 ${i}번`,
+    status: 'todo' as const,
+    priority: 'medium' as const,
+    startAt: null,
+    dueAt: todayStr,
+    doneAt: null,
+    parentId: null,
+    order: i,
+    recurrence: null,
+    recurrenceId: null,
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+  })
+  return { mockTodos: [1, 2, 3, 4, 5].map(makeTodo) }
+})
+
+vi.mock('@/features/todo', () => ({
+  useTodo: () => ({
+    useGetTodos: { data: mockTodos, isLoading: false, isError: false },
+    useUpdateTodoDueAt: { mutate: vi.fn() },
+  }),
+  TodoForm: () => null,
+}))
+
+vi.mock('@/shared', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/shared')>()
+  return {
+    ...actual,
+    useToast: () => ({ error: vi.fn(), success: vi.fn() }),
+  }
+})
+
+const renderCalendar = () =>
+  render(
+    <MemoryRouter>
+      <Calendar />
+    </MemoryRouter>,
+  )
+
+describe('Calendar 하루 다건 "+N개" 표시', () => {
+  beforeAll(() => {
+    // jsdom에는 ResizeObserver가 없다
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  })
+
+  it('하루에 할 일이 많으면 "+N개" more 링크가 표시된다', async () => {
+    renderCalendar()
+    const moreLink = await screen.findByText(/\+\d+개/)
+    expect(moreLink).toBeInTheDocument()
+  })
+
+  it('"+N개" 클릭 시 FC 기본 팝오버 대신 바텀시트가 열린다', async () => {
+    renderCalendar()
+    const moreLink = await screen.findByText(/\+\d+개/)
+    fireEvent.click(moreLink)
+
+    // 바텀시트가 열려 그 날짜의 목록 + 추가 버튼이 보인다
+    expect(await screen.findByText('이 날짜에 할 일 추가')).toBeInTheDocument()
+    expect(screen.getAllByText(/마감:/).length).toBeGreaterThan(0)
+    // FullCalendar 기본 팝오버는 열리지 않아야 한다
+    expect(document.querySelector('.fc-popover')).toBeNull()
+  })
+})

--- a/client/src/features/dashboard/components/__tests__/calendar.test.tsx
+++ b/client/src/features/dashboard/components/__tests__/calendar.test.tsx
@@ -85,6 +85,42 @@ describe('Calendar 하루 다건 "+N개" 표시', () => {
   })
 })
 
+// 구버전 생성 경로(일반/하위 할 일)는 폼 값을 정규화 없이 저장해서 시작일을
+// 비워두면 startAt이 null이 아니라 ""(빈 문자열)로 저장됐다. 캘린더가 ??로
+// null만 거르면 ""가 이벤트 시작일이 되어 FC가 이벤트를 통째로 버린다.
+describe('Calendar 빈 문자열 startAt 방어', () => {
+  let saved: (typeof mockTodos)[number][]
+
+  beforeAll(() => {
+    saved = [...mockTodos]
+  })
+
+  afterAll(() => {
+    mockTodos.splice(0, mockTodos.length, ...saved)
+  })
+
+  it('startAt이 ""로 저장된 마감일 전용 할 일이 마감일 셀에 표시된다', async () => {
+    const d = new Date()
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
+      d.getDate(),
+    ).padStart(2, '0')}`
+
+    mockTodos.splice(0, mockTodos.length, {
+      ...saved[0],
+      id: 'empty-start-todo',
+      title: '빈 시작일 할 일',
+      startAt: '',
+      dueAt: `${key}T00:00`, // 구버전 생성 경로의 raw datetime-local 형식
+    } as unknown as (typeof mockTodos)[number])
+
+    renderCalendar()
+    await screen.findByText('빈 시작일 할 일')
+
+    const dueCell = document.querySelector(`[data-date="${key}"]`)
+    expect(dueCell?.textContent).toContain('빈 시작일 할 일')
+  })
+})
+
 // dueAt은 UTC Z 문자열로 저장되므로(todoForm이 toISOString 사용), KST에서
 // 자정~오전 9시 마감은 UTC 날짜가 전날이 된다. 캘린더가 UTC 기준으로 날짜를
 // 뽑으면 마감일 전날 셀에 표시되는 회귀를 막는다. CI는 UTC라서 TZ를 비-UTC로

--- a/client/src/features/dashboard/components/calendar.styles.tsx
+++ b/client/src/features/dashboard/components/calendar.styles.tsx
@@ -35,7 +35,8 @@ const CalendarContainer = styled.div`
 
   .fc-daygrid-more-link {
     font-size: 11px;
-    color: #666;
+    font-weight: 600;
+    color: #5f6368;
   }
 
   /* 날짜 셀 클릭 가능하도록 */
@@ -80,8 +81,10 @@ const CalendarContainer = styled.div`
       display: none !important;
     }
 
+    /* 모바일: 얇은 바만으로는 건수 구분이 안 되므로 "+N개"로 개수를 알린다 */
     .fc-daygrid-more-link {
-      display: none !important;
+      font-size: 10px;
+      padding: 0 2px;
     }
   }
 `;

--- a/client/src/features/dashboard/components/calendar.tsx
+++ b/client/src/features/dashboard/components/calendar.tsx
@@ -73,7 +73,7 @@ const Calendar = () => {
     today.setHours(0, 0, 0, 0);
 
     return todos
-      ?.filter((todo: Todo) => todo.startAt !== null || todo.dueAt !== null)
+      ?.filter((todo: Todo) => !!todo.startAt || !!todo.dueAt)
       .map((todo: Todo) => {
         const overdue =
           todo.dueAt !== null &&
@@ -82,7 +82,10 @@ const Calendar = () => {
 
         // FullCalendar all-day 형식 (date-only 문자열)
         // end는 배타적이므로 dueAt 다음 날로 설정해야 dueAt 당일이 표시됨
-        const startSrc = todo.startAt ?? todo.dueAt ?? null;
+        // 구버전 생성 경로가 시작일 미입력을 null이 아닌 ""로 저장한 문서가 있어
+        // ??(null만 거름) 대신 ||로 falsy를 함께 걸러야 한다. ""가 시작일로
+        // 넘어가면 FC가 이벤트를 통째로 버려 캘린더에서 사라진다.
+        const startSrc = todo.startAt || todo.dueAt || null;
         const startDate = startSrc ? toLocalDateOnly(startSrc) : null;
         let endDate: string | null = null;
         if (todo.startAt && todo.dueAt) {

--- a/client/src/features/dashboard/components/calendar.tsx
+++ b/client/src/features/dashboard/components/calendar.tsx
@@ -270,7 +270,12 @@ const Calendar = () => {
           displayEventTime={false}
           dateClick={handleDateClick}
           eventClick={handleEventClick}
-          dayMaxEvents={true}
+          /* 높이 기반 자동(true)은 이벤트 바가 압축된 이 앱(특히 모바일 6px 바)에서는
+             현실적인 건수(3~6건)로 임계치에 닿지 않아 +N개가 표시되지 않는다.
+             디자인 스펙(최대 3개 + +N)대로 고정 상한을 사용한다.
+             주간 뷰는 세로 공간이 충분하므로 높이 기반 자동을 유지한다. */
+          dayMaxEvents={3}
+          views={{ dayGridWeek: { dayMaxEvents: true } }}
           moreLinkContent={(arg) => `+${arg.num}개`}
           moreLinkClick={handleMoreLinkClick}
           moreLinkHint={(num) => `할 일 ${num}개 더 보기`}

--- a/client/src/features/dashboard/components/calendar.tsx
+++ b/client/src/features/dashboard/components/calendar.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTodo, TodoForm } from "@/features/todo";
 import type { Todo } from "@/features/todo";
-import type { EventInput, EventClickArg, EventContentArg } from "@fullcalendar/core/index.js";
+import type { EventInput, EventClickArg, EventContentArg, MoreLinkArg } from "@fullcalendar/core/index.js";
 import type { DateClickArg } from "@fullcalendar/interaction";
 import type { EventDropArg } from "@fullcalendar/core";
 import {
@@ -131,6 +131,16 @@ const Calendar = () => {
   const handleDateClick = useCallback((info: DateClickArg) => {
     setSelectedDate(info.dateStr);
     setIsBottomSheetOpen(true);
+  }, []);
+
+  const handleMoreLinkClick = useCallback((info: MoreLinkArg) => {
+    // FC 마커 날짜는 UTC 필드에 달력 날짜를 담고 있으므로 UTC로 읽어야
+    // 사용자 타임존과 무관하게 올바른 날짜가 된다
+    setSelectedDate(info.date.toISOString().slice(0, 10));
+    setIsBottomSheetOpen(true);
+    // void 반환 시 FC 기본 팝오버가, 뷰 이름 문자열 반환 시 뷰 전환(zoomTo)이
+    // 일어난다. 둘 다 막는 공식 반환값이 없어 truthy 비문자열을 반환한다
+    return true as unknown as string;
   }, []);
 
   const handleEventClick = useCallback((info: EventClickArg) => {
@@ -260,6 +270,10 @@ const Calendar = () => {
           displayEventTime={false}
           dateClick={handleDateClick}
           eventClick={handleEventClick}
+          dayMaxEvents={true}
+          moreLinkContent={(arg) => `+${arg.num}개`}
+          moreLinkClick={handleMoreLinkClick}
+          moreLinkHint={(num) => `할 일 ${num}개 더 보기`}
           eventContent={renderEventContent}
           editable={true}
           eventDrop={handleEventDrop}

--- a/client/src/features/dashboard/components/calendar.tsx
+++ b/client/src/features/dashboard/components/calendar.tsx
@@ -44,6 +44,18 @@ function toLocalDateStr(date: Date): string {
   return `${y}-${m}-${d}`;
 }
 
+/**
+ * datetime 문자열 → 로컬 타임존 기준 "YYYY-MM-DD".
+ * dueAt/startAt은 UTC Z 문자열로 저장되므로(todoForm이 toISOString 사용)
+ * split("T")로 자르면 UTC 날짜가 나온다 — KST에서 자정~오전 9시 마감이
+ * 전날로 밀리는 원인. 반드시 로컬 타임존으로 변환해서 날짜를 뽑는다.
+ * "T"가 없는 date-only 문자열은 이미 달력 날짜이므로 그대로 반환한다.
+ */
+function toLocalDateOnly(dateTimeStr: string): string {
+  if (!dateTimeStr.includes("T")) return dateTimeStr;
+  return toLocalDateStr(new Date(dateTimeStr));
+}
+
 const Calendar = () => {
   const calendarRef = useRef<FullCalendar>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -70,10 +82,11 @@ const Calendar = () => {
 
         // FullCalendar all-day 형식 (date-only 문자열)
         // end는 배타적이므로 dueAt 다음 날로 설정해야 dueAt 당일이 표시됨
-        const startDate = (todo.startAt ?? todo.dueAt ?? null)?.split("T")[0] ?? null;
+        const startSrc = todo.startAt ?? todo.dueAt ?? null;
+        const startDate = startSrc ? toLocalDateOnly(startSrc) : null;
         let endDate: string | null = null;
         if (todo.startAt && todo.dueAt) {
-          const [y, mo, d] = todo.dueAt.split("T")[0].split("-").map(Number);
+          const [y, mo, d] = toLocalDateOnly(todo.dueAt).split("-").map(Number);
           endDate = toLocalDateStr(new Date(y, mo - 1, d + 1));
         }
 
@@ -109,20 +122,22 @@ const Calendar = () => {
 
   const selectedDateTodos = useMemo(() => {
     if (!selectedDate || !todos) return [];
-    const selected = new Date(selectedDate);
 
+    // selectedDate는 "YYYY-MM-DD" — 같은 형식의 로컬 날짜 문자열끼리 비교한다
+    // (사전순 비교가 날짜순과 일치). 격자(events)와 동일한 로컬 기준이어야
+    // 셀에 보이는 항목과 바텀시트 목록이 어긋나지 않는다.
     return todos.filter((todo: Todo) => {
       if (!todo.startAt && !todo.dueAt) return false;
 
-      const start = todo.startAt ? new Date(todo.startAt.split("T")[0]) : null;
-      const end = todo.dueAt ? new Date(todo.dueAt.split("T")[0]) : null;
+      const start = todo.startAt ? toLocalDateOnly(todo.startAt) : null;
+      const end = todo.dueAt ? toLocalDateOnly(todo.dueAt) : null;
 
       // 시작일만 있는 경우
-      if (start && !end) return start.getTime() === selected.getTime();
+      if (start && !end) return start === selectedDate;
       // 종료일만 있는 경우
-      if (!start && end) return end.getTime() === selected.getTime();
+      if (!start && end) return end === selectedDate;
       // 둘 다 있는 경우: 시작일 <= 선택일 <= 종료일
-      if (start && end) return selected >= start && selected <= end;
+      if (start && end) return selectedDate >= start && selectedDate <= end;
 
       return false;
     });

--- a/client/src/features/dashboard/components/calendar.tsx
+++ b/client/src/features/dashboard/components/calendar.tsx
@@ -276,6 +276,10 @@ const Calendar = () => {
              주간 뷰는 세로 공간이 충분하므로 높이 기반 자동을 유지한다. */
           dayMaxEvents={3}
           views={{ dayGridWeek: { dayMaxEvents: true } }}
+          /* 기본 정렬(긴 이벤트 우선)은 기간 바가 상단 3개 슬롯을 독점해
+             마감일만 있는 단일일 할 일이 전부 +N개 뒤로 숨는다.
+             짧은 이벤트 우선으로 마감일 항목이 항상 해당 날짜에 노출되게 한다. */
+          eventOrder="duration,start,title"
           moreLinkContent={(arg) => `+${arg.num}개`}
           moreLinkClick={handleMoreLinkClick}
           moreLinkHint={(num) => `할 일 ${num}개 더 보기`}

--- a/client/src/features/todo/components/todoForm/todoForm.tsx
+++ b/client/src/features/todo/components/todoForm/todoForm.tsx
@@ -206,10 +206,16 @@ const TodoForm = ({ todo, parentId, initialDueAt, onClose }: TodoFormProps) => {
       });
     } else if (parentId) {
       // 자식 todo 생성 (반복 설정 대상 아님)
+      // 빈 datetime-local 값은 null이 아닌 ""라서 그대로 저장하면 캘린더 등
+      // ?? 기반 소비처가 오동작한다 — 다른 경로처럼 ISO/null로 정규화한다
       useCreateChildTodo.mutate(
         {
           parentId,
-          todo: data,
+          todo: {
+            ...data,
+            startAt: data.startAt ? new Date(data.startAt).toISOString() : null,
+            dueAt: dueAtIso,
+          },
         },
         {
           onSuccess: () => {
@@ -242,8 +248,13 @@ const TodoForm = ({ todo, parentId, initialDueAt, onClose }: TodoFormProps) => {
         }
       );
     } else {
-      // 일반 todo 생성
-      useCreateTodo.mutate(data as Todo, {
+      // 일반 todo 생성 — 빈 datetime-local 값("")을 null로, 값은 ISO로 정규화
+      useCreateTodo.mutate(
+        {
+          ...data,
+          startAt: data.startAt ? new Date(data.startAt).toISOString() : null,
+          dueAt: dueAtIso,
+        } as Todo, {
         onSuccess: () => {
           toast.success("추가 완료", `"${data.title}" 할 일이 추가되었습니다`);
           onClose?.();


### PR DESCRIPTION
## 개요

캘린더에서 하루에 할 일이 여러 개 있는지 유저가 알 수 없던 문제(특히 모바일은 6px 바만 표시)를 FullCalendar `dayMaxEvents`(최대 3개) + "+N개" 링크 + 기존 날짜 바텀시트 연결로 해결합니다. PM·디자이너·UI 담당 의견 수렴 결과 채택된 안(업계 표준 "최대 N개 + more" 패턴)입니다.

## 변경 사항

### 기능 (1cc9682)
- `dayMaxEvents={3}`: 하루 4건 이상이면 상위 3개 + "+N개" 링크로 축약 (주간 뷰는 세로 공간이 충분해 높이 기반 자동 유지)
- "+N개" 클릭 시 FC 기본 팝오버 대신 기존 날짜 바텀시트 오픈 (FC 6.1.19는 팝오버·뷰전환을 둘 다 막는 공식 반환값이 없어 truthy 비문자열 반환으로 우회, 주석에 근거 기록)
- `moreLinkHint`로 스크린리더 힌트 한글화, 모바일에서 more 링크 숨기던 CSS 제거

### 구현 과정에서 발견·수정한 버그 4건
- **d2dfcc3**: `dayMaxEvents={true}`(높이 기반)는 압축된 이벤트 바 때문에 실데이터에서 발동하지 않음 → 고정 상한 3
- **a2c4dec**: FC 기본 정렬(긴 이벤트 우선)로 기간 바가 슬롯을 독점해 마감일-only 항목이 전부 접힘 → `eventOrder="duration,start,title"`
- **688b096**: 캘린더만 `split("T")[0]`(UTC 날짜)를 써서 KST 자정~오전 마감이 전날 셀에 표시 → 로컬 타임존 변환으로 통일 (투데이와 불일치 해소)
- **39ee746**: 구 생성 경로가 `startAt: ""`(빈 문자열)를 저장해 캘린더에서 이벤트가 통째로 드롭 → 읽기 방어(`||`) + 쓰기 정규화(ISO/null). 기존 `""` 데이터도 마이그레이션 없이 표시됨

## 테스트

- 유닛 테스트 198개 통과 — 신규 4개: "+N개" 표시, 팝오버 억제+바텀시트 오픈, `TZ=Asia/Seoul` 강제 고정 타임존 회귀, 빈 문자열 `startAt` 회귀
- UTC / America/New_York 타임존 환경에서도 통과, 린트·빌드 정상
- 동일 FC 버전+CSS 실브라우저 재현 페이지로 데스크톱/모바일 동작 검증

상세 트러블슈팅 기록은 Notion 개발 기록 > 트러블슈팅 DB 참고.

🤖 Generated with [Claude Code](https://claude.com/claude-code)