### PR TITLE
fix: 칸반 같은 컬럼 내 드래그 재정렬 순서 미저장 버그 수정

### DIFF
--- a/client/src/features/kanban/components/kanbanBoard.tsx
+++ b/client/src/features/kanban/components/kanbanBoard.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { DndContext, DragOverlay, closestCenter } from "@dnd-kit/core";
+import { DndContext, DragOverlay, closestCorners } from "@dnd-kit/core";
 import { useTodo, type Todo } from "@/features/todo";
 import { useMediaQuery, KanbanSkeleton, EmptyState } from "@/shared";
 import KanbanColumn, { type Status } from "./kanbanColumn";
@@ -116,7 +116,7 @@ const KanbanBoard = () => {
   return (
     <DndContext
       sensors={sensors}
-      collisionDetection={closestCenter}
+      collisionDetection={closestCorners}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
     >

--- a/client/src/features/kanban/components/kanbanBoard.tsx
+++ b/client/src/features/kanban/components/kanbanBoard.tsx
@@ -22,7 +22,7 @@ type KanbanTab = "todo" | "doing" | "done";
 
 const KanbanBoard = () => {
   const navigate = useNavigate();
-  const { useGetTodos, useUpdateTodo } = useTodo();
+  const { useGetTodos, useUpdateTodo, useReorderTodos } = useTodo();
   const { data: todos, isLoading, isError } = useGetTodos;
   const [activeTab, setActiveTab] = useState<KanbanTab>("todo");
   const isTablet = useMediaQuery("tablet");
@@ -31,6 +31,7 @@ const KanbanBoard = () => {
     useKanbanDrag({
       todos,
       onUpdateTodo: (todo) => useUpdateTodo.mutate(todo),
+      onReorderTodos: (updates) => useReorderTodos.mutate(updates),
     });
 
   // 반복 인스턴스는 며칠 방치되면 같은 recurrenceId의 인스턴스가 여러 개 노출 조건을

--- a/client/src/features/kanban/hooks/__tests__/useKanbanDrag.test.tsx
+++ b/client/src/features/kanban/hooks/__tests__/useKanbanDrag.test.tsx
@@ -48,7 +48,7 @@ describe("useKanbanDrag", () => {
     it("드래그 시작 시 activeId와 activeTodo가 설정된다", () => {
       const todos = [makeTodo({ id: "todo-1" }), makeTodo({ id: "todo-2" })];
       const onUpdateTodo = vi.fn();
-      const { result } = renderHook(() => useKanbanDrag({ todos, onUpdateTodo }));
+      const { result } = renderHook(() => useKanbanDrag({ todos, onUpdateTodo, onReorderTodos: vi.fn() }));
 
       act(() => {
         result.current.handleDragStart(makeDragStartEvent("todo-1"));
@@ -61,7 +61,7 @@ describe("useKanbanDrag", () => {
     it("드래그 종료 시 activeId가 null로 초기화된다", () => {
       const todos = [makeTodo({ id: "todo-1", status: "todo" })];
       const onUpdateTodo = vi.fn();
-      const { result } = renderHook(() => useKanbanDrag({ todos, onUpdateTodo }));
+      const { result } = renderHook(() => useKanbanDrag({ todos, onUpdateTodo, onReorderTodos: vi.fn() }));
 
       act(() => {
         result.current.handleDragStart(makeDragStartEvent("todo-1"));
@@ -83,7 +83,7 @@ describe("useKanbanDrag", () => {
       // 자체를 over로 준다 — over.id가 곧 컬럼의 status 값이다.
       const todos = [makeTodo({ id: "todo-1", status: "todo" })];
       const onUpdateTodo = vi.fn();
-      const { result } = renderHook(() => useKanbanDrag({ todos, onUpdateTodo }));
+      const { result } = renderHook(() => useKanbanDrag({ todos, onUpdateTodo, onReorderTodos: vi.fn() }));
 
       act(() => {
         result.current.handleDragEnd(makeDragEndEvent("todo-1", "doing"));
@@ -102,7 +102,7 @@ describe("useKanbanDrag", () => {
         makeTodo({ id: "todo-2", status: "doing" }),
       ];
       const onUpdateTodo = vi.fn();
-      const { result } = renderHook(() => useKanbanDrag({ todos, onUpdateTodo }));
+      const { result } = renderHook(() => useKanbanDrag({ todos, onUpdateTodo, onReorderTodos: vi.fn() }));
 
       act(() => {
         result.current.handleDragEnd(makeDragEndEvent("todo-1", "todo-2"));
@@ -116,7 +116,7 @@ describe("useKanbanDrag", () => {
     it("doing 카드를 done 컬럼으로 옮기면 status가 done으로 바뀐다", () => {
       const todos = [makeTodo({ id: "todo-1", status: "doing" })];
       const onUpdateTodo = vi.fn();
-      const { result } = renderHook(() => useKanbanDrag({ todos, onUpdateTodo }));
+      const { result } = renderHook(() => useKanbanDrag({ todos, onUpdateTodo, onReorderTodos: vi.fn() }));
 
       act(() => {
         result.current.handleDragEnd(makeDragEndEvent("todo-1", "done"));
@@ -130,7 +130,7 @@ describe("useKanbanDrag", () => {
     it("done 카드를 todo 컬럼으로 되돌리면 status가 todo로 바뀐다", () => {
       const todos = [makeTodo({ id: "todo-1", status: "done" })];
       const onUpdateTodo = vi.fn();
-      const { result } = renderHook(() => useKanbanDrag({ todos, onUpdateTodo }));
+      const { result } = renderHook(() => useKanbanDrag({ todos, onUpdateTodo, onReorderTodos: vi.fn() }));
 
       act(() => {
         result.current.handleDragEnd(makeDragEndEvent("todo-1", "todo"));
@@ -151,7 +151,7 @@ describe("useKanbanDrag", () => {
       });
       const onUpdateTodo = vi.fn();
       const { result } = renderHook(() =>
-        useKanbanDrag({ todos: [original], onUpdateTodo }),
+        useKanbanDrag({ todos: [original], onUpdateTodo, onReorderTodos: vi.fn() }),
       );
 
       act(() => {
@@ -166,35 +166,156 @@ describe("useKanbanDrag", () => {
   });
 
   describe("같은 컬럼 내 재정렬(같은 status로 드롭)", () => {
-    it("같은 컬럼 안의 다른 카드 위에 드롭하면(status 변화 없음) onUpdateTodo가 호출되지 않는다", () => {
-      // useKanbanDrag는 카드 순서(order)를 재계산하지 않고 컬럼 간 status 전이만
-      // 처리한다. 드롭 대상 카드의 status가 드래그한 카드와 같으면(=같은 컬럼 내
-      // 재정렬) 아무 것도 변경하지 않는다 — 현재 구현에서는 같은 컬럼 내 순서가
-      // 서버에 반영되지 않는다.
+    // onReorderTodos는 allTodos(status 풀 전체, 반복 인스턴스로 숨겨진 형제 포함)를
+    // 기준으로 arrayMove 후 order가 실제로 바뀐 문서만 diff해서 전달한다 — 컬럼 전체를
+    // 매번 다시 쓰지 않는다(비용 검토 결과 반영).
+    it("같은 컬럼 안의 다른 카드 위에 드롭하면 onUpdateTodo는 호출되지 않고, 두 카드의 order만 바뀐 diff로 onReorderTodos가 호출된다", () => {
       const todos = [
         makeTodo({ id: "todo-1", status: "todo", order: 0 }),
         makeTodo({ id: "todo-2", status: "todo", order: 1 }),
       ];
       const onUpdateTodo = vi.fn();
-      const { result } = renderHook(() => useKanbanDrag({ todos, onUpdateTodo }));
+      const onReorderTodos = vi.fn();
+      const { result } = renderHook(() =>
+        useKanbanDrag({ todos, onUpdateTodo, onReorderTodos }),
+      );
 
       act(() => {
         result.current.handleDragEnd(makeDragEndEvent("todo-1", "todo-2"));
       });
 
       expect(onUpdateTodo).not.toHaveBeenCalled();
+      expect(onReorderTodos).toHaveBeenCalledTimes(1);
+      const updates = onReorderTodos.mock.calls[0][0];
+      expect(updates).toHaveLength(2);
+      expect(updates).toEqual(
+        expect.arrayContaining([
+          { id: "todo-1", order: 1 },
+          { id: "todo-2", order: 0 },
+        ]),
+      );
     });
 
-    it("같은 컬럼(빈 자리 포함)에 드롭해도 status가 같으면 onUpdateTodo가 호출되지 않는다", () => {
-      const todos = [makeTodo({ id: "todo-1", status: "todo" })];
+    it("같은 카드 위에 그대로 드롭하면(순서 변화 없음) onReorderTodos가 호출되지 않는다", () => {
+      const todos = [
+        makeTodo({ id: "todo-1", status: "todo", order: 0 }),
+        makeTodo({ id: "todo-2", status: "todo", order: 1 }),
+      ];
       const onUpdateTodo = vi.fn();
-      const { result } = renderHook(() => useKanbanDrag({ todos, onUpdateTodo }));
+      const onReorderTodos = vi.fn();
+      const { result } = renderHook(() =>
+        useKanbanDrag({ todos, onUpdateTodo, onReorderTodos }),
+      );
+
+      act(() => {
+        result.current.handleDragEnd(makeDragEndEvent("todo-1", "todo-1"));
+      });
+
+      expect(onUpdateTodo).not.toHaveBeenCalled();
+      expect(onReorderTodos).not.toHaveBeenCalled();
+    });
+
+    it("카드가 하나뿐인 컬럼의 빈 영역(컬럼 자체 id)에 드롭해도 순서 변화가 없으므로 onReorderTodos가 호출되지 않는다", () => {
+      const todos = [makeTodo({ id: "todo-1", status: "todo", order: 0 })];
+      const onUpdateTodo = vi.fn();
+      const onReorderTodos = vi.fn();
+      const { result } = renderHook(() =>
+        useKanbanDrag({ todos, onUpdateTodo, onReorderTodos }),
+      );
 
       act(() => {
         result.current.handleDragEnd(makeDragEndEvent("todo-1", "todo"));
       });
 
       expect(onUpdateTodo).not.toHaveBeenCalled();
+      expect(onReorderTodos).not.toHaveBeenCalled();
+    });
+
+    it("컬럼 빈 영역(컬럼 자체 id)에 드롭하면 맨 끝으로 이동한 것으로 간주해 order를 재계산한다", () => {
+      const todos = [
+        makeTodo({ id: "todo-1", status: "todo", order: 0 }),
+        makeTodo({ id: "todo-2", status: "todo", order: 1 }),
+        makeTodo({ id: "todo-3", status: "todo", order: 2 }),
+      ];
+      const onUpdateTodo = vi.fn();
+      const onReorderTodos = vi.fn();
+      const { result } = renderHook(() =>
+        useKanbanDrag({ todos, onUpdateTodo, onReorderTodos }),
+      );
+
+      // todo-1을 컬럼 빈 영역(over.id === "todo" 상태 id)에 드롭 → 맨 끝으로 이동
+      act(() => {
+        result.current.handleDragEnd(makeDragEndEvent("todo-1", "todo"));
+      });
+
+      const updates = onReorderTodos.mock.calls[0][0];
+      expect(updates).toHaveLength(3);
+      expect(updates).toEqual(
+        expect.arrayContaining([
+          { id: "todo-1", order: 2 },
+          { id: "todo-2", order: 0 },
+          { id: "todo-3", order: 1 },
+        ]),
+      );
+    });
+
+    it("다른 컬럼(status)에 드롭하면 재정렬이 아니라 기존 status 전이(onUpdateTodo)로만 처리된다", () => {
+      const todos = [
+        makeTodo({ id: "todo-1", status: "todo", order: 0 }),
+        makeTodo({ id: "todo-2", status: "doing", order: 0 }),
+      ];
+      const onUpdateTodo = vi.fn();
+      const onReorderTodos = vi.fn();
+      const { result } = renderHook(() =>
+        useKanbanDrag({ todos, onUpdateTodo, onReorderTodos }),
+      );
+
+      act(() => {
+        result.current.handleDragEnd(makeDragEndEvent("todo-1", "todo-2"));
+      });
+
+      expect(onUpdateTodo).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "todo-1", status: "doing" }),
+      );
+      expect(onReorderTodos).not.toHaveBeenCalled();
+    });
+
+    it("화면에 숨겨진 반복 인스턴스 형제(같은 status, 다른 recurrenceId 인스턴스)가 있어도 allTodos 기준으로 order를 재계산해 형제와의 상대 순서를 보존한다", () => {
+      // 시나리오: 같은 recurrenceId를 가진 반복 인스턴스 두 개(overdue-1, overdue-2)가
+      // 둘 다 status:"todo"라서 collapseRecurringInstances가 dueAt이 이른 overdue-1만
+      // 대표로 노출하고 overdue-2는 화면에서 숨긴다. useKanbanDrag는 컬럼에 실제로
+      // 렌더링되는 대표 카드만이 아니라 allTodos(todos prop, 숨은 형제 포함)를 기준으로
+      // 재인덱싱해야 overdue-2가 나중에 대표로 떠오를 때도 상대 순서가 어긋나지 않는다.
+      const todos = [
+        makeTodo({ id: "overdue-1", status: "todo", order: 0, recurrenceId: "series-1", dueAt: "2026-07-28T00:00:00.000Z" }),
+        makeTodo({ id: "overdue-2", status: "todo", order: 1, recurrenceId: "series-1", dueAt: "2026-07-29T00:00:00.000Z" }),
+        makeTodo({ id: "todo-solo", status: "todo", order: 2 }),
+      ];
+      const onUpdateTodo = vi.fn();
+      const onReorderTodos = vi.fn();
+      const { result } = renderHook(() =>
+        useKanbanDrag({ todos, onUpdateTodo, onReorderTodos }),
+      );
+
+      // 화면에는 overdue-1(대표)과 todo-solo만 카드로 보이고, 사용자가 todo-solo를
+      // overdue-1 앞으로 드래그했다고 가정 — over는 여전히 실제 문서 id(overdue-1)다.
+      act(() => {
+        result.current.handleDragEnd(makeDragEndEvent("todo-solo", "overdue-1"));
+      });
+
+      // allTodos 기준 배열 [overdue-1(0), overdue-2(1), todo-solo(2)]에서
+      // todo-solo(index 2)를 overdue-1(index 0) 위치로 옮기면
+      // [todo-solo, overdue-1, overdue-2] → order 0,1,2로 재부여된다.
+      // 숨겨진 overdue-2도 함께 재번호되어(1→2) 상대 순서(overdue-1 다음)가 보존된다.
+      const updates = onReorderTodos.mock.calls[0][0];
+      expect(updates).toHaveLength(3);
+      expect(updates).toEqual(
+        expect.arrayContaining([
+          { id: "todo-solo", order: 0 },
+          { id: "overdue-1", order: 1 },
+          { id: "overdue-2", order: 2 },
+        ]),
+      );
     });
   });
 
@@ -202,7 +323,7 @@ describe("useKanbanDrag", () => {
     it("드롭 가능한 영역 밖(over === null)에 놓으면 아무 것도 변경되지 않는다", () => {
       const todos = [makeTodo({ id: "todo-1", status: "todo" })];
       const onUpdateTodo = vi.fn();
-      const { result } = renderHook(() => useKanbanDrag({ todos, onUpdateTodo }));
+      const { result } = renderHook(() => useKanbanDrag({ todos, onUpdateTodo, onReorderTodos: vi.fn() }));
 
       act(() => {
         result.current.handleDragEnd(makeDragEndEvent("todo-1", null));
@@ -215,7 +336,7 @@ describe("useKanbanDrag", () => {
     it("todos가 undefined(로딩 중)여도 에러 없이 처리되고 onUpdateTodo가 호출되지 않는다", () => {
       const onUpdateTodo = vi.fn();
       const { result } = renderHook(() =>
-        useKanbanDrag({ todos: undefined, onUpdateTodo }),
+        useKanbanDrag({ todos: undefined, onUpdateTodo, onReorderTodos: vi.fn() }),
       );
 
       expect(() => {
@@ -230,7 +351,7 @@ describe("useKanbanDrag", () => {
     it("드래그 시작 후 목록에서 사라진 카드(낙관적 업데이트 등)를 드롭해도 안전하게 무시된다", () => {
       const onUpdateTodo = vi.fn();
       const { result, rerender } = renderHook(
-        ({ todos }) => useKanbanDrag({ todos, onUpdateTodo }),
+        ({ todos }) => useKanbanDrag({ todos, onUpdateTodo, onReorderTodos: vi.fn() }),
         { initialProps: { todos: [makeTodo({ id: "todo-1", status: "todo" })] } },
       );
 
@@ -257,7 +378,7 @@ describe("useKanbanDrag", () => {
         // done 컬럼은 비어 있음
       ];
       const onUpdateTodo = vi.fn();
-      const { result } = renderHook(() => useKanbanDrag({ todos, onUpdateTodo }));
+      const { result } = renderHook(() => useKanbanDrag({ todos, onUpdateTodo, onReorderTodos: vi.fn() }));
 
       act(() => {
         result.current.handleDragEnd(makeDragEndEvent("todo-1", "done"));
@@ -271,7 +392,7 @@ describe("useKanbanDrag", () => {
     it("존재하지 않는 카드 id로 드래그 종료가 발생해도 안전하게 무시된다", () => {
       const todos = [makeTodo({ id: "todo-1", status: "todo" })];
       const onUpdateTodo = vi.fn();
-      const { result } = renderHook(() => useKanbanDrag({ todos, onUpdateTodo }));
+      const { result } = renderHook(() => useKanbanDrag({ todos, onUpdateTodo, onReorderTodos: vi.fn() }));
 
       act(() => {
         result.current.handleDragEnd(makeDragEndEvent("nonexistent-id", "doing"));
@@ -284,7 +405,7 @@ describe("useKanbanDrag", () => {
   describe("센서 구성", () => {
     it("PointerSensor, TouchSensor, KeyboardSensor 3개의 센서가 구성된다", () => {
       const { result } = renderHook(() =>
-        useKanbanDrag({ todos: [], onUpdateTodo: vi.fn() }),
+        useKanbanDrag({ todos: [], onUpdateTodo: vi.fn(), onReorderTodos: vi.fn() }),
       );
 
       expect(result.current.sensors).toHaveLength(3);

--- a/client/src/features/kanban/hooks/useKanbanDrag.ts
+++ b/client/src/features/kanban/hooks/useKanbanDrag.ts
@@ -19,6 +19,11 @@ interface UseKanbanDragProps {
   onReorderTodos: (updates: TodoReorderUpdate[]) => void;
 }
 
+/** order 필드가 없는(undefined) 레거시 문서를 만나도 비교 함수가 NaN을 반환해 정렬
+ * 전체가 깨지지 않도록, 없는 값은 맨 뒤로 보낸다(todoApi.ts의 getTodos와 동일한 이유). */
+const normalizeOrder = (order: number | undefined): number =>
+  typeof order === "number" && !Number.isNaN(order) ? order : Infinity;
+
 export const useKanbanDrag = ({
   todos,
   onUpdateTodo,
@@ -86,9 +91,11 @@ export const useKanbanDrag = ({
     // 같은 status를 가진 문서 전체를 order 기준으로 정렬해 기준 배열로 삼는다 —
     // collapseRecurringInstances가 화면에서 숨긴 반복 인스턴스 형제도 여기 포함되므로,
     // 나중에 그 형제가 대표로 떠오르더라도 상대 순서가 어긋나지 않는다.
+    // order가 없는(undefined) 레거시 문서가 섞여 있으면 비교 함수가 NaN을 반환해
+    // 전체 정렬이 깨지므로(getTodos()와 동일한 이유), 없는 값은 맨 뒤로 보낸다.
     const allStatusTodos = (todos ?? [])
       .filter((t) => t.status === draggedTodo.status)
-      .sort((a, b) => a.order - b.order);
+      .sort((a, b) => normalizeOrder(a.order) - normalizeOrder(b.order));
 
     const oldIndex = allStatusTodos.findIndex((t) => t.id === draggedTodo.id);
     if (oldIndex === -1) return;

--- a/client/src/features/kanban/hooks/useKanbanDrag.ts
+++ b/client/src/features/kanban/hooks/useKanbanDrag.ts
@@ -9,16 +9,21 @@ import {
   type DragStartEvent,
   type DragEndEvent,
 } from "@dnd-kit/core";
-import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
-import type { Todo } from "@/features/todo";
+import { arrayMove, sortableKeyboardCoordinates } from "@dnd-kit/sortable";
+import type { Todo, TodoReorderUpdate } from "@/features/todo";
 import type { Status } from "../components/kanbanColumn";
 
 interface UseKanbanDragProps {
   todos: Todo[] | undefined;
   onUpdateTodo: (todo: Todo) => void;
+  onReorderTodos: (updates: TodoReorderUpdate[]) => void;
 }
 
-export const useKanbanDrag = ({ todos, onUpdateTodo }: UseKanbanDragProps) => {
+export const useKanbanDrag = ({
+  todos,
+  onUpdateTodo,
+  onReorderTodos,
+}: UseKanbanDragProps) => {
   const [activeId, setActiveId] = useState<string | null>(null);
 
   const sensors = useSensors(
@@ -67,11 +72,43 @@ export const useKanbanDrag = ({ todos, onUpdateTodo }: UseKanbanDragProps) => {
       targetStatus = over.id as Status;
     }
 
-    if (targetStatus && draggedTodo.status !== targetStatus) {
+    if (!targetStatus) return;
+
+    if (draggedTodo.status !== targetStatus) {
       onUpdateTodo({
         ...draggedTodo,
         status: targetStatus,
       });
+      return;
+    }
+
+    // 같은 컬럼(status) 내 재정렬. todos(allTodos, collapse/가시성 필터 적용 전)에서
+    // 같은 status를 가진 문서 전체를 order 기준으로 정렬해 기준 배열로 삼는다 —
+    // collapseRecurringInstances가 화면에서 숨긴 반복 인스턴스 형제도 여기 포함되므로,
+    // 나중에 그 형제가 대표로 떠오르더라도 상대 순서가 어긋나지 않는다.
+    const allStatusTodos = (todos ?? [])
+      .filter((t) => t.status === draggedTodo.status)
+      .sort((a, b) => a.order - b.order);
+
+    const oldIndex = allStatusTodos.findIndex((t) => t.id === draggedTodo.id);
+    if (oldIndex === -1) return;
+
+    // overTodo가 없으면 컬럼의 빈 영역(컬럼 자체가 드롭 대상)에 드롭된 것이므로
+    // 맨 끝으로 이동한 것으로 간주한다.
+    const newIndex = overTodo
+      ? allStatusTodos.findIndex((t) => t.id === overTodo.id)
+      : allStatusTodos.length - 1;
+    if (newIndex === -1) return;
+
+    const reordered = arrayMove(allStatusTodos, oldIndex, newIndex);
+
+    const originalOrderById = new Map(allStatusTodos.map((t) => [t.id, t.order]));
+    const updates = reordered
+      .map((t, index) => ({ id: t.id, order: index }))
+      .filter((u) => originalOrderById.get(u.id) !== u.order);
+
+    if (updates.length > 0) {
+      onReorderTodos(updates);
     }
   };
 

--- a/client/src/features/todo/api/__tests__/todoApi.test.ts
+++ b/client/src/features/todo/api/__tests__/todoApi.test.ts
@@ -20,6 +20,7 @@ vi.mock('firebase/firestore', () => ({
   query: vi.fn(),
   where: vi.fn(),
   getDoc: vi.fn(),
+  writeBatch: vi.fn(),
 }))
 
 // 테스트용 Todo 팩토리
@@ -130,6 +131,66 @@ describe('todoApi', () => {
       const result = await getSearchTodoList('react')
 
       expect(result).toHaveLength(2)
+    })
+  })
+
+  describe('reorderTodos', () => {
+    const makeBatch = () => ({
+      set: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      commit: vi.fn().mockResolvedValue(undefined),
+    })
+
+    beforeEach(async () => {
+      vi.clearAllMocks()
+      const firebase = await import('@/shared/lib/firebase')
+      Object.assign(firebase.auth, { currentUser: { uid: 'test-user-id' } })
+    })
+
+    it('전달받은 id/order 쌍마다 batch.update를 호출하고 한 번에 commit해야 한다', async () => {
+      const { doc, writeBatch } = await import('firebase/firestore')
+      const { reorderTodos } = await import('../todoApi')
+
+      const batch = makeBatch()
+      vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>)
+      vi.mocked(doc).mockImplementation((...args: unknown[]) => ({ id: args[2] }) as ReturnType<typeof doc>)
+
+      await reorderTodos([
+        { id: 'todo-1', order: 0 },
+        { id: 'todo-2', order: 1 },
+      ])
+
+      expect(batch.update).toHaveBeenCalledTimes(2)
+      expect(batch.update).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'todo-1' }),
+        expect.objectContaining({ order: 0 }),
+      )
+      expect(batch.update).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'todo-2' }),
+        expect.objectContaining({ order: 1 }),
+      )
+      expect(batch.commit).toHaveBeenCalledTimes(1)
+    })
+
+    it('빈 배열이 전달되면 batch를 생성하지 않고 아무 것도 쓰지 않아야 한다', async () => {
+      const { writeBatch } = await import('firebase/firestore')
+      const { reorderTodos } = await import('../todoApi')
+
+      await reorderTodos([])
+
+      expect(writeBatch).not.toHaveBeenCalled()
+    })
+
+    it('인증되지 않은 경우 에러를 던져야 한다', async () => {
+      const firebase = await import('@/shared/lib/firebase')
+      Object.defineProperty(firebase.auth, 'currentUser', { value: null, configurable: true })
+
+      const { reorderTodos } = await import('../todoApi')
+
+      await expect(reorderTodos([{ id: 'todo-1', order: 0 }])).rejects.toThrow('Not authenticated')
+
+      Object.defineProperty(firebase.auth, 'currentUser', { value: { uid: 'test-user-id' }, configurable: true })
     })
   })
 })

--- a/client/src/features/todo/api/__tests__/todoApi.test.ts
+++ b/client/src/features/todo/api/__tests__/todoApi.test.ts
@@ -65,6 +65,31 @@ describe('todoApi', () => {
       expect(result[1].order).toBe(1)
     })
 
+    it('order 필드가 없는(undefined) 레거시 문서가 섞여 있어도 나머지 문서는 정상적으로 order 순 정렬되어야 한다', async () => {
+      // 비교 함수가 undefined - number = NaN을 반환하면 정렬 전체가 깨지는 회귀
+      // 버그가 있었다(order가 있는 문서끼리도 전혀 정렬되지 않음).
+      const { getDocs, query, where } = await import('firebase/firestore')
+      const { getTodos } = await import('../todoApi')
+
+      const legacyDone = { ...makeTodo({ title: '레거시', status: 'done' }), id: undefined, order: undefined }
+      const mockDocs = [
+        { id: 'todo-3', data: () => ({ ...makeTodo({ title: '셋', order: 2 }), id: undefined }) },
+        { id: 'legacy-done', data: () => legacyDone },
+        { id: 'todo-1', data: () => ({ ...makeTodo({ title: '하나', order: 0 }), id: undefined }) },
+        { id: 'todo-2', data: () => ({ ...makeTodo({ title: '둘', order: 1 }), id: undefined }) },
+      ]
+
+      vi.mocked(getDocs).mockResolvedValueOnce({
+        docs: mockDocs,
+      } as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never)
+      vi.mocked(query).mockReturnValue({} as ReturnType<typeof query>)
+      vi.mocked(where).mockReturnValue({} as ReturnType<typeof where>)
+
+      const result = await getTodos()
+
+      expect(result.map((t) => t.title)).toEqual(['하나', '둘', '셋', '레거시'])
+    })
+
     it('인증되지 않은 경우 에러를 던져야 한다', async () => {
       const firebase = await import('@/shared/lib/firebase')
       Object.defineProperty(firebase.auth, 'currentUser', { value: null, configurable: true })

--- a/client/src/features/todo/api/todoApi.ts
+++ b/client/src/features/todo/api/todoApi.ts
@@ -26,6 +26,18 @@ const mapDocToTodo = (id: string, data: Record<string, unknown>): Todo =>
   ({ id, ...data }) as Todo;
 
 /**
+ * order 필드가 도입되기 전에 만들어진 레거시 문서는 order가 아예 없다(undefined).
+ * `a.order - b.order`에 undefined가 섞이면 NaN을 반환하는데, sort 비교 함수가 NaN을
+ * 반환하면 그 비교뿐 아니라 배열 전체의 정렬 결과가 신뢰할 수 없어진다(V8 정렬
+ * 알고리즘이 비교 결과의 일관성을 전제하므로, 일부 쌍이 NaN이면 관련 없는 다른
+ * 요소들의 상대 순서까지 흐트러질 수 있다) — 실제로 이 상태에서 정상 order를 가진
+ * 문서들끼리도 전혀 정렬되지 않는 것을 확인했다. order 없는 문서를 맨 뒤로 보내
+ * 비교가 항상 유효한 숫자를 반환하도록 방어한다.
+ */
+const normalizeOrder = (order: number | undefined): number =>
+  typeof order === "number" && !Number.isNaN(order) ? order : Infinity;
+
+/**
  * 반복 인스턴스 문서 ID를 {recurrenceId}_{YYYY-MM-DD}로 결정론적으로 만든다(로컬 타임존
  * 기준 연-월-일 — 코드베이스 전반의 toDateString() 기반 "같은 날짜" 판정과 동일 기준).
  *
@@ -84,7 +96,7 @@ export const getTodos = async () => {
   const snapshot = await getDocs(q);
   return snapshot.docs
     .map((doc) => mapDocToTodo(doc.id, doc.data()))
-    .sort((a, b) => a.order - b.order);
+    .sort((a, b) => normalizeOrder(a.order) - normalizeOrder(b.order));
 };
 
 export const getTodoDetail = async (id: string) => {

--- a/client/src/features/todo/api/todoApi.ts
+++ b/client/src/features/todo/api/todoApi.ts
@@ -11,7 +11,7 @@ import {
 } from "firebase/firestore";
 import { db, auth } from "@/shared/lib/firebase";
 import { toDateKeyFromISO } from "@/shared/utils/date";
-import type { RecurrenceRule, Todo } from "../types/todo.type";
+import type { RecurrenceRule, Todo, TodoReorderUpdate } from "../types/todo.type";
 import { generateRecurringDueDates, getDefaultHorizonEnd } from "../utils/recurrence";
 
 const todosRef = collection(db, "todos");
@@ -268,6 +268,37 @@ export const updateTodoDueAt = async (
     updates.startAt = startAt;
   }
   await updateDoc(docRef, updates);
+};
+
+/**
+ * 칸반 보드 같은 컬럼(status) 내 드래그 재정렬 시 여러 문서의 order를 한 번에 반영한다.
+ * 호출부(useKanbanDrag)가 이미 변경된 문서만 diff해서 넘기므로, 여기서는 추가 필터링 없이
+ * 그대로 batch write한다. 개별 getDoc 소유권 재검증은 생략한다 — id 목록은 항상 호출자가
+ * getTodos()(userId 필터링됨)로 이미 받아둔 자신의 캐시에서만 나오고, 최종 방어선은
+ * firestore.rules의 `resource.data.userId == request.auth.uid`(update 규칙)이므로 카드
+ * 수만큼 getDoc 왕복을 추가하는 비용이 정당화되지 않는다. writeBatch는 원자적이라 그
+ * 전제가 깨지는 경우(예: 다른 탭에서 그 사이 삭제된 문서)에도 부분 쓰기로 데이터가
+ * 어긋나진 않는다 — 다만 이때 에러는 다른 함수들의 "Forbidden"/"Todo not found"가 아니라
+ * Firestore의 raw permission-denied로 표면화된다.
+ *
+ * 읽기 없이 절대 order 값을 그대로 덮어쓰므로, 두 탭/기기에서 같은 컬럼을 거의 동시에
+ * 재정렬하면 나중에 commit된 batch가 이긴다(last-write-wins). 값이 사라지는 데이터
+ * 유실은 아니고 "방금 옮긴 순서가 다른 기기의 조작에 덮어써질 수 있다" 정도라, 이
+ * 코드베이스가 반복 시리즈 등에서 이미 택한 "완전한 원자성 대신 최종 수렴" 철학과
+ * 일치하는 트레이드오프로 판단해 트랜잭션을 쓰지 않았다.
+ */
+export const reorderTodos = async (
+  updates: TodoReorderUpdate[],
+): Promise<void> => {
+  getUserId();
+  if (updates.length === 0) return;
+
+  const now = new Date().toISOString();
+  const batch = writeBatch(db);
+  updates.forEach(({ id, order }) => {
+    batch.update(doc(db, "todos", id), { order, updatedAt: now });
+  });
+  await batch.commit();
 };
 
 export const createChildTodo = async (

--- a/client/src/features/todo/hooks/__tests__/useTodo.test.tsx
+++ b/client/src/features/todo/hooks/__tests__/useTodo.test.tsx
@@ -28,6 +28,7 @@ vi.mock('../../api', () => ({
   editRecurringSeries: vi.fn(),
   deleteRecurringSeries: vi.fn(),
   extendIndefiniteRecurringSeries: vi.fn(),
+  reorderTodos: vi.fn(),
 }))
 
 const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
@@ -313,6 +314,134 @@ describe('useTodo 훅', () => {
       })
 
       expect(vi.mocked(deleteRecurringSeries)).toHaveBeenCalledWith('series-1')
+    })
+  })
+
+  describe('useReorderTodos', () => {
+    // onMutate 중간 상태(캐시가 낙관적으로 갱신됐는지)와 onError 롤백을 검증하려면
+    // 내부 QueryClient에 직접 접근해야 해서, createWrapper()와 별도로 QueryClient를
+    // 함께 반환하는 헬퍼를 이 describe 블록 안에서만 사용한다.
+    const createWrapperWithClient = () => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false, gcTime: 0 },
+          mutations: { retry: false },
+        },
+      })
+      const Wrapper = ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      )
+      return { Wrapper, queryClient }
+    }
+
+    it('재정렬 mutation이 정의되어 있어야 한다', () => {
+      const { result } = renderHook(() => useTodo(), {
+        wrapper: createWrapper(),
+      })
+
+      expect(result.current.useReorderTodos).toBeDefined()
+      expect(typeof result.current.useReorderTodos.mutate).toBe('function')
+    })
+
+    it('성공 시 reorderTodos를 호출하고 todos 쿼리를 무효화해야 한다', async () => {
+      const { getTodos, reorderTodos } = await import('../../api')
+
+      vi.mocked(getTodos).mockResolvedValue([
+        makeTodo({ id: 'todo-1', order: 0 }),
+        makeTodo({ id: 'todo-2', order: 1 }),
+      ])
+      vi.mocked(reorderTodos).mockResolvedValueOnce(undefined)
+
+      const { result } = renderHook(() => useTodo(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.useGetTodos.isSuccess).toBe(true)
+      })
+
+      const updates = [
+        { id: 'todo-1', order: 1 },
+        { id: 'todo-2', order: 0 },
+      ]
+      result.current.useReorderTodos.mutate(updates)
+
+      await waitFor(() => {
+        expect(result.current.useReorderTodos.isSuccess).toBe(true)
+      })
+
+      expect(vi.mocked(reorderTodos)).toHaveBeenCalledWith(updates)
+    })
+
+    it('mutate 호출 즉시(서버 응답 전) 캐시에 새 order를 낙관적으로 반영해야 한다', async () => {
+      const { getTodos, reorderTodos } = await import('../../api')
+
+      vi.mocked(getTodos).mockResolvedValue([
+        makeTodo({ id: 'todo-1', order: 0 }),
+        makeTodo({ id: 'todo-2', order: 1 }),
+      ])
+
+      // 서버 응답을 인위적으로 지연시켜, 응답 전 캐시 상태(낙관적 갱신 결과)를 검증한다.
+      let resolveReorder: () => void = () => {}
+      vi.mocked(reorderTodos).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveReorder = () => resolve(undefined)
+          }),
+      )
+
+      const { Wrapper, queryClient } = createWrapperWithClient()
+      const { result } = renderHook(() => useTodo(), { wrapper: Wrapper })
+
+      await waitFor(() => {
+        expect(result.current.useGetTodos.isSuccess).toBe(true)
+      })
+
+      result.current.useReorderTodos.mutate([
+        { id: 'todo-1', order: 1 },
+        { id: 'todo-2', order: 0 },
+      ])
+
+      await waitFor(() => {
+        const cached = queryClient.getQueryData<Todo[]>(['todos'])
+        expect(cached?.find((t) => t.id === 'todo-1')?.order).toBe(1)
+        expect(cached?.find((t) => t.id === 'todo-2')?.order).toBe(0)
+      })
+
+      resolveReorder()
+      await waitFor(() => {
+        expect(result.current.useReorderTodos.isSuccess).toBe(true)
+      })
+    })
+
+    it('실패 시 재정렬 이전 캐시 상태로 롤백해야 한다', async () => {
+      const { getTodos, reorderTodos } = await import('../../api')
+
+      vi.mocked(getTodos).mockResolvedValue([
+        makeTodo({ id: 'todo-1', order: 0 }),
+        makeTodo({ id: 'todo-2', order: 1 }),
+      ])
+      vi.mocked(reorderTodos).mockRejectedValueOnce(new Error('네트워크 오류'))
+
+      const { Wrapper, queryClient } = createWrapperWithClient()
+      const { result } = renderHook(() => useTodo(), { wrapper: Wrapper })
+
+      await waitFor(() => {
+        expect(result.current.useGetTodos.isSuccess).toBe(true)
+      })
+
+      result.current.useReorderTodos.mutate([
+        { id: 'todo-1', order: 1 },
+        { id: 'todo-2', order: 0 },
+      ])
+
+      await waitFor(() => {
+        expect(result.current.useReorderTodos.isError).toBe(true)
+      })
+
+      const cached = queryClient.getQueryData<Todo[]>(['todos'])
+      expect(cached?.find((t) => t.id === 'todo-1')?.order).toBe(0)
+      expect(cached?.find((t) => t.id === 'todo-2')?.order).toBe(1)
     })
   })
 

--- a/client/src/features/todo/hooks/useTodo.ts
+++ b/client/src/features/todo/hooks/useTodo.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import type { Todo } from "../types";
+import type { Todo, TodoReorderUpdate } from "../types";
 import {
   createTodo,
   getTodos,
@@ -13,6 +13,7 @@ import {
   editRecurringSeries,
   deleteRecurringSeries,
   extendIndefiniteRecurringSeries,
+  reorderTodos,
 } from "../api";
 
 export const useTodo = () => {
@@ -80,6 +81,35 @@ export const useTodo = () => {
       return { previous };
     },
     onError: (_err, _todo, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(["todos"], context.previous);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["todos"] });
+    },
+  });
+
+  // 칸반 보드 같은 컬럼 내 드래그 재정렬(useKanbanDrag)에서 사용. 여러 문서의 order를
+  // 한 번에 bulk write하는 reorderTodos를 감싼다. useUpdateTodo와 동일한 이유로
+  // optimistic update를 적용한다 — 그러지 않으면 batch.commit()이 끝날 때까지 드래그로
+  // 옮긴 카드가 캐시상 원래 자리로 순간적으로 스냅백되는 것처럼 보인다.
+  const useReorderTodos = useMutation({
+    mutationFn: (updates: TodoReorderUpdate[]) => reorderTodos(updates),
+    onMutate: async (updates) => {
+      await queryClient.cancelQueries({ queryKey: ["todos"] });
+      const previous = queryClient.getQueryData<Todo[]>(["todos"]);
+
+      queryClient.setQueryData<Todo[]>(["todos"], (old = []) => {
+        const orderById = new Map(updates.map((u) => [u.id, u.order]));
+        return old.map((t) =>
+          orderById.has(t.id) ? { ...t, order: orderById.get(t.id)! } : t,
+        );
+      });
+
+      return { previous };
+    },
+    onError: (_err, _updates, context) => {
       if (context?.previous) {
         queryClient.setQueryData(["todos"], context.previous);
       }
@@ -187,6 +217,7 @@ export const useTodo = () => {
   return {
     useCreateTodo,
     useUpdateTodo,
+    useReorderTodos,
     useDeleteTodo,
     useGetTodos,
     useUpdateToDone,

--- a/client/src/features/todo/index.ts
+++ b/client/src/features/todo/index.ts
@@ -1,5 +1,5 @@
 export { useTodo, useTodoDetail } from "./hooks";
-export type { Todo, RecurrenceRule } from "./types";
+export type { Todo, RecurrenceRule, TodoReorderUpdate } from "./types";
 export { collapseRecurringInstances } from "./utils/projectUtils";
 export { default as TodoList } from "./components/todoList";
 export { default as TodoDetail } from "./components/todoDetail/todoDetail";

--- a/client/src/features/todo/types/index.ts
+++ b/client/src/features/todo/types/index.ts
@@ -1,2 +1,2 @@
-export type { Todo, RecurrenceRule } from "./todo.type";
+export type { Todo, RecurrenceRule, TodoReorderUpdate } from "./todo.type";
 export type { ProjectCardData } from "../utils/projectUtils";

--- a/client/src/features/todo/types/todo.type.ts
+++ b/client/src/features/todo/types/todo.type.ts
@@ -33,4 +33,10 @@ interface Todo {
   recurrenceId: string | null;
 }
 
-export type { Todo, RecurrenceRule };
+/** 칸반 같은 컬럼 내 드래그 재정렬 시 bulk write할 order 변경분. */
+interface TodoReorderUpdate {
+  id: string;
+  order: number;
+}
+
+export type { Todo, RecurrenceRule, TodoReorderUpdate };

--- a/client/src/features/todo/utils/__tests__/collapseRecurringInstances.test.ts
+++ b/client/src/features/todo/utils/__tests__/collapseRecurringInstances.test.ts
@@ -46,4 +46,24 @@ describe("collapseRecurringInstances", () => {
     const result = collapseRecurringInstances(todos);
     expect(result.map((t) => t.id).sort()).toEqual(["a2", "b1"]);
   });
+
+  it("대표가 나중에 만난(더 이른 dueAt) 인스턴스로 바뀌어도, 처음 만난 인스턴스의 자리가 아니라 대표 자신의 원래 위치에 남는다", () => {
+    // 칸반 재정렬(useKanbanDrag)은 order로 정렬된 원본 배열에서 카드의 위치를
+    // 계산하므로, collapse된 대표 카드가 화면에 보이는 위치는 반드시 그 대표
+    // 자신의 order 순위와 일치해야 한다 — 첫 인스턴스의 자리를 빌려 쓰면 어긋난다.
+    const todos = [
+      makeTodo({ id: "other-1", order: 0 }),
+      makeTodo({ id: "first-seen", recurrenceId: "series-1", order: 1, dueAt: "2026-07-12T00:00:00.000Z" }),
+      makeTodo({ id: "other-2", order: 2 }),
+      makeTodo({ id: "other-3", order: 3 }),
+      makeTodo({
+        id: "true-representative",
+        recurrenceId: "series-1",
+        order: 4,
+        dueAt: "2026-07-10T00:00:00.000Z",
+      }),
+    ];
+    const result = collapseRecurringInstances(todos);
+    expect(result.map((t) => t.id)).toEqual(["other-1", "other-2", "other-3", "true-representative"]);
+  });
 });

--- a/client/src/features/todo/utils/projectUtils.ts
+++ b/client/src/features/todo/utils/projectUtils.ts
@@ -8,31 +8,32 @@ import type { Todo } from "../types";
  */
 export function collapseRecurringInstances(todos: Todo[]): Todo[] {
   const representativeByRecurrenceId = new Map<string, Todo>();
-  const result: Todo[] = [];
 
   for (const todo of todos) {
-    if (!todo.recurrenceId) {
-      result.push(todo);
-      continue;
-    }
+    if (!todo.recurrenceId) continue;
 
     const existing = representativeByRecurrenceId.get(todo.recurrenceId);
     if (!existing) {
       representativeByRecurrenceId.set(todo.recurrenceId, todo);
-      result.push(todo);
       continue;
     }
 
     const existingDue = existing.dueAt ? new Date(existing.dueAt).getTime() : Infinity;
     const currentDue = todo.dueAt ? new Date(todo.dueAt).getTime() : Infinity;
     if (currentDue < existingDue) {
-      const index = result.indexOf(existing);
-      result[index] = todo;
       representativeByRecurrenceId.set(todo.recurrenceId, todo);
     }
   }
 
-  return result;
+  // 대표를 처음 만난 인스턴스의 자리에 끼워넣지 않고, 대표 인스턴스 자신이 원래
+  // todos 배열에서 차지하는 위치(=order 순위)에 그대로 남긴다. 그러지 않으면(과거
+  // result[index] = todo로 첫 인스턴스 자리를 덮어쓰던 방식) 화면에 보이는 카드의
+  // 위치가 실제 order 값과 어긋나, 칸반 드래그 재정렬(useKanbanDrag)이 이 카드의
+  // over.id를 실제 order(대표의 order)로 찾는데 화면상 위치는 첫 인스턴스의 order
+  // 근처로 보여 사용자가 드롭한 자리와 전혀 다른 위치로 카드가 이동하는 버그가 있었다.
+  return todos.filter(
+    (todo) => !todo.recurrenceId || representativeByRecurrenceId.get(todo.recurrenceId) === todo,
+  );
 }
 
 export interface ProjectCardData {


### PR DESCRIPTION
## Summary
- Issue #63: 칸반 보드에서 같은 컬럼 내 드래그로 카드 순서를 바꿔도 저장되지 않고 스냅백되던 버그 수정
- `reorderTodos` bulk write API 신설 + `useReorderTodos` optimistic mutation 추가, `useKanbanDrag`에 같은-컬럼 재정렬 로직 구현
- 실사용 중 발견된 후속 버그(카드가 엉뚱한 위치로 이동/화면 미반영) 근본 원인 수정: `getTodos()` 정렬 비교 함수가 `order` 필드 없는 레거시 문서(done 상태 49건)를 만나면 NaN을 반환해 배열 전체 정렬이 깨지던 문제. order 없는 값은 맨 뒤로 보내도록 방어
- 부수 수정: `collapseRecurringInstances`가 반복 대표 카드를 화면 위치가 아닌 첫 인스턴스 자리에 고정하던 버그, `closestCenter` → `closestCorners`(멀티 컨테이너 드래그 충돌 감지 정확도 개선)

## Test plan
- [x] `npm run lint` 통과
- [x] `npm run test` 256개 전부 통과 (신규 회귀 테스트 포함: order 없는 문서 혼재 시 정렬, collapseRecurringInstances 위치 보존, reorderTodos batch write, optimistic update/rollback)
- [x] `npm run build` 통과
- [ ] 실제 브라우저에서 사용자 확인 완료(같은 컬럼 재정렬이 의도한 위치에 정확히 반영됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)