### PR TITLE
fix: 하위 항목 없는 루트 투두의 마감일 초과 배지 미표시 버그 수정

### DIFF
--- a/client/src/features/todo/components/todoList.tsx
+++ b/client/src/features/todo/components/todoList.tsx
@@ -136,7 +136,7 @@ const TodoList = ({ todos }: { todos: Todo[] }) => {
       childTodos: rootTodo.childTodos,
       progress: getProjectProgress(todos, rootTodo.id),
       subtaskInfo: getProjectSubtaskInfo(todos, rootTodo.id),
-      overdueInfo: getProjectOverdue(todos, rootTodo.id),
+      overdueInfo: getProjectOverdue(todos, rootTodo),
       isExpanded: expandedProjectIds.has(rootTodo.id),
     }));
   }, [todoTree, todos, expandedProjectIds]);
@@ -228,7 +228,7 @@ const TodoList = ({ todos }: { todos: Todo[] }) => {
                   childTodos: todo.childTodos,
                   progress: getProjectProgress(todos, todo.id),
                   subtaskInfo: getProjectSubtaskInfo(todos, todo.id),
-                  overdueInfo: getProjectOverdue(todos, todo.id),
+                  overdueInfo: getProjectOverdue(todos, todo),
                   isExpanded: expandedProjectIds.has(todo.id),
                 };
                 return (

--- a/client/src/features/todo/utils/__tests__/projectUtils.test.ts
+++ b/client/src/features/todo/utils/__tests__/projectUtils.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { getProjectOverdue } from '../projectUtils'
+import type { Todo } from '../../types/todo.type'
+
+const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
+  id: 'todo-1',
+  userId: 'user-1',
+  title: '테스트 할 일',
+  status: 'todo',
+  priority: 'medium',
+  startAt: null,
+  dueAt: null,
+  doneAt: null,
+  parentId: null,
+  order: 0,
+  recurrence: null,
+  recurrenceId: null,
+  createdAt: '2026-06-14T00:00:00.000Z',
+  updatedAt: '2026-06-14T00:00:00.000Z',
+  ...overrides,
+})
+
+// 절대 날짜 하드코딩 대신, 고정된 시스템 시간(ANCHOR) 기준 상대 offset으로 dueAt을 만든다.
+// 로컬 자정 기준 N일 전/후의 ISO 문자열을 반환한다 (due.ts / dueTodo 등 기존 컨벤션과 동일하게
+// new Date(...).setHours(0,0,0,0) 로 로컬 자정 정규화 후 비교하는 로직과 짝을 맞추기 위함).
+const ANCHOR = new Date('2026-06-14T09:00:00.000Z') // 임의의 앵커 시각 (TZ 무관하게 하루 중간)
+
+const daysFromAnchor = (offsetDays: number): string => {
+  const d = new Date(ANCHOR)
+  d.setHours(0, 0, 0, 0)
+  d.setDate(d.getDate() + offsetDays)
+  return d.toISOString()
+}
+
+describe('getProjectOverdue', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(ANCHOR)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('하위 투두가 없고 루트 자신의 dueAt이 과거이면 초과로 판정해야 한다', () => {
+    const project = makeTodo({
+      id: 'project-1',
+      status: 'todo',
+      dueAt: daysFromAnchor(-3),
+    })
+
+    const result = getProjectOverdue([project], project)
+
+    expect(result).toEqual({ isOverdue: true, daysOver: 3 })
+  })
+
+  it('하위 투두가 없고 루트 자신의 dueAt이 미래이면 초과가 아니어야 한다', () => {
+    const project = makeTodo({
+      id: 'project-1',
+      status: 'todo',
+      dueAt: daysFromAnchor(2),
+    })
+
+    const result = getProjectOverdue([project], project)
+
+    expect(result).toEqual({ isOverdue: false, daysOver: 0 })
+  })
+
+  it('루트와 하위 투두 모두 아직 초과되지 않았으면 초과가 아니어야 한다', () => {
+    const project = makeTodo({ id: 'project-1', status: 'todo', dueAt: daysFromAnchor(1) })
+    const subtask = makeTodo({
+      id: 'sub-1',
+      parentId: 'project-1',
+      status: 'todo',
+      dueAt: daysFromAnchor(2),
+    })
+
+    const result = getProjectOverdue([project, subtask], project)
+
+    expect(result).toEqual({ isOverdue: false, daysOver: 0 })
+  })
+
+  it('루트는 초과되지 않았지만 하위 투두가 초과됐으면 하위 기준으로 초과 판정해야 한다 (기존 동작 유지)', () => {
+    const project = makeTodo({ id: 'project-1', status: 'todo', dueAt: daysFromAnchor(5) })
+    const subtask = makeTodo({
+      id: 'sub-1',
+      parentId: 'project-1',
+      status: 'todo',
+      dueAt: daysFromAnchor(-4),
+    })
+
+    const result = getProjectOverdue([project, subtask], project)
+
+    expect(result).toEqual({ isOverdue: true, daysOver: 4 })
+  })
+
+  it('루트와 하위 투두 모두 초과됐으면 가장 오래 초과된 것(daysOver 최대) 기준으로 계산해야 한다', () => {
+    const project = makeTodo({ id: 'project-1', status: 'todo', dueAt: daysFromAnchor(-2) })
+    const olderSubtask = makeTodo({
+      id: 'sub-1',
+      parentId: 'project-1',
+      status: 'todo',
+      dueAt: daysFromAnchor(-10),
+    })
+    const newerSubtask = makeTodo({
+      id: 'sub-2',
+      parentId: 'project-1',
+      status: 'todo',
+      dueAt: daysFromAnchor(-1),
+    })
+
+    const result = getProjectOverdue([project, olderSubtask, newerSubtask], project)
+
+    expect(result).toEqual({ isOverdue: true, daysOver: 10 })
+  })
+
+  it('루트 자신의 dueAt이 과거여도 status가 done이면 초과가 아니어야 한다', () => {
+    const project = makeTodo({
+      id: 'project-1',
+      status: 'done',
+      dueAt: daysFromAnchor(-3),
+    })
+
+    const result = getProjectOverdue([project], project)
+
+    expect(result).toEqual({ isOverdue: false, daysOver: 0 })
+  })
+
+  it('루트 dueAt이 null이고 하위 투두도 없으면 초과가 아니어야 한다', () => {
+    const project = makeTodo({ id: 'project-1', status: 'todo', dueAt: null })
+
+    const result = getProjectOverdue([project], project)
+
+    expect(result).toEqual({ isOverdue: false, daysOver: 0 })
+  })
+})

--- a/client/src/features/todo/utils/projectUtils.ts
+++ b/client/src/features/todo/utils/projectUtils.ts
@@ -82,34 +82,34 @@ export function getProjectSubtaskInfo(
   return { total, statusText };
 }
 
-// 서브태스크 중 dueAt이 오늘보다 이전인 것 감지
-// 가장 오래된 초과 서브태스크 기준으로 daysOver 계산
+// 루트 투두 자신 또는 서브태스크 중 dueAt이 오늘보다 이전인 것 감지
+// 가장 오래된 초과 건(루트 자신 포함) 기준으로 daysOver 계산
 export function getProjectOverdue(
   allTodos: Todo[],
-  projectId: string
+  project: Todo
 ): { isOverdue: boolean; daysOver: number } {
-  const subtasks = allTodos.filter((t) => t.parentId === projectId);
-
-  if (subtasks.length === 0) {
-    return { isOverdue: false, daysOver: 0 };
-  }
+  const subtasks = allTodos.filter((t) => t.parentId === project.id);
 
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
-  const overdueSubtasks = subtasks.filter((t) => {
+  const isOverdueCandidate = (t: Todo) => {
     if (!t.dueAt || t.status === "done") return false;
     const dueDate = new Date(t.dueAt);
     dueDate.setHours(0, 0, 0, 0);
     return dueDate < today;
-  });
+  };
 
-  if (overdueSubtasks.length === 0) {
+  // 루트 투두 자신도 후보에 포함시켜, 하위 투두가 없거나 아직 지나지 않았더라도
+  // 루트 자신의 dueAt이 지났으면 초과로 판정되도록 한다.
+  const overdueCandidates = [project, ...subtasks].filter(isOverdueCandidate);
+
+  if (overdueCandidates.length === 0) {
     return { isOverdue: false, daysOver: 0 };
   }
 
-  // 가장 오래된 초과 서브태스크 기준
-  const oldestDue = overdueSubtasks.reduce((oldest, t) => {
+  // 가장 오래된 초과 건 기준
+  const oldestDue = overdueCandidates.reduce((oldest, t) => {
     const tDate = new Date(t.dueAt!);
     const oldestDate = new Date(oldest.dueAt!);
     return tDate < oldestDate ? t : oldest;


### PR DESCRIPTION
## Summary
- `getProjectOverdue`가 하위 투두만 검사해 루트 투두 자신의 `dueAt`을 무시하던 버그 수정 — 하위 항목이 없는 루트 투두는 자신의 마감일이 지나도 "N일 초과" 배지가 절대 뜨지 않았음
- 초과 후보 목록에 루트 투두 자신을 포함시키도록 시그니처를 `(allTodos, projectId: string)` → `(allTodos, project: Todo)`로 변경, `todoList.tsx` 호출부 2곳도 함께 수정
- `projectUtils.ts`에 대한 단위 테스트가 전혀 없어서 TDD로 신규 작성 (7개 케이스)

## Test plan
- [x] `npm run test` — 전체 통과 (신규 `projectUtils.test.ts` 7건 포함)
- [x] `npm run lint` — 에러 0 (기존 무관한 `useResize.ts` 경고 1건만 존재)
- [x] `npm run build` — 정상 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)