### PR TITLE
fix: 반복 할 일 호라이즌 확장 에러 로깅 및 경계 테스트 보강

### DIFF
--- a/client/src/features/todo/hooks/__tests__/useTodo.test.tsx
+++ b/client/src/features/todo/hooks/__tests__/useTodo.test.tsx
@@ -348,6 +348,36 @@ describe('useTodo 훅', () => {
 
       expect(vi.mocked(extendIndefiniteRecurringSeries)).toHaveBeenCalled()
     })
+
+    it('실패 시 사용자에게는 알리지 않되 콘솔에는 에러를 남겨야 한다', async () => {
+      const { getTodos, extendIndefiniteRecurringSeries } = await import('../../api')
+
+      vi.mocked(getTodos).mockResolvedValue([])
+      const error = new Error('permission-denied')
+      vi.mocked(extendIndefiniteRecurringSeries).mockRejectedValueOnce(error)
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const { result } = renderHook(() => useTodo(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.useGetTodos.isSuccess).toBe(true)
+      })
+
+      result.current.useExtendIndefiniteRecurringSeries.mutate()
+
+      await waitFor(() => {
+        expect(result.current.useExtendIndefiniteRecurringSeries.isError).toBe(true)
+      })
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('반복 할 일 호라이즌 확장 실패'),
+        error,
+      )
+
+      consoleErrorSpy.mockRestore()
+    })
   })
 })
 

--- a/client/src/features/todo/hooks/useTodo.ts
+++ b/client/src/features/todo/hooks/useTodo.ts
@@ -171,11 +171,16 @@ export const useTodo = () => {
 
   // 앱 진입 시 1회 호출해 무기한 반복 시리즈들의 남은 인스턴스를 오늘 기준으로
   // 이어서 채운다(App.tsx). 사용자 액션이 아니라 백그라운드 유지보수 성격이라
-  // 실패해도 조용히 넘어가고(다음 접속 때 다시 시도됨) 성공 시에만 목록을 갱신한다.
+  // 사용자에게는 조용히 넘어가고(다음 접속 때 다시 시도됨) 성공 시에만 목록을 갱신한다.
+  // 다만 실패 자체를 아무도 알 수 없으면 운영 중 문제(예: permission-denied)를
+  // 감지할 수 없으므로 최소한 콘솔에는 남긴다.
   const useExtendIndefiniteRecurringSeries = useMutation({
     mutationFn: () => extendIndefiniteRecurringSeries(),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["todos"] });
+    },
+    onError: (error) => {
+      console.error("반복 할 일 호라이즌 확장 실패:", error);
     },
   });
 

--- a/client/src/features/todo/utils/__tests__/recurrence.test.ts
+++ b/client/src/features/todo/utils/__tests__/recurrence.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   generateRecurringDueDates,
   getDefaultHorizonEnd,
@@ -107,6 +107,80 @@ describe("generateRecurringDueDates", () => {
     ]);
   });
 
+  it("monthly: 윤년에는 2월 29일까지 클램핑한다 (평년 28일과 구분)", () => {
+    const rule: RecurrenceRule = { type: "monthly", endType: "indefinite" };
+    const base = "2028-01-31T09:00:00"; // 2028년은 윤년 → 2월은 29일까지 존재
+    const horizonEnd = new Date("2028-04-30T00:00:00");
+
+    const result = generateRecurringDueDates(base, rule, horizonEnd);
+
+    expect(result.map(toDateKey)).toEqual([
+      "2028-01-31",
+      "2028-02-29", // 평년이었다면 28일로 클램핑되었을 자리
+      "2028-03-31",
+      "2028-04-30",
+    ]);
+  });
+
+  it("monthly: 윤년 2월 29일 기준으로 반복하면 이듬해(평년) 2월은 28일로 클램핑된다", () => {
+    const rule: RecurrenceRule = { type: "monthly", endType: "indefinite" };
+    const base = "2028-02-29T09:00:00"; // 2028년 윤년의 2월 29일
+    const horizonEnd = new Date("2029-02-28T23:59:59");
+
+    const result = generateRecurringDueDates(base, rule, horizonEnd);
+    const keys = result.map(toDateKey);
+
+    // 2028-02(29일) ~ 2029-02(평년, 28일로 클램핑)까지 매월 하나씩 총 13건
+    expect(keys).toHaveLength(13);
+    expect(keys[0]).toBe("2028-02-29");
+    expect(keys[keys.length - 1]).toBe("2029-02-28");
+  });
+
+  it("daily: horizonEnd 당일이면 시각과 무관하게 그 날의 인스턴스까지 포함한다 (등호 경계)", () => {
+    const rule: RecurrenceRule = { type: "daily", endType: "indefinite" };
+    const base = "2026-07-10T18:00:00";
+    // horizonEnd가 그 날의 이른 시각이어도 그 날 전체(23:59:59.999)로 확장되어 포함되어야 한다.
+    const horizonEnd = new Date("2026-07-12T00:00:01");
+
+    const result = generateRecurringDueDates(base, rule, horizonEnd);
+
+    expect(result.map(toDateKey)).toEqual([
+      "2026-07-10",
+      "2026-07-11",
+      "2026-07-12",
+    ]);
+  });
+
+  it("daily: horizonEnd가 하루 전 23:59:59.999(자정 1ms 전)이면 다음날 인스턴스는 제외된다 (off-by-one 경계)", () => {
+    const rule: RecurrenceRule = { type: "daily", endType: "indefinite" };
+    const base = "2026-07-10T18:00:00";
+    const horizonEnd = new Date("2026-07-11T23:59:59.999");
+
+    const result = generateRecurringDueDates(base, rule, horizonEnd);
+
+    expect(result.map(toDateKey)).toEqual(["2026-07-10", "2026-07-11"]);
+  });
+
+  it("monthly: horizonEnd가 클램핑된 말일과 정확히 같으면 포함된다 (등호 경계)", () => {
+    const rule: RecurrenceRule = { type: "monthly", endType: "indefinite" };
+    const base = "2026-01-31T09:00:00";
+    const horizonEnd = new Date("2026-02-28T00:00:00"); // 2026년은 평년 → 2월 마지막 날은 28일
+
+    const result = generateRecurringDueDates(base, rule, horizonEnd);
+
+    expect(result.map(toDateKey)).toEqual(["2026-01-31", "2026-02-28"]);
+  });
+
+  it("monthly: horizonEnd가 클램핑된 말일 하루 전이면 그 달의 인스턴스는 제외된다 (off-by-one 경계)", () => {
+    const rule: RecurrenceRule = { type: "monthly", endType: "indefinite" };
+    const base = "2026-01-31T09:00:00";
+    const horizonEnd = new Date("2026-02-27T00:00:00"); // 2월 마지막 날(28일) 하루 전까지만 허용
+
+    const result = generateRecurringDueDates(base, rule, horizonEnd);
+
+    expect(result.map(toDateKey)).toEqual(["2026-01-31"]);
+  });
+
   it("endType이 untilDate이면 endDate와 horizonEnd 중 더 이른 날짜까지만 생성한다 (endDate가 더 이른 경우)", () => {
     const rule: RecurrenceRule = {
       type: "daily",
@@ -182,6 +256,25 @@ describe("generateRecurringDueDates", () => {
       process.env.TZ = originalTz;
     }
   });
+
+  // monthly 말일 클램핑과 horizonEnd 경계 비교는 모두 로컬 Date getter/setter(getDate,
+  // new Date(y, m, d) 등)로만 계산되지만, CI가 UTC라 타임존 버그가 있어도 통과해버릴 수
+  // 있다. UTC보다 느린 타임존에서도 윤년 클램핑과 등호 경계가 동일하게 성립하는지 확인한다.
+  it("UTC보다 시간이 느린 타임존에서도 윤년 2월 29일 클램핑과 horizonEnd 등호 경계가 유지된다", () => {
+    const originalTz = process.env.TZ;
+    process.env.TZ = "America/New_York";
+    try {
+      const rule: RecurrenceRule = { type: "monthly", endType: "indefinite" };
+      const base = "2028-01-31T09:00:00";
+      const horizonEnd = new Date("2028-02-29T00:00:00"); // 클램핑된 말일과 정확히 같은 날
+
+      const result = generateRecurringDueDates(base, rule, horizonEnd);
+
+      expect(result.map(toDateKey)).toEqual(["2028-01-31", "2028-02-29"]);
+    } finally {
+      process.env.TZ = originalTz;
+    }
+  });
 });
 
 describe("getDefaultHorizonEnd", () => {
@@ -192,5 +285,22 @@ describe("getDefaultHorizonEnd", () => {
       (result.getTime() - from.getTime()) / (1000 * 60 * 60 * 24),
     );
     expect(diffDays).toBe(RECURRENCE_HORIZON_WEEKS * 7);
+  });
+
+  // from을 생략하면 내부에서 new Date()(현재 시스템 시각)를 기준으로 삼는다. 이 기본값
+  // 경로는 시스템 시간을 고정하지 않으면 검증할 수 없으므로 fake timer로 "오늘"을 고정한다.
+  it("from을 생략하면 현재 시스템 시각 기준 4주 뒤를 반환한다", () => {
+    const anchor = new Date("2026-07-03T10:00:00");
+    vi.useFakeTimers();
+    vi.setSystemTime(anchor);
+    try {
+      const result = getDefaultHorizonEnd();
+      const diffDays = Math.round(
+        (result.getTime() - anchor.getTime()) / (1000 * 60 * 60 * 24),
+      );
+      expect(diffDays).toBe(RECURRENCE_HORIZON_WEEKS * 7);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- `useExtendIndefiniteRecurringSeries` mutation에 `onError` 콜백을 추가해 실패 시 `console.error`로 로그를 남기도록 함 (기존에는 실패가 완전히 조용히 무시됨)
- `recurrence.ts` 유틸 테스트에 윤년 2/29 monthly 클램핑, `horizonEnd` 등호/off-by-one 경계, `getDefaultHorizonEnd()` 기본 인자 경로 등 기존에 커버되지 않던 케이스 8건 추가 (버그는 발견되지 않음 — 기존 로직이 이미 올바르게 처리)

배경: 이전에 수정 완료된 반복 할 일 호라이즌 데이터 누락 버그(커밋 9f659ea)에 대해 code-reviewer/security-specialist/test-specialist/frontend-developer 4개 에이전트로 다각도 검토를 진행했고, 그중 우선순위가 가장 높았던 두 항목(에러 로깅 부재, 테스트 커버리지 공백)을 반영했습니다.

## Test plan
- [x] `useTodo.test.tsx`, `recurrence.test.ts` 관련 테스트 38건 통과
- [x] `npm run lint` 클린
- [x] 전체 스위트 실행 시 무관한 바텀시트 관련 테스트 3건이 타임아웃 났으나, 개별 실행 시 모두 통과 확인 (기존 플레이키 테스트, 이번 변경과 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)