### PR TITLE
feat: Today 화면 기간 투두 매일 노출 및 마감 임박 강조

### DIFF
--- a/client/src/features/dashboard/components/calendar.tsx
+++ b/client/src/features/dashboard/components/calendar.tsx
@@ -29,32 +29,14 @@ import styled, { keyframes } from "styled-components";
 import { colors } from "@/styles/colors";
 import { isOverdue, getDropDates } from "../utils/calendarUtils";
 import { formatRecurrenceSummary } from "@/features/todo/utils/recurrenceSummary";
+import { toDateKey, toDateKeyFromISO } from "@/shared/utils/date";
+import { isDateInTodoRange } from "@/shared/utils/dateRange";
 
 const statusLabels: Record<Status, string> = {
   todo: "할 일",
   doing: "진행 중",
   done: "완료",
 };
-
-/** Date → "YYYY-MM-DD" 로컬 날짜 문자열 변환 (UTC 변환 없음) */
-function toLocalDateStr(date: Date): string {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, "0");
-  const d = String(date.getDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
-}
-
-/**
- * datetime 문자열 → 로컬 타임존 기준 "YYYY-MM-DD".
- * dueAt/startAt은 UTC Z 문자열로 저장되므로(todoForm이 toISOString 사용)
- * split("T")로 자르면 UTC 날짜가 나온다 — KST에서 자정~오전 9시 마감이
- * 전날로 밀리는 원인. 반드시 로컬 타임존으로 변환해서 날짜를 뽑는다.
- * "T"가 없는 date-only 문자열은 이미 달력 날짜이므로 그대로 반환한다.
- */
-function toLocalDateOnly(dateTimeStr: string): string {
-  if (!dateTimeStr.includes("T")) return dateTimeStr;
-  return toLocalDateStr(new Date(dateTimeStr));
-}
 
 const Calendar = () => {
   const calendarRef = useRef<FullCalendar>(null);
@@ -86,11 +68,11 @@ const Calendar = () => {
         // ??(null만 거름) 대신 ||로 falsy를 함께 걸러야 한다. ""가 시작일로
         // 넘어가면 FC가 이벤트를 통째로 버려 캘린더에서 사라진다.
         const startSrc = todo.startAt || todo.dueAt || null;
-        const startDate = startSrc ? toLocalDateOnly(startSrc) : null;
+        const startDate = startSrc ? toDateKeyFromISO(startSrc) : null;
         let endDate: string | null = null;
         if (todo.startAt && todo.dueAt) {
-          const [y, mo, d] = toLocalDateOnly(todo.dueAt).split("-").map(Number);
-          endDate = toLocalDateStr(new Date(y, mo - 1, d + 1));
+          const [y, mo, d] = toDateKeyFromISO(todo.dueAt).split("-").map(Number);
+          endDate = toDateKey(new Date(y, mo - 1, d + 1));
         }
 
         return {
@@ -126,24 +108,10 @@ const Calendar = () => {
   const selectedDateTodos = useMemo(() => {
     if (!selectedDate || !todos) return [];
 
-    // selectedDate는 "YYYY-MM-DD" — 같은 형식의 로컬 날짜 문자열끼리 비교한다
-    // (사전순 비교가 날짜순과 일치). 격자(events)와 동일한 로컬 기준이어야
-    // 셀에 보이는 항목과 바텀시트 목록이 어긋나지 않는다.
-    return todos.filter((todo: Todo) => {
-      if (!todo.startAt && !todo.dueAt) return false;
-
-      const start = todo.startAt ? toLocalDateOnly(todo.startAt) : null;
-      const end = todo.dueAt ? toLocalDateOnly(todo.dueAt) : null;
-
-      // 시작일만 있는 경우
-      if (start && !end) return start === selectedDate;
-      // 종료일만 있는 경우
-      if (!start && end) return end === selectedDate;
-      // 둘 다 있는 경우: 시작일 <= 선택일 <= 종료일
-      if (start && end) return selectedDate >= start && selectedDate <= end;
-
-      return false;
-    });
+    // selectedDate는 "YYYY-MM-DD" — 격자(events)와 동일한 range 포함 판정
+    // (`isDateInTodoRange`, today 화면과 공유)을 써야 셀에 보이는 항목과 바텀시트
+    // 목록이 어긋나지 않는다.
+    return todos.filter((todo: Todo) => isDateInTodoRange(selectedDate, todo));
   }, [selectedDate, todos]);
 
   const handleDateClick = useCallback((info: DateClickArg) => {

--- a/client/src/features/today/components/periodBadge.styles.tsx
+++ b/client/src/features/today/components/periodBadge.styles.tsx
@@ -1,0 +1,19 @@
+import { styled } from "styled-components";
+import { colors } from "@/styles/colors";
+import { radius } from "@/styles/radius";
+
+// shared/ui/recurrenceBadge의 Badge와 동일한 padding/radius/font-size 패턴을
+// 색만 중립 회색으로 교체해 재정의한다(피처 간 직접 의존을 최소화하기 위해
+// recurrenceBadge를 import해 override하지 않고 today 피처 로컬에 둔다).
+export const Badge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px;
+  border-radius: ${radius.md};
+  background: ${colors.background.secondary};
+  color: ${colors.text.secondary};
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+  flex-shrink: 0;
+`;

--- a/client/src/features/today/components/periodBadge.tsx
+++ b/client/src/features/today/components/periodBadge.tsx
@@ -1,0 +1,20 @@
+import { Badge } from "./periodBadge.styles";
+
+interface PeriodBadgeProps {
+  /** 1부터 시작하는 진행 일차 */
+  dayIndex: number;
+  /** startAt~dueAt 총 일수(양 끝 포함) */
+  totalDays: number;
+}
+
+/**
+ * 기간(startAt~dueAt) 항목이 매일 노출될 때 "오늘이 며칠째인지" 보여주는 정보 칩.
+ * 브랜드 그린(RecurrenceBadge)과 달리 중립 회색을 써서 "완료"와의 오인, 마감 임박
+ * 배지(주황/빨강)와의 위계 혼동을 피한다(design/spec.md 참고).
+ */
+const PeriodBadge = ({ dayIndex, totalDays }: PeriodBadgeProps) => (
+  <Badge>{`${dayIndex}/${totalDays}일차`}</Badge>
+);
+
+export default PeriodBadge;
+export type { PeriodBadgeProps };

--- a/client/src/features/today/components/todayTodoItem.styles.tsx
+++ b/client/src/features/today/components/todayTodoItem.styles.tsx
@@ -1,6 +1,11 @@
 import { styled } from "styled-components";
 import { colors } from "@/styles/colors";
 import { radius } from "@/styles/radius";
+import { urgencyColors } from "@/styles/urgencyColors";
+import type { Urgency } from "@/shared/utils/due";
+
+/** Checkbox 링 색상용 2단계(+없음) — Urgency의 "normal"은 체크박스에서 "none"과 동일하게 취급한다. */
+type CheckboxUrgency = Extract<Urgency, "soon" | "danger"> | "none";
 
 const Row = styled.div`
   display: flex;
@@ -15,7 +20,7 @@ const Row = styled.div`
   }
 `;
 
-const Checkbox = styled.button<{ $isDone: boolean; $isDanger: boolean }>`
+const Checkbox = styled.button<{ $isDone: boolean; $urgency: CheckboxUrgency }>`
   position: relative;
   flex-shrink: 0;
   width: 44px;
@@ -37,12 +42,12 @@ const Checkbox = styled.button<{ $isDone: boolean; $isDanger: boolean }>`
     border-radius: ${radius.full};
     box-sizing: border-box;
     border: 1.5px solid
-      ${({ $isDone, $isDanger }) =>
-        $isDone
-          ? "transparent"
-          : $isDanger
-            ? colors.border.danger
-            : colors.border.secondary};
+      ${({ $isDone, $urgency }) => {
+        if ($isDone) return "transparent";
+        if ($urgency === "danger") return colors.border.danger;
+        if ($urgency === "soon") return urgencyColors.soon.main;
+        return colors.border.secondary;
+      }};
     background-color: ${({ $isDone }) =>
       $isDone ? colors.brand.secondary : "transparent"};
     transition: background-color 0.15s ease;
@@ -104,6 +109,16 @@ const OverdueBadge = styled.span`
   color: ${colors.danger.text};
 `;
 
+const DueSoonBadge = styled.span`
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 7px;
+  border-radius: 99px;
+  background-color: ${urgencyColors.soon.background};
+  color: ${urgencyColors.soon.text};
+`;
+
 const DeleteButton = styled.button`
   flex-shrink: 0;
   width: 44px;
@@ -133,5 +148,7 @@ export {
   Description,
   TimeLabel,
   OverdueBadge,
+  DueSoonBadge,
   DeleteButton,
 };
+export type { CheckboxUrgency };

--- a/client/src/features/today/components/todayTodoItem.tsx
+++ b/client/src/features/today/components/todayTodoItem.tsx
@@ -2,8 +2,11 @@ import { Check, Trash2 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import type { Todo } from "@/features/todo/types";
 import { RecurrenceBadge } from "@/shared";
-import { getDaysLeft, getDueBadgeLabel } from "@/shared/utils/due";
+import { getDaysLeft, getDueBadgeLabel, getUrgency } from "@/shared/utils/due";
+import { getPeriodProgress } from "@/shared/utils/dateRange";
+import { toDateKey } from "@/shared/utils/date";
 import { formatDueTime } from "@/shared/utils/formatToday";
+import PeriodBadge from "./periodBadge";
 import {
   Row,
   Checkbox,
@@ -13,12 +16,15 @@ import {
   Description,
   TimeLabel,
   OverdueBadge,
+  DueSoonBadge,
   DeleteButton,
 } from "./todayTodoItem.styles";
 
 interface TodayTodoItemProps {
   todo: Todo;
   onToggleDone: (todo: Todo) => void;
+  /** 기간(startAt~dueAt) 진행률 배지("n/총일 일차") 계산 기준 날짜(로컬 yyyy-MM-dd). 기본값: 오늘. */
+  selectedDate?: string;
   /** 기본값: 기존처럼 navigate(`/todo/${todo.id}`). 상세 라우트가 없는 컨텍스트(게스트 등)에서 오버라이드용. */
   onItemClick?: (todo: Todo) => void;
   /** 전달된 경우에만 우측 삭제 아이콘(44px 터치 타겟) 노출. 기존 호출부는 미전달 → 기존 동작 100% 유지. */
@@ -28,14 +34,23 @@ interface TodayTodoItemProps {
 const TodayTodoItem = ({
   todo,
   onToggleDone,
+  selectedDate,
   onItemClick,
   onDelete,
 }: TodayTodoItemProps) => {
   const navigate = useNavigate();
   const isDone = todo.status === "done";
+  const dateKey = selectedDate ?? toDateKey(new Date());
   const daysLeft = todo.dueAt ? getDaysLeft(todo.dueAt) : null;
-  const isOverdue = !isDone && daysLeft !== null && daysLeft < 0;
+  const urgency = daysLeft !== null ? getUrgency(daysLeft) : "normal";
   const dueTime = todo.dueAt ? formatDueTime(todo.dueAt) : null;
+  const periodProgress = !isDone ? getPeriodProgress(dateKey, todo) : null;
+  // 기간 항목의 마지막 날(=마감일 당일)에는 기존처럼 시각(dueTime)을, 그 이전
+  // 진행 중인 날에는 "며칠 남았는지"가 더 유효한 정보이므로 D-n 텍스트를 보여준다.
+  // 단일 마감일 항목(periodProgress === null)은 항상 마지막 날 취급.
+  const isLastDayOfPeriod = periodProgress
+    ? periodProgress.dayIndex === periodProgress.totalDays
+    : true;
 
   const handleItemClick = () =>
     onItemClick ? onItemClick(todo) : navigate(`/todo/${todo.id}`);
@@ -47,7 +62,7 @@ const TodayTodoItem = ({
         aria-checked={isDone}
         aria-label={`${todo.title} 완료 처리`}
         $isDone={isDone}
-        $isDanger={isOverdue}
+        $urgency={isDone ? "none" : urgency === "normal" ? "none" : urgency}
         onClick={(e) => {
           e.stopPropagation();
           onToggleDone(todo);
@@ -57,15 +72,29 @@ const TodayTodoItem = ({
       </Checkbox>
       <Content onClick={handleItemClick}>
         <TitleRow>
+          {periodProgress && (
+            <PeriodBadge
+              dayIndex={periodProgress.dayIndex}
+              totalDays={periodProgress.totalDays}
+            />
+          )}
           <Title $isDone={isDone}>{todo.title}</Title>
           {todo.recurrenceId != null && <RecurrenceBadge compact />}
         </TitleRow>
         {todo.description && <Description>{todo.description}</Description>}
       </Content>
-      {!isDone && isOverdue && daysLeft !== null ? (
+      {!isDone && daysLeft !== null && urgency === "danger" && (
         <OverdueBadge>{getDueBadgeLabel(daysLeft)}</OverdueBadge>
-      ) : (
-        !isDone && dueTime && <TimeLabel>{dueTime}</TimeLabel>
+      )}
+      {!isDone && daysLeft !== null && urgency === "soon" && (
+        <DueSoonBadge>{getDueBadgeLabel(daysLeft)}</DueSoonBadge>
+      )}
+      {!isDone && urgency === "normal" && (
+        <>
+          {isLastDayOfPeriod
+            ? dueTime && <TimeLabel>{dueTime}</TimeLabel>
+            : daysLeft !== null && <TimeLabel>{getDueBadgeLabel(daysLeft)}</TimeLabel>}
+        </>
       )}
       {onDelete && (
         <DeleteButton

--- a/client/src/features/today/hooks/__tests__/useTodayTodos.test.tsx
+++ b/client/src/features/today/hooks/__tests__/useTodayTodos.test.tsx
@@ -112,6 +112,137 @@ describe('useTodayTodos 훅', () => {
     expect(result.current.doneCount).toBe(1)
   })
 
+  // 기간(startAt~dueAt) 항목은 캘린더 화면과 동일하게 시작일~마감일 매일 노출되도록
+  // 필터가 dueAt 단독 비교에서 range 포함 판정(`isDateInTodoRange`)으로 바뀌었다.
+  describe('기간(startAt~dueAt) 항목 노출', () => {
+    it('기간 중간 날짜에도 노출되어야 한다', async () => {
+      const { getTodos } = await import('@/features/todo/api')
+      const mockTodos: Todo[] = [
+        makeTodo({
+          id: 'period-1',
+          title: '3일짜리 작업',
+          startAt: localISO(2026, 6, 14, 9),
+          dueAt: localISO(2026, 6, 16, 18),
+        }),
+      ]
+      vi.mocked(getTodos).mockResolvedValue(mockTodos)
+
+      const { result } = renderHook(() => useTodayTodos('2026-06-15', '2026-06-15'), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      // 2026-06-15는 시작일(06-14)과 마감일(06-16) 사이의 중간 날짜
+      expect(result.current.inProgressTodos.map((t) => t.id)).toContain('period-1')
+    })
+
+    it('기간의 시작일과 마감일 당일에도 노출되어야 한다', async () => {
+      const { getTodos } = await import('@/features/todo/api')
+      const mockTodos: Todo[] = [
+        makeTodo({
+          id: 'period-1',
+          startAt: localISO(2026, 6, 14, 9),
+          dueAt: localISO(2026, 6, 16, 18),
+        }),
+      ]
+      vi.mocked(getTodos).mockResolvedValue(mockTodos)
+
+      const startResult = renderHook(() => useTodayTodos('2026-06-14', '2026-06-14'), {
+        wrapper: createWrapper(),
+      })
+      await waitFor(() => expect(startResult.result.current.isLoading).toBe(false))
+      expect(startResult.result.current.inProgressTodos.map((t) => t.id)).toContain('period-1')
+
+      const endResult = renderHook(() => useTodayTodos('2026-06-16', '2026-06-16'), {
+        wrapper: createWrapper(),
+      })
+      await waitFor(() => expect(endResult.result.current.isLoading).toBe(false))
+      expect(endResult.result.current.inProgressTodos.map((t) => t.id)).toContain('period-1')
+    })
+
+    it('기간 범위 밖 날짜에는 노출되지 않아야 한다', async () => {
+      const { getTodos } = await import('@/features/todo/api')
+      const mockTodos: Todo[] = [
+        makeTodo({
+          id: 'period-1',
+          startAt: localISO(2026, 6, 14, 9),
+          dueAt: localISO(2026, 6, 16, 18),
+        }),
+      ]
+      vi.mocked(getTodos).mockResolvedValue(mockTodos)
+
+      const { result } = renderHook(() => useTodayTodos('2026-06-17', '2026-06-17'), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      expect(result.current.inProgressTodos.map((t) => t.id)).not.toContain('period-1')
+      expect(result.current.totalCount).toBe(0)
+    })
+
+    it('startAt만 있고 dueAt이 없으면 시작일에만 노출되어야 한다(캘린더와 동일 정책)', async () => {
+      const { getTodos } = await import('@/features/todo/api')
+      const mockTodos: Todo[] = [
+        makeTodo({ id: 'start-only', startAt: localISO(2026, 6, 15, 9), dueAt: null }),
+      ]
+      vi.mocked(getTodos).mockResolvedValue(mockTodos)
+
+      const onDate = renderHook(() => useTodayTodos('2026-06-15', '2026-06-15'), {
+        wrapper: createWrapper(),
+      })
+      await waitFor(() => expect(onDate.result.current.isLoading).toBe(false))
+      expect(onDate.result.current.inProgressTodos.map((t) => t.id)).toContain('start-only')
+
+      const otherDate = renderHook(() => useTodayTodos('2026-06-16', '2026-06-16'), {
+        wrapper: createWrapper(),
+      })
+      await waitFor(() => expect(otherDate.result.current.isLoading).toBe(false))
+      expect(otherDate.result.current.inProgressTodos.map((t) => t.id)).not.toContain('start-only')
+    })
+
+    it('dueAt만 있고 startAt이 없으면 마감일에만 노출되어야 한다(단일 마감일 항목, 기존 동작)', async () => {
+      const { getTodos } = await import('@/features/todo/api')
+      const mockTodos: Todo[] = [
+        makeTodo({ id: 'due-only', startAt: null, dueAt: localISO(2026, 6, 15, 9) }),
+      ]
+      vi.mocked(getTodos).mockResolvedValue(mockTodos)
+
+      const onDate = renderHook(() => useTodayTodos('2026-06-15', '2026-06-15'), {
+        wrapper: createWrapper(),
+      })
+      await waitFor(() => expect(onDate.result.current.isLoading).toBe(false))
+      expect(onDate.result.current.inProgressTodos.map((t) => t.id)).toContain('due-only')
+
+      const otherDate = renderHook(() => useTodayTodos('2026-06-14', '2026-06-14'), {
+        wrapper: createWrapper(),
+      })
+      await waitFor(() => expect(otherDate.result.current.isLoading).toBe(false))
+      expect(otherDate.result.current.inProgressTodos.map((t) => t.id)).not.toContain('due-only')
+    })
+
+    it('startAt/dueAt이 모두 없으면 어떤 날짜에도 노출되지 않아야 한다', async () => {
+      const { getTodos } = await import('@/features/todo/api')
+      const mockTodos: Todo[] = [makeTodo({ id: 'no-date', startAt: null, dueAt: null })]
+      vi.mocked(getTodos).mockResolvedValue(mockTodos)
+
+      const { result } = renderHook(() => useTodayTodos('2026-06-15', '2026-06-15'), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      expect(result.current.totalCount).toBe(0)
+    })
+  })
+
   it('완료 목록은 doneAt 기준 내림차순으로 정렬되어야 한다', async () => {
     const { getTodos } = await import('@/features/todo/api')
     const mockTodos: Todo[] = [

--- a/client/src/features/today/hooks/useTodayTodos.ts
+++ b/client/src/features/today/hooks/useTodayTodos.ts
@@ -3,6 +3,7 @@ import { useTodo } from "@/features/todo/hooks";
 import type { Todo } from "@/features/todo/types";
 import { getDaysLeft } from "@/shared/utils/due";
 import { getStripDates, toDateKey, toDateKeyFromISO } from "@/shared/utils/date";
+import { isDateInTodoRange } from "@/shared/utils/dateRange";
 
 export type DayMarker = "none" | "normal" | "danger";
 
@@ -18,8 +19,9 @@ export interface UseTodayTodosResult {
 }
 
 /**
- * 선택된 날짜(dueAt 기준)에 해당하는 todo를 진행중/완료로 분리하고,
- * 주간 스트립용 마커와 완료율을 계산한다.
+ * 선택된 날짜가 startAt~dueAt 구간에 포함되는 todo(캘린더와 동일한 range 포함
+ * 판정, `isDateInTodoRange` 참고)를 진행중/완료로 분리하고, 주간 스트립용 마커와
+ * 완료율을 계산한다.
  */
 export const useTodayTodos = (selectedDate: string, windowStart: string): UseTodayTodosResult => {
   const { useGetTodos, useUpdateTodo } = useTodo();
@@ -28,9 +30,9 @@ export const useTodayTodos = (selectedDate: string, windowStart: string): UseTod
 
   const todosForSelectedDate = useMemo(() => {
     if (!todos) return [];
-    return todos.filter(
-      (todo) => todo.dueAt && toDateKeyFromISO(todo.dueAt) === selectedDate,
-    );
+    // 기간(startAt~dueAt) 항목은 캘린더 화면과 동일한 정책으로 시작일~마감일 매일
+    // 노출한다(dueAt 단독 비교였던 기존 필터를 range 포함 판정으로 교체).
+    return todos.filter((todo) => isDateInTodoRange(selectedDate, todo));
   }, [todos, selectedDate]);
 
   const inProgressTodos = useMemo(
@@ -50,6 +52,13 @@ export const useTodayTodos = (selectedDate: string, windowStart: string): UseTod
     [todosForSelectedDate],
   );
 
+  // 주간 스트립 마커는 의도적으로 dueAt 단독 기준을 유지한다(리스트 필터와 달리
+  // range 포함으로 확장하지 않음). "마감 임박(빨간 점)"이라는 마커의 의미가 여전히
+  // dueAt 기준 위험도 신호이고, 기간 항목을 진행 중인 모든 날짜에 점을 찍으면
+  // "이 날 마감"과 "이 날 진행 중"이 시각적으로 구분되지 않아 주간 스트립 자체의
+  // 정보 가치가 흐려진다. 이 확장 여부는 별도 논의로 미뤄졌다(spec.md 참고) —
+  // 필터와 마커의 기준이 달라졌다는 사실 자체는 위 docstring/isDateInTodoRange로
+  // 명시해 둔다.
   const markers = useMemo(() => {
     const stripDateKeys = getStripDates(windowStart).map(toDateKey);
     const result: Record<string, DayMarker> = {};

--- a/client/src/features/today/pages/todayPage.tsx
+++ b/client/src/features/today/pages/todayPage.tsx
@@ -94,6 +94,7 @@ const TodayPage = () => {
                   <TodayTodoItem
                     key={todo.id}
                     todo={todo}
+                    selectedDate={selectedDate}
                     onToggleDone={toggleDone}
                   />
                 ))}
@@ -108,6 +109,7 @@ const TodayPage = () => {
                   <TodayTodoItem
                     key={todo.id}
                     todo={todo}
+                    selectedDate={selectedDate}
                     onToggleDone={toggleDone}
                   />
                 ))}

--- a/client/src/shared/utils/__tests__/dateRange.test.ts
+++ b/client/src/shared/utils/__tests__/dateRange.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { isDateInTodoRange, getPeriodProgress } from '../dateRange'
+
+// 로컬 타임존 기준 특정 시각의 UTC ISO 문자열을 만든다. dueAt/startAt은 UTC Z
+// 문자열로 저장되므로(toISOString), "yyyy-MM-ddT..Z"를 직접 하드코딩하면 실행
+// 머신의 로컬 타임존에 따라 로컬 날짜가 하루 밀려 보일 수 있다(KST에서 확인됨).
+// new Date(y, m-1, d, h)로 로컬 시각을 만든 뒤 toISOString()하면 어떤 타임존에서
+// 실행해도 왕복이 대칭이라 항상 의도한 로컬 날짜로 복원된다.
+const localISO = (y: number, m: number, d: number, h = 9): string =>
+  new Date(y, m - 1, d, h).toISOString()
+
+describe('isDateInTodoRange', () => {
+  it('startAt/dueAt이 모두 없으면 false를 반환해야 한다', () => {
+    expect(isDateInTodoRange('2026-06-15', { startAt: null, dueAt: null })).toBe(false)
+  })
+
+  it('startAt만 있으면 startAt 날짜와 정확히 일치할 때만 true여야 한다', () => {
+    const todo = { startAt: localISO(2026, 6, 15), dueAt: null }
+    expect(isDateInTodoRange('2026-06-15', todo)).toBe(true)
+    expect(isDateInTodoRange('2026-06-16', todo)).toBe(false)
+  })
+
+  it('dueAt만 있으면 dueAt 날짜와 정확히 일치할 때만 true여야 한다(단일 마감일 항목, 기존 동작)', () => {
+    const todo = { startAt: null, dueAt: localISO(2026, 6, 15) }
+    expect(isDateInTodoRange('2026-06-15', todo)).toBe(true)
+    expect(isDateInTodoRange('2026-06-14', todo)).toBe(false)
+  })
+
+  it('startAt/dueAt이 모두 있으면 그 구간(양 끝 포함)에서 true여야 한다', () => {
+    const todo = { startAt: localISO(2026, 6, 14), dueAt: localISO(2026, 6, 16) }
+    expect(isDateInTodoRange('2026-06-14', todo)).toBe(true) // 시작일
+    expect(isDateInTodoRange('2026-06-15', todo)).toBe(true) // 중간
+    expect(isDateInTodoRange('2026-06-16', todo)).toBe(true) // 마감일
+    expect(isDateInTodoRange('2026-06-13', todo)).toBe(false) // 이전
+    expect(isDateInTodoRange('2026-06-17', todo)).toBe(false) // 이후
+  })
+
+  it('date-only(T 없음) 문자열도 그대로 비교할 수 있어야 한다', () => {
+    const todo = { startAt: '2026-06-14', dueAt: '2026-06-16' }
+    expect(isDateInTodoRange('2026-06-15', todo)).toBe(true)
+  })
+})
+
+describe('getPeriodProgress', () => {
+  it('startAt이 없으면 null을 반환해야 한다', () => {
+    expect(getPeriodProgress('2026-06-15', { startAt: null, dueAt: localISO(2026, 6, 16) })).toBeNull()
+  })
+
+  it('dueAt이 없으면 null을 반환해야 한다', () => {
+    expect(getPeriodProgress('2026-06-15', { startAt: localISO(2026, 6, 14), dueAt: null })).toBeNull()
+  })
+
+  it('startAt과 dueAt의 로컬 날짜가 같으면(단일 마감일 항목) null을 반환해야 한다', () => {
+    const todo = { startAt: localISO(2026, 6, 15, 9), dueAt: localISO(2026, 6, 15, 18) }
+    expect(getPeriodProgress('2026-06-15', todo)).toBeNull()
+  })
+
+  it('기간 항목의 dayIndex/totalDays를 1부터 계산해야 한다(예: 3일 중 2일차)', () => {
+    const todo = { startAt: localISO(2026, 6, 14), dueAt: localISO(2026, 6, 16) }
+    expect(getPeriodProgress('2026-06-14', todo)).toEqual({ dayIndex: 1, totalDays: 3 })
+    expect(getPeriodProgress('2026-06-15', todo)).toEqual({ dayIndex: 2, totalDays: 3 })
+    expect(getPeriodProgress('2026-06-16', todo)).toEqual({ dayIndex: 3, totalDays: 3 })
+  })
+
+  it('긴 기간(5일)에서도 총일수를 정확히 계산해야 한다', () => {
+    const todo = { startAt: localISO(2026, 6, 1), dueAt: localISO(2026, 6, 5) }
+    expect(getPeriodProgress('2026-06-03', todo)).toEqual({ dayIndex: 3, totalDays: 5 })
+  })
+})

--- a/client/src/shared/utils/__tests__/due.test.ts
+++ b/client/src/shared/utils/__tests__/due.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
-import { getDaysLeft, getDueBadgeLabel, DUE_SOON_DAYS } from '../due'
+import { getDaysLeft, getDueBadgeLabel, getUrgency, DUE_SOON_DAYS } from '../due'
 
 describe('due 유틸 함수', () => {
   beforeEach(() => {
@@ -66,6 +66,28 @@ describe('due 유틸 함수', () => {
       expect(getDueBadgeLabel(-1)).toBe('1일 초과')
       expect(getDueBadgeLabel(-3)).toBe('3일 초과')
       expect(getDueBadgeLabel(-10)).toBe('10일 초과')
+    })
+  })
+
+  describe('getUrgency', () => {
+    it('daysLeft가 음수(지남)이면 "danger"를 반환해야 한다', () => {
+      expect(getUrgency(-1)).toBe('danger')
+      expect(getUrgency(-10)).toBe('danger')
+    })
+
+    it('daysLeft가 0(D-day)이면 "danger"를 반환해야 한다', () => {
+      expect(getUrgency(0)).toBe('danger')
+    })
+
+    it('daysLeft가 1~DUE_SOON_DAYS(3)이면 "soon"을 반환해야 한다', () => {
+      expect(getUrgency(1)).toBe('soon')
+      expect(getUrgency(2)).toBe('soon')
+      expect(getUrgency(DUE_SOON_DAYS)).toBe('soon')
+    })
+
+    it('daysLeft가 DUE_SOON_DAYS(3)보다 크면 "normal"을 반환해야 한다', () => {
+      expect(getUrgency(DUE_SOON_DAYS + 1)).toBe('normal')
+      expect(getUrgency(10)).toBe('normal')
     })
   })
 })

--- a/client/src/shared/utils/date.ts
+++ b/client/src/shared/utils/date.ts
@@ -16,8 +16,16 @@ export const toDateKey = (date: Date): string => {
   return `${year}-${month}-${day}`;
 };
 
-/** ISO 문자열을 로컬 타임존 기준 "yyyy-MM-dd" 키로 변환한다. */
-export const toDateKeyFromISO = (iso: string): string => toDateKey(new Date(iso));
+/**
+ * ISO(또는 date-only) 문자열을 로컬 타임존 기준 "yyyy-MM-dd" 키로 변환한다.
+ * dueAt/startAt은 보통 UTC Z ISO 문자열로 저장되므로 `new Date(iso)`로 파싱한 뒤
+ * 로컬 게터로 날짜를 뽑아야 한다. "T"가 없는 순수 date-only 문자열("yyyy-MM-dd")은
+ * 이미 로컬 달력 날짜이므로 파싱 없이 그대로 반환한다 — `new Date("yyyy-MM-dd")`는
+ * UTC 자정으로 해석되어 UTC보다 느린(음수 오프셋) 타임존에서 하루 당겨지는 버그가
+ * 있다(구 `calendar.tsx`의 `toLocalDateOnly`와 동일 원칙을 통합).
+ */
+export const toDateKeyFromISO = (iso: string): string =>
+  iso.includes("T") ? toDateKey(new Date(iso)) : iso;
 
 /**
  * ISO 문자열을 <input type="datetime-local">에 넣을 로컬 타임존 기준

--- a/client/src/shared/utils/dateRange.ts
+++ b/client/src/shared/utils/dateRange.ts
@@ -1,0 +1,62 @@
+import { parseLocalDateOnly, toDateKeyFromISO } from "./date";
+
+/** startAt/dueAt range 판정에 필요한 최소 필드만 요구한다(Todo 전체에 의존하지 않음). */
+export interface TodoRangeLike {
+  startAt: string | null;
+  dueAt: string | null;
+}
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+/**
+ * dateKey(로컬 "yyyy-MM-dd")가 todo의 [startAt, dueAt] 구간에 포함되는지 판정한다.
+ * `calendar.tsx`의 `selectedDateTodos` 필터와 동일한 정책(동작 보존, 재사용을 위해 추출):
+ * - 시작일/마감일 모두 없으면 false
+ * - 시작일만 있으면 시작일과 정확히 일치할 때만 true
+ * - 마감일만 있으면 마감일과 정확히 일치할 때만 true
+ * - 둘 다 있으면 시작일 <= dateKey <= 마감일
+ */
+export function isDateInTodoRange(dateKey: string, todo: TodoRangeLike): boolean {
+  const start = todo.startAt ? toDateKeyFromISO(todo.startAt) : null;
+  const end = todo.dueAt ? toDateKeyFromISO(todo.dueAt) : null;
+
+  if (start && !end) return start === dateKey;
+  if (!start && end) return end === dateKey;
+  if (start && end) return dateKey >= start && dateKey <= end;
+
+  return false;
+}
+
+export interface PeriodProgress {
+  /** 1부터 시작하는 진행 일차 */
+  dayIndex: number;
+  /** startAt~dueAt 총 일수(양 끝 포함) */
+  totalDays: number;
+}
+
+/**
+ * dateKey 시점에 todo가 startAt~dueAt 기간 중 몇 일차 / 총 며칠인지 계산한다.
+ * startAt이 없거나 startAt·dueAt의 로컬 날짜가 같은 경우(=단일 마감일 항목)는
+ * "기간 항목"이 아니므로 null을 반환한다. dateKey가 기간 밖이어도 계산 자체는
+ * 수행한다(1 미만이거나 totalDays 초과 값이 나올 수 있음 — 호출측에서 범위 내
+ * 날짜만 넘기는 것을 전제로 한다, 예: `isDateInTodoRange`로 먼저 걸러진 목록).
+ */
+export function getPeriodProgress(dateKey: string, todo: TodoRangeLike): PeriodProgress | null {
+  if (!todo.startAt || !todo.dueAt) return null;
+
+  const startKey = toDateKeyFromISO(todo.startAt);
+  const endKey = toDateKeyFromISO(todo.dueAt);
+  if (startKey === endKey) return null;
+
+  return {
+    dayIndex: diffDaysInclusive(startKey, dateKey),
+    totalDays: diffDaysInclusive(startKey, endKey),
+  };
+}
+
+/** fromKey부터 toKey까지 며칠째인지(양 끝 포함, fromKey === toKey면 1) 계산한다. */
+function diffDaysInclusive(fromKey: string, toKey: string): number {
+  const from = parseLocalDateOnly(fromKey);
+  const to = parseLocalDateOnly(toKey);
+  return Math.round((to.getTime() - from.getTime()) / MS_PER_DAY) + 1;
+}

--- a/client/src/shared/utils/due.ts
+++ b/client/src/shared/utils/due.ts
@@ -13,3 +13,16 @@ export function getDueBadgeLabel(daysLeft: number): string {
   if (daysLeft === 0) return "D-day";
   return `D-${daysLeft}`;
 }
+
+export type Urgency = "normal" | "soon" | "danger";
+
+/**
+ * daysLeft(`getDaysLeft` 결과)를 3단계 긴급도로 분류한다.
+ * D-day(0)는 지남(overdue)과 함께 "danger"로 묶는다 — 마감 당일도 지금 처리해야
+ * 하는 상태라는 점은 지난 것과 동일하다는 today 화면 스펙 기준(D-3 이내는 soon).
+ */
+export function getUrgency(daysLeft: number): Urgency {
+  if (daysLeft <= 0) return "danger";
+  if (daysLeft <= DUE_SOON_DAYS) return "soon";
+  return "normal";
+}

--- a/client/src/shared/utils/index.ts
+++ b/client/src/shared/utils/index.ts
@@ -1,4 +1,5 @@
-export { DUE_SOON_DAYS, getDaysLeft, getDueBadgeLabel } from "./due";
+export { DUE_SOON_DAYS, getDaysLeft, getDueBadgeLabel, getUrgency } from "./due";
+export type { Urgency } from "./due";
 export { formatTodayLabel, formatDueTime } from "./formatToday";
 export {
   parseLocalDateOnly,
@@ -8,3 +9,5 @@ export {
   isSameLocalDay,
   getWeekDates,
 } from "./date";
+export { isDateInTodoRange, getPeriodProgress } from "./dateRange";
+export type { TodoRangeLike, PeriodProgress } from "./dateRange";

--- a/client/src/styles/urgencyColors.ts
+++ b/client/src/styles/urgencyColors.ts
@@ -1,0 +1,16 @@
+import { colors } from "./colors";
+
+/**
+ * "마감 임박" 2단계 강조 색 토큰(Today 화면 전용, design/spec.md 참고).
+ * `danger`는 기존 `colors.danger` 토큰을 그대로 재사용하고, `soon`은 신규 색상이다.
+ * `todoListItem`/`dueTodo`의 기존 3단계 하드코딩 정리는 이번 스펙 범위 밖이라
+ * 아직 이 토큰을 참조하지 않는다(후속 리팩터링 권장 사항).
+ */
+export const urgencyColors = {
+  soon: { main: "#F97316", background: "#FFEDD5", text: "#C2410C" },
+  danger: {
+    main: colors.danger.main,
+    background: colors.danger.background,
+    text: colors.danger.text,
+  },
+} as const;


### PR DESCRIPTION
## Summary
- 기간(startAt~dueAt)이 지정된 투두가 Today 화면에서 마감일에만 표시되던 것을, 캘린더처럼 기간 내 매일 노출하도록 변경 (`useTodayTodos.ts`)
- 기간 진행 중인 항목은 제목 앞에 "N/M일차" 정보 칩 표시 (`periodBadge`)
- 마감 D-3 이내 항목에 주황색 강조 배지, D-day/초과는 기존 빨간 배지 유지 (`todayTodoItem` `$urgency` prop)
- 캘린더(`calendar.tsx`)와 Today가 중복 구현하던 날짜 range 판정 로직을 `shared/utils/dateRange.ts`로 통합, `toLocalDateOnly`/`toDateKeyFromISO` 중복도 정리 (캘린더 동작 보존)

## Test plan
- [x] `npm run test` — 35 files / 308 tests 통과
- [x] `npm run lint` — 에러 0 (기존 무관한 warning 1건)
- [x] `npm run build` — 통과
- [x] dev 서버에서 실제 로그인 후 기간 투두/마감 임박 투두로 Today 화면 시각 확인 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)