### PR TITLE
오늘 페이지 하단 고정 할 일 추가 버튼(FAB) 추가

### DIFF
--- a/client/src/features/today/pages/__tests__/todayPage.test.tsx
+++ b/client/src/features/today/pages/__tests__/todayPage.test.tsx
@@ -22,9 +22,10 @@ vi.mock('@/features/todo/hooks', () => ({
 }))
 
 vi.mock('@/features/todo/components/todoForm/todoForm', () => ({
-  default: ({ onClose }: { onClose: () => void }) => (
+  default: ({ initialDueAt, onClose }: { initialDueAt?: string; onClose: () => void }) => (
     <div>
       <span>할 일 폼</span>
+      <span>초기 마감일: {initialDueAt ?? '없음'}</span>
       <button onClick={onClose}>폼 닫기</button>
     </div>
   ),
@@ -130,23 +131,89 @@ describe('TodayPage 컴포넌트', () => {
     renderPage()
 
     expect(screen.getByText('오늘 할 일이 없습니다')).toBeInTheDocument()
-    expect(screen.getByText('새 할 일 추가')).toBeInTheDocument()
   })
 
-  it('빈 상태에서 "새 할 일 추가" 클릭 시 할 일 추가 모달이 열려야 한다', () => {
+  it('할 일이 없을 때 EmptyState 자체에는 더 이상 액션 버튼이 없어야 한다', () => {
     vi.mocked(useTodayTodos).mockReturnValue(makeTodayTodosResult())
 
     renderPage()
-    fireEvent.click(screen.getByText('새 할 일 추가'))
+
+    expect(screen.queryByText('새 할 일 추가')).not.toBeInTheDocument()
+  })
+
+  it('할 일이 없어도 하단 고정 추가 버튼은 노출되어야 한다', () => {
+    vi.mocked(useTodayTodos).mockReturnValue(makeTodayTodosResult())
+
+    renderPage()
+
+    expect(screen.getByText('새 할일')).toBeInTheDocument()
+  })
+
+  it('할 일이 있어도 하단 고정 추가 버튼이 계속 노출되어야 한다', () => {
+    const inProgress = makeTodo({ id: 'p1', title: '진행 중 할 일' })
+    vi.mocked(useTodayTodos).mockReturnValue(
+      makeTodayTodosResult({ inProgressTodos: [inProgress], totalCount: 1 }),
+    )
+
+    renderPage()
+
+    expect(screen.getByText('진행 중 할 일')).toBeInTheDocument()
+    expect(screen.getByText('새 할일')).toBeInTheDocument()
+  })
+
+  it('로딩 중에도 하단 고정 추가 버튼은 노출되어야 한다', () => {
+    vi.mocked(useTodayTodos).mockReturnValue(
+      makeTodayTodosResult({ isLoading: true }),
+    )
+
+    renderPage()
+
+    expect(screen.getByText('새 할일')).toBeInTheDocument()
+  })
+
+  it('에러 상태에서도 하단 고정 추가 버튼은 노출되어야 한다', () => {
+    vi.mocked(useTodayTodos).mockReturnValue(
+      makeTodayTodosResult({ isError: true }),
+    )
+
+    renderPage()
+
+    expect(screen.getByText('새 할일')).toBeInTheDocument()
+  })
+
+  it('하단 고정 추가 버튼 클릭 시 할 일 추가 모달이 열려야 한다', () => {
+    vi.mocked(useTodayTodos).mockReturnValue(makeTodayTodosResult())
+
+    renderPage()
+    fireEvent.click(screen.getByText('새 할일'))
 
     expect(screen.getByText('할 일 폼')).toBeInTheDocument()
+  })
+
+  it('하단 고정 추가 버튼 클릭 시 현재 선택된 날짜가 초기 마감일로 전달되어야 한다', () => {
+    vi.mocked(useTodayTodos).mockReturnValue(makeTodayTodosResult())
+
+    renderPage()
+    fireEvent.click(screen.getByText('새 할일'))
+
+    expect(screen.getByText('초기 마감일: 2026-07-31T00:00')).toBeInTheDocument()
+  })
+
+  it('날짜 셀 클릭 후 하단 추가 버튼을 누르면 새로 선택된 날짜가 초기 마감일로 전달되어야 한다', () => {
+    vi.mocked(useTodayTodos).mockReturnValue(makeTodayTodosResult())
+
+    renderPage()
+    fireEvent.click(screen.getByLabelText('8월 1일 토요일, 일정 없음'))
+    fireEvent.click(screen.getByText('새 할일'))
+
+    expect(screen.getByText('초기 마감일: 2026-08-01T00:00')).toBeInTheDocument()
   })
 
   it('모달의 닫기 콜백 호출 시 모달이 닫혀야 한다', () => {
     vi.mocked(useTodayTodos).mockReturnValue(makeTodayTodosResult())
 
     renderPage()
-    fireEvent.click(screen.getByText('새 할 일 추가'))
+    fireEvent.click(screen.getByText('새 할일'))
     expect(screen.getByText('할 일 폼')).toBeInTheDocument()
 
     fireEvent.click(screen.getByText('폼 닫기'))

--- a/client/src/features/today/pages/todayPage.styles.tsx
+++ b/client/src/features/today/pages/todayPage.styles.tsx
@@ -3,6 +3,7 @@ import { media } from "@/styles/breakpoints";
 import { colors } from "@/styles/colors";
 
 const Container = styled.div`
+  position: relative;
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -13,6 +14,7 @@ const ScrollArea = styled.div`
   overflow-y: auto;
   display: flex;
   flex-direction: column;
+  padding-bottom: 88px;
 `;
 
 const List = styled.div`
@@ -20,30 +22,51 @@ const List = styled.div`
   flex-direction: column;
 `;
 
-const AddButton = styled.button`
-  width: 100%;
+const Fab = styled.button`
+  position: absolute;
+  bottom: 24px;
+  right: 24px;
+  z-index: 2;
+
   height: 48px;
-  flex-shrink: 0;
+  padding: 0 20px;
+  border-radius: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
   background-color: ${colors.brand.primary};
   color: white;
   font-size: 14px;
   font-weight: 500;
   border: none;
-  border-radius: var(--border-radius-lg, 10px);
   cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  transition: background-color 0.2s ease;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  transition:
+    background-color 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.15s ease;
 
   &:hover {
     background-color: #0d5e49;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+    transform: translateY(-1px);
+  }
+
+  &:active {
+    transform: translateY(0) scale(0.97);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${colors.brand.secondary};
+    outline-offset: 2px;
   }
 
   ${media.mobile} {
-    height: 44px;
+    bottom: 16px;
+    right: 16px;
   }
 `;
 
-export { Container, ScrollArea, List, AddButton };
+export { Container, ScrollArea, List, Fab };

--- a/client/src/features/today/pages/todayPage.styles.tsx
+++ b/client/src/features/today/pages/todayPage.styles.tsx
@@ -1,10 +1,18 @@
 import { styled } from "styled-components";
+import { media } from "@/styles/breakpoints";
+import { colors } from "@/styles/colors";
 
 const Container = styled.div`
   display: flex;
   flex-direction: column;
   height: 100%;
+`;
+
+const ScrollArea = styled.div`
+  flex: 1;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
 `;
 
 const List = styled.div`
@@ -12,4 +20,30 @@ const List = styled.div`
   flex-direction: column;
 `;
 
-export { Container, List };
+const AddButton = styled.button`
+  width: 100%;
+  height: 48px;
+  flex-shrink: 0;
+  background-color: ${colors.brand.primary};
+  color: white;
+  font-size: 14px;
+  font-weight: 500;
+  border: none;
+  border-radius: var(--border-radius-lg, 10px);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: #0d5e49;
+  }
+
+  ${media.mobile} {
+    height: 44px;
+  }
+`;
+
+export { Container, ScrollArea, List, AddButton };

--- a/client/src/features/today/pages/todayPage.tsx
+++ b/client/src/features/today/pages/todayPage.tsx
@@ -10,7 +10,7 @@ import WeekStrip from "../components/weekStrip";
 import DailyProgress from "../components/dailyProgress";
 import TodaySection from "../components/todaySection";
 import TodayTodoItem from "../components/todayTodoItem";
-import { Container, ScrollArea, List, AddButton } from "./todayPage.styles";
+import { Container, ScrollArea, List, Fab } from "./todayPage.styles";
 
 const TodayPage = () => {
   const [selectedDate, setSelectedDate] = useState(() => toDateKey(new Date()));
@@ -118,10 +118,10 @@ const TodayPage = () => {
         )}
       </ScrollArea>
 
-      <AddButton onClick={() => setIsAddOpen(true)}>
-        <Plus size={16} />
+      <Fab onClick={() => setIsAddOpen(true)}>
+        <Plus size={16} aria-hidden="true" />
         새 할일
-      </AddButton>
+      </Fab>
 
       <Modal
         isOpen={isAddOpen}

--- a/client/src/features/today/pages/todayPage.tsx
+++ b/client/src/features/today/pages/todayPage.tsx
@@ -10,7 +10,7 @@ import WeekStrip from "../components/weekStrip";
 import DailyProgress from "../components/dailyProgress";
 import TodaySection from "../components/todaySection";
 import TodayTodoItem from "../components/todayTodoItem";
-import { Container, List } from "./todayPage.styles";
+import { Container, ScrollArea, List, AddButton } from "./todayPage.styles";
 
 const TodayPage = () => {
   const [selectedDate, setSelectedDate] = useState(() => toDateKey(new Date()));
@@ -62,67 +62,76 @@ const TodayPage = () => {
         totalCount={totalCount}
       />
 
-      {isLoading && <TodayItemSkeleton />}
+      <ScrollArea>
+        {isLoading && <TodayItemSkeleton />}
 
-      {!isLoading && isError && (
-        <EmptyState
-          icon={Sun}
-          title="할 일을 불러오지 못했습니다"
-          description="잠시 후 다시 시도해주세요"
-          actionLabel="다시 시도"
-          onAction={() => useGetTodos.refetch()}
-        />
-      )}
+        {!isLoading && isError && (
+          <EmptyState
+            icon={Sun}
+            title="할 일을 불러오지 못했습니다"
+            description="잠시 후 다시 시도해주세요"
+            actionLabel="다시 시도"
+            onAction={() => useGetTodos.refetch()}
+          />
+        )}
 
-      {!isLoading && !isError && !hasTodos && (
-        <EmptyState
-          icon={Sun}
-          title="오늘 할 일이 없습니다"
-          description="여유로운 하루네요. 새로운 할 일을 추가해보세요"
-          actionLabel="새 할 일 추가"
-          actionIcon={Plus}
-          onAction={() => setIsAddOpen(true)}
-        />
-      )}
+        {!isLoading && !isError && !hasTodos && (
+          <EmptyState
+            icon={Sun}
+            title="오늘 할 일이 없습니다"
+            description="여유로운 하루네요. 새로운 할 일을 추가해보세요"
+          />
+        )}
 
-      {!isLoading && !isError && hasTodos && (
-        <>
-          {inProgressTodos.length > 0 && (
-            <TodaySection title="진행 중">
-              <List>
-                {inProgressTodos.map((todo) => (
-                  <TodayTodoItem
-                    key={todo.id}
-                    todo={todo}
-                    selectedDate={selectedDate}
-                    onToggleDone={toggleDone}
-                  />
-                ))}
-              </List>
-            </TodaySection>
-          )}
+        {!isLoading && !isError && hasTodos && (
+          <>
+            {inProgressTodos.length > 0 && (
+              <TodaySection title="진행 중">
+                <List>
+                  {inProgressTodos.map((todo) => (
+                    <TodayTodoItem
+                      key={todo.id}
+                      todo={todo}
+                      selectedDate={selectedDate}
+                      onToggleDone={toggleDone}
+                    />
+                  ))}
+                </List>
+              </TodaySection>
+            )}
 
-          {doneTodos.length > 0 && (
-            <TodaySection title="완료">
-              <List>
-                {doneTodos.map((todo) => (
-                  <TodayTodoItem
-                    key={todo.id}
-                    todo={todo}
-                    selectedDate={selectedDate}
-                    onToggleDone={toggleDone}
-                  />
-                ))}
-              </List>
-            </TodaySection>
-          )}
-        </>
-      )}
+            {doneTodos.length > 0 && (
+              <TodaySection title="완료">
+                <List>
+                  {doneTodos.map((todo) => (
+                    <TodayTodoItem
+                      key={todo.id}
+                      todo={todo}
+                      selectedDate={selectedDate}
+                      onToggleDone={toggleDone}
+                    />
+                  ))}
+                </List>
+              </TodaySection>
+            )}
+          </>
+        )}
+      </ScrollArea>
+
+      <AddButton onClick={() => setIsAddOpen(true)}>
+        <Plus size={16} />
+        새 할일
+      </AddButton>
 
       <Modal
         isOpen={isAddOpen}
         setIsOpen={setIsAddOpen}
-        children={<TodoForm onClose={() => setIsAddOpen(false)} />}
+        children={
+          <TodoForm
+            initialDueAt={`${selectedDate}T00:00`}
+            onClose={() => setIsAddOpen(false)}
+          />
+        }
       />
     </Container>
   );

--- a/client/src/layouts/bottomTabBar/bottomTabBar.styles.tsx
+++ b/client/src/layouts/bottomTabBar/bottomTabBar.styles.tsx
@@ -2,8 +2,15 @@ import { styled } from "styled-components";
 import { NavLink } from "react-router-dom";
 import { colors } from "@/styles/colors";
 
-/** 탭바 전체 높이(약): padding 10px*2 + 아이콘 20px + gap 4px + 라벨 약 13px */
-export const BOTTOM_TAB_BAR_HEIGHT = 57;
+/**
+ * 탭바 전체 높이: padding 10px*2 + border-top 0.5px + TabNavLink 내용 높이.
+ * TabNavLink는 아이콘(20px)+gap(4px)+라벨(~13px)=37px보다 터치 타겟
+ * min-height: 44px가 더 크므로 실제 내용 높이는 44px가 기준이 된다.
+ * 20 + 0.5 + 44 = 64.5px → 서브픽셀 반올림 오차로 인한 겹침을 피하기 위해
+ * 65px로 올림한다. (기존에 37px 기준으로 계산한 57px는 실제보다 낮아
+ * 하단 고정 버튼이 탭바에 7px 이상 가려지는 버그의 원인이었다)
+ */
+export const BOTTOM_TAB_BAR_HEIGHT = 65;
 
 const TabBarContainer = styled.nav`
   position: fixed;

--- a/docs/superpowers/plans/2026-07-31-today-page-add-todo-button.md
+++ b/docs/superpowers/plans/2026-07-31-today-page-add-todo-button.md
@@ -1,0 +1,661 @@
+# 오늘 페이지 상시 노출 할 일 추가 버튼 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 오늘 페이지(`/today`)에서 할 일이 이미 있는 상태에도 목록 페이지와 동일한 스타일의 "새 할일" 버튼이 하단에 항상 고정 노출되어, 어떤 상태에서든 새 할 일을 추가할 수 있게 한다.
+
+**Architecture:** `TodayPage`의 `Container`를 flex column으로 재구성해 `WeekStrip`/`DailyProgress`는 상단 고정, 리스트/로딩/에러/빈 상태는 새 `ScrollArea`(flex:1, overflow-y:auto) 안으로, 신규 `AddButton`은 `ScrollArea` 바깥 하단에 항상 렌더링한다. 버튼 클릭 시 기존 `Modal`+`TodoForm` 흐름을 재사용하되 `initialDueAt`으로 현재 선택된 날짜를 넘긴다.
+
+**Tech Stack:** React, TypeScript, styled-components, Vitest + React Testing Library
+
+## Global Constraints
+
+- 스펙 문서: `docs/superpowers/specs/2026-07-31-today-page-add-todo-design.md` (이 계획의 근거 문서)
+- 버튼 스타일은 `client/src/features/todo/components/todoList.styles.tsx`의 `AddButton`과 시각적으로 동일해야 한다 (배경 `colors.brand.primary`, 높이 48px/모바일 44px, full-width, `border-radius: var(--border-radius-lg, 10px)`)
+- 버튼은 로딩/에러/빈 상태/리스트 상태와 무관하게 항상 렌더링된다 (조건부 렌더링 금지)
+- "오늘 할 일이 없습니다" `EmptyState`의 action prop(`actionLabel`/`actionIcon`/`onAction`)은 제거한다. "할 일을 불러오지 못했습니다" 에러 `EmptyState`의 "다시 시도" action은 그대로 유지한다
+- `TodoForm`에는 `initialDueAt` prop으로 ``${selectedDate}T00:00`` 형식 문자열(`calendar.tsx`와 동일 패턴)을 전달한다
+- 새 공용 컴포넌트를 만들지 않는다 — 스타일은 `todayPage.styles.tsx`에 feature-scoped로 추가한다
+- 커밋은 브랜치 `feature/today-page-add-todo-button`에서 진행한다 (이미 체크아웃되어 있음)
+
+---
+
+### Task 1: 오늘 페이지 레이아웃 스타일 추가 (ScrollArea, AddButton)
+
+**Files:**
+- Modify: `client/src/features/today/pages/todayPage.styles.tsx`
+
+**Interfaces:**
+- Consumes: 없음 (styled-components 정의만 추가)
+- Produces: `Container`(기존 유지, `overflow-y: auto` 제거), `ScrollArea`(신규), `List`(기존 유지), `AddButton`(신규) — Task 2가 이 네 가지를 `todayPage.tsx`에서 import해서 사용
+
+현재 파일 전체 내용:
+
+```tsx
+import { styled } from "styled-components";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+`;
+
+const List = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export { Container, List };
+```
+
+- [ ] **Step 1: 파일 전체를 아래 내용으로 교체**
+
+```tsx
+import { styled } from "styled-components";
+import { media } from "@/styles/breakpoints";
+import { colors } from "@/styles/colors";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+`;
+
+const ScrollArea = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+`;
+
+const List = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const AddButton = styled.button`
+  width: 100%;
+  height: 48px;
+  flex-shrink: 0;
+  background-color: ${colors.brand.primary};
+  color: white;
+  font-size: 14px;
+  font-weight: 500;
+  border: none;
+  border-radius: var(--border-radius-lg, 10px);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: #0d5e49;
+  }
+
+  ${media.mobile} {
+    height: 44px;
+  }
+`;
+
+export { Container, ScrollArea, List, AddButton };
+```
+
+- [ ] **Step 2: 타입체크로 문법 오류 확인**
+
+Run: `cd client && npx tsc --noEmit`
+Expected: 이 파일 관련 에러 없음 (아직 `todayPage.tsx`가 새 export를 쓰지 않으므로 `ScrollArea`/`AddButton` unused 경고는 없음 — named export라 unused 체크 대상이 아님)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/features/today/pages/todayPage.styles.tsx
+git commit -m "style: 오늘 페이지에 ScrollArea/AddButton 스타일 추가"
+```
+
+---
+
+### Task 2: TodayPage 컴포넌트에 하단 고정 추가 버튼 연결
+
+**Files:**
+- Modify: `client/src/features/today/pages/todayPage.tsx`
+- Test: `client/src/features/today/pages/__tests__/todayPage.test.tsx`
+
+**Interfaces:**
+- Consumes: Task 1의 `Container`, `ScrollArea`, `List`, `AddButton` (from `./todayPage.styles`); 기존 `TodoForm` props `initialDueAt?: string`, `onClose?: () => void` (변경 없음, `client/src/features/todo/components/todoForm/todoForm.tsx` 그대로 사용)
+- Produces: 없음 (최상위 페이지 컴포넌트)
+
+먼저 테스트를 새 동작 기준으로 갱신한 뒤(TDD), 컴포넌트를 구현한다.
+
+- [ ] **Step 1: 테스트 파일을 아래 전체 내용으로 교체**
+
+```tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import TodayPage from '../todayPage'
+import { useTodayTodos } from '../../hooks/useTodayTodos'
+import { useTodo } from '@/features/todo/hooks'
+import type { Todo } from '@/features/todo/types/todo.type'
+import type { UseTodayTodosResult } from '../../hooks/useTodayTodos'
+
+vi.mock('@/shared/lib/firebase', () => ({
+  db: {},
+  auth: { currentUser: null },
+  googleProvider: {},
+}))
+
+vi.mock('../../hooks/useTodayTodos', () => ({
+  useTodayTodos: vi.fn(),
+}))
+
+vi.mock('@/features/todo/hooks', () => ({
+  useTodo: vi.fn(),
+}))
+
+vi.mock('@/features/todo/components/todoForm/todoForm', () => ({
+  default: ({ initialDueAt, onClose }: { initialDueAt?: string; onClose: () => void }) => (
+    <div>
+      <span>할 일 폼</span>
+      <span>초기 마감일: {initialDueAt ?? '없음'}</span>
+      <button onClick={onClose}>폼 닫기</button>
+    </div>
+  ),
+}))
+
+// TodayItemSkeleton은 접근성 텍스트가 없는 순수 시각적 컴포넌트라
+// 로딩 상태를 명확히 식별할 수 있도록 마커로 교체하고, 나머지 shared export는 실제 구현을 사용한다.
+vi.mock('@/shared', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/shared')>()
+  return {
+    ...actual,
+    TodayItemSkeleton: () => <div>로딩 스켈레톤</div>,
+  }
+})
+
+const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
+  id: 'todo-1',
+  userId: 'user-1',
+  title: '테스트 할 일',
+  status: 'todo',
+  priority: 'medium',
+  startAt: null,
+  dueAt: null,
+  doneAt: null,
+  parentId: null,
+  order: 0,
+  recurrence: null,
+  recurrenceId: null,
+  createdAt: '2026-07-31T00:00:00.000Z',
+  updatedAt: '2026-07-31T00:00:00.000Z',
+  ...overrides,
+})
+
+const makeTodayTodosResult = (
+  overrides: Partial<UseTodayTodosResult> = {},
+): UseTodayTodosResult => ({
+  inProgressTodos: [],
+  doneTodos: [],
+  doneCount: 0,
+  totalCount: 0,
+  markers: {},
+  isLoading: false,
+  isError: false,
+  toggleDone: vi.fn(),
+  ...overrides,
+})
+
+const refetch = vi.fn()
+
+const renderPage = () => render(<MemoryRouter><TodayPage /></MemoryRouter>)
+
+describe('TodayPage 컴포넌트', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 6, 31, 9, 0))
+    vi.mocked(useTodo).mockReturnValue({
+      useGetTodos: { refetch } as unknown as ReturnType<typeof useTodo>['useGetTodos'],
+    } as ReturnType<typeof useTodo>)
+    refetch.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('로딩 중이면 스켈레톤을 표시하고 목록/빈 상태는 표시하지 않아야 한다', () => {
+    vi.mocked(useTodayTodos).mockReturnValue(
+      makeTodayTodosResult({ isLoading: true }),
+    )
+
+    renderPage()
+
+    expect(screen.getByText('로딩 스켈레톤')).toBeInTheDocument()
+    expect(screen.queryByText('오늘 할 일이 없습니다')).not.toBeInTheDocument()
+  })
+
+  it('에러 상태이면 에러 안내와 다시 시도 버튼을 표시해야 한다', () => {
+    vi.mocked(useTodayTodos).mockReturnValue(
+      makeTodayTodosResult({ isError: true }),
+    )
+
+    renderPage()
+
+    expect(screen.getByText('할 일을 불러오지 못했습니다')).toBeInTheDocument()
+    expect(screen.getByText('다시 시도')).toBeInTheDocument()
+  })
+
+  it('다시 시도 버튼 클릭 시 refetch가 호출되어야 한다', () => {
+    vi.mocked(useTodayTodos).mockReturnValue(
+      makeTodayTodosResult({ isError: true }),
+    )
+
+    renderPage()
+    fireEvent.click(screen.getByText('다시 시도'))
+
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('할 일이 없으면 빈 상태 안내를 표시해야 한다', () => {
+    vi.mocked(useTodayTodos).mockReturnValue(makeTodayTodosResult())
+
+    renderPage()
+
+    expect(screen.getByText('오늘 할 일이 없습니다')).toBeInTheDocument()
+  })
+
+  it('할 일이 없을 때 EmptyState 자체에는 더 이상 액션 버튼이 없어야 한다', () => {
+    vi.mocked(useTodayTodos).mockReturnValue(makeTodayTodosResult())
+
+    renderPage()
+
+    expect(screen.queryByText('새 할 일 추가')).not.toBeInTheDocument()
+  })
+
+  it('할 일이 없어도 하단 고정 추가 버튼은 노출되어야 한다', () => {
+    vi.mocked(useTodayTodos).mockReturnValue(makeTodayTodosResult())
+
+    renderPage()
+
+    expect(screen.getByText('새 할일')).toBeInTheDocument()
+  })
+
+  it('할 일이 있어도 하단 고정 추가 버튼이 계속 노출되어야 한다', () => {
+    const inProgress = makeTodo({ id: 'p1', title: '진행 중 할 일' })
+    vi.mocked(useTodayTodos).mockReturnValue(
+      makeTodayTodosResult({ inProgressTodos: [inProgress], totalCount: 1 }),
+    )
+
+    renderPage()
+
+    expect(screen.getByText('진행 중 할 일')).toBeInTheDocument()
+    expect(screen.getByText('새 할일')).toBeInTheDocument()
+  })
+
+  it('로딩 중에도 하단 고정 추가 버튼은 노출되어야 한다', () => {
+    vi.mocked(useTodayTodos).mockReturnValue(
+      makeTodayTodosResult({ isLoading: true }),
+    )
+
+    renderPage()
+
+    expect(screen.getByText('새 할일')).toBeInTheDocument()
+  })
+
+  it('에러 상태에서도 하단 고정 추가 버튼은 노출되어야 한다', () => {
+    vi.mocked(useTodayTodos).mockReturnValue(
+      makeTodayTodosResult({ isError: true }),
+    )
+
+    renderPage()
+
+    expect(screen.getByText('새 할일')).toBeInTheDocument()
+  })
+
+  it('하단 고정 추가 버튼 클릭 시 할 일 추가 모달이 열려야 한다', () => {
+    vi.mocked(useTodayTodos).mockReturnValue(makeTodayTodosResult())
+
+    renderPage()
+    fireEvent.click(screen.getByText('새 할일'))
+
+    expect(screen.getByText('할 일 폼')).toBeInTheDocument()
+  })
+
+  it('하단 고정 추가 버튼 클릭 시 현재 선택된 날짜가 초기 마감일로 전달되어야 한다', () => {
+    vi.mocked(useTodayTodos).mockReturnValue(makeTodayTodosResult())
+
+    renderPage()
+    fireEvent.click(screen.getByText('새 할일'))
+
+    expect(screen.getByText('초기 마감일: 2026-07-31T00:00')).toBeInTheDocument()
+  })
+
+  it('날짜 셀 클릭 후 하단 추가 버튼을 누르면 새로 선택된 날짜가 초기 마감일로 전달되어야 한다', () => {
+    vi.mocked(useTodayTodos).mockReturnValue(makeTodayTodosResult())
+
+    renderPage()
+    fireEvent.click(screen.getByLabelText('8월 1일 토요일, 일정 없음'))
+    fireEvent.click(screen.getByText('새 할일'))
+
+    expect(screen.getByText('초기 마감일: 2026-08-01T00:00')).toBeInTheDocument()
+  })
+
+  it('모달의 닫기 콜백 호출 시 모달이 닫혀야 한다', () => {
+    vi.mocked(useTodayTodos).mockReturnValue(makeTodayTodosResult())
+
+    renderPage()
+    fireEvent.click(screen.getByText('새 할일'))
+    expect(screen.getByText('할 일 폼')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('폼 닫기'))
+    expect(screen.queryByText('할 일 폼')).not.toBeInTheDocument()
+  })
+
+  it('진행 중인 할 일이 있으면 "진행 중" 섹션에 표시해야 한다', () => {
+    const inProgress = makeTodo({ id: 'p1', title: '진행 중 할 일' })
+    vi.mocked(useTodayTodos).mockReturnValue(
+      makeTodayTodosResult({
+        inProgressTodos: [inProgress],
+        totalCount: 1,
+      }),
+    )
+
+    renderPage()
+
+    expect(screen.getByText('진행 중')).toBeInTheDocument()
+    expect(screen.getByText('진행 중 할 일')).toBeInTheDocument()
+    expect(screen.queryByText('완료')).not.toBeInTheDocument()
+  })
+
+  it('완료된 할 일이 있으면 "완료" 섹션에 표시해야 한다', () => {
+    const done = makeTodo({ id: 'd1', title: '완료된 할 일', status: 'done' })
+    vi.mocked(useTodayTodos).mockReturnValue(
+      makeTodayTodosResult({
+        doneTodos: [done],
+        doneCount: 1,
+        totalCount: 1,
+      }),
+    )
+
+    renderPage()
+
+    expect(screen.getByText('완료')).toBeInTheDocument()
+    expect(screen.getByText('완료된 할 일')).toBeInTheDocument()
+    expect(screen.queryByText('진행 중')).not.toBeInTheDocument()
+  })
+
+  it('진행 중/완료 할 일이 모두 있으면 두 섹션을 모두 표시해야 한다', () => {
+    const inProgress = makeTodo({ id: 'p1', title: '진행 중 할 일' })
+    const done = makeTodo({ id: 'd1', title: '완료된 할 일', status: 'done' })
+    vi.mocked(useTodayTodos).mockReturnValue(
+      makeTodayTodosResult({
+        inProgressTodos: [inProgress],
+        doneTodos: [done],
+        doneCount: 1,
+        totalCount: 2,
+      }),
+    )
+
+    renderPage()
+
+    expect(screen.getByText('진행 중')).toBeInTheDocument()
+    expect(screen.getByText('완료')).toBeInTheDocument()
+  })
+
+  it('체크박스 클릭 시 toggleDone이 해당 todo와 함께 호출되어야 한다', () => {
+    const toggleDone = vi.fn()
+    const inProgress = makeTodo({ id: 'p1', title: '체크할 할 일' })
+    vi.mocked(useTodayTodos).mockReturnValue(
+      makeTodayTodosResult({
+        inProgressTodos: [inProgress],
+        totalCount: 1,
+        toggleDone,
+      }),
+    )
+
+    renderPage()
+    fireEvent.click(screen.getByRole('checkbox', { name: '체크할 할 일 완료 처리' }))
+
+    expect(toggleDone).toHaveBeenCalledWith(inProgress)
+  })
+
+  it('완료 진행률(DailyProgress)에 doneCount/totalCount를 전달해야 한다', () => {
+    const inProgress = makeTodo({ id: 'p1', title: '할 일 A' })
+    const done = makeTodo({ id: 'd1', title: '할 일 B', status: 'done' })
+    vi.mocked(useTodayTodos).mockReturnValue(
+      makeTodayTodosResult({
+        inProgressTodos: [inProgress],
+        doneTodos: [done],
+        doneCount: 1,
+        totalCount: 2,
+      }),
+    )
+
+    renderPage()
+
+    expect(screen.getByText('1 / 2 완료')).toBeInTheDocument()
+  })
+
+  it('날짜 셀 클릭 시 useTodayTodos가 새로운 selectedDate로 재호출되어야 한다', () => {
+    vi.mocked(useTodayTodos).mockReturnValue(makeTodayTodosResult())
+
+    renderPage()
+
+    // 오늘(2026-07-31) 기준 주간 스트립에서 8/1 셀 클릭
+    fireEvent.click(screen.getByLabelText('8월 1일 토요일, 일정 없음'))
+
+    const lastCallArgs = vi.mocked(useTodayTodos).mock.calls.at(-1)
+    expect(lastCallArgs?.[0]).toBe('2026-08-01')
+  })
+
+  it('다음 버튼 클릭 시 windowStart가 7일 뒤로 이동해야 한다', () => {
+    vi.mocked(useTodayTodos).mockReturnValue(makeTodayTodosResult())
+
+    renderPage()
+    fireEvent.click(screen.getByLabelText('다음 날짜'))
+
+    const lastCallArgs = vi.mocked(useTodayTodos).mock.calls.at(-1)
+    expect(lastCallArgs?.[1]).toBe('2026-08-07')
+  })
+})
+```
+
+- [ ] **Step 2: 테스트 실행해서 실패 확인**
+
+Run: `cd client && npx vitest run src/features/today/pages/__tests__/todayPage.test.tsx`
+Expected: FAIL — `screen.getByText('새 할일')`를 찾지 못하는 테스트들(하단 버튼 관련 신규/변경 테스트)이 실패. 기존 EmptyState 액션 관련 테스트도 `queryByText('새 할 일 추가')`가 여전히 존재해서 실패할 수 있음(컴포넌트를 아직 안 고쳤으므로)
+
+- [ ] **Step 3: `todayPage.tsx` 전체를 아래 내용으로 교체**
+
+```tsx
+import { useState, useCallback } from "react";
+import { Sun, Plus } from "lucide-react";
+import { useTodayTodos } from "../hooks/useTodayTodos";
+import { useTodo } from "@/features/todo/hooks";
+import { formatTodayLabel } from "@/shared/utils/formatToday";
+import { toDateKey, parseLocalDateOnly } from "@/shared/utils/date";
+import { EmptyState, TodayItemSkeleton, Modal } from "@/shared";
+import TodoForm from "@/features/todo/components/todoForm/todoForm";
+import WeekStrip from "../components/weekStrip";
+import DailyProgress from "../components/dailyProgress";
+import TodaySection from "../components/todaySection";
+import TodayTodoItem from "../components/todayTodoItem";
+import { Container, ScrollArea, List, AddButton } from "./todayPage.styles";
+
+const TodayPage = () => {
+  const [selectedDate, setSelectedDate] = useState(() => toDateKey(new Date()));
+  const [windowStart, setWindowStart] = useState(() => toDateKey(new Date()));
+  const [isAddOpen, setIsAddOpen] = useState(false);
+
+  const shiftWindow = useCallback((days: number) => {
+    setWindowStart((prev) => {
+      const d = parseLocalDateOnly(prev);
+      d.setDate(d.getDate() + days);
+      return toDateKey(d);
+    });
+  }, []);
+
+  const handleGoToToday = useCallback(() => {
+    const today = toDateKey(new Date());
+    setWindowStart(today);
+    setSelectedDate(today);
+  }, []);
+
+  const {
+    inProgressTodos,
+    doneTodos,
+    doneCount,
+    totalCount,
+    markers,
+    isLoading,
+    isError,
+    toggleDone,
+  } = useTodayTodos(selectedDate, windowStart);
+  const { useGetTodos } = useTodo();
+
+  const hasTodos = inProgressTodos.length > 0 || doneTodos.length > 0;
+
+  return (
+    <Container>
+      <WeekStrip
+        selectedDate={selectedDate}
+        windowStart={windowStart}
+        markers={markers}
+        onSelectDate={setSelectedDate}
+        onShiftLeft={() => shiftWindow(-7)}
+        onShiftRight={() => shiftWindow(7)}
+        onGoToToday={handleGoToToday}
+      />
+      <DailyProgress
+        dateLabel={formatTodayLabel(selectedDate)}
+        doneCount={doneCount}
+        totalCount={totalCount}
+      />
+
+      <ScrollArea>
+        {isLoading && <TodayItemSkeleton />}
+
+        {!isLoading && isError && (
+          <EmptyState
+            icon={Sun}
+            title="할 일을 불러오지 못했습니다"
+            description="잠시 후 다시 시도해주세요"
+            actionLabel="다시 시도"
+            onAction={() => useGetTodos.refetch()}
+          />
+        )}
+
+        {!isLoading && !isError && !hasTodos && (
+          <EmptyState
+            icon={Sun}
+            title="오늘 할 일이 없습니다"
+            description="여유로운 하루네요. 새로운 할 일을 추가해보세요"
+          />
+        )}
+
+        {!isLoading && !isError && hasTodos && (
+          <>
+            {inProgressTodos.length > 0 && (
+              <TodaySection title="진행 중">
+                <List>
+                  {inProgressTodos.map((todo) => (
+                    <TodayTodoItem
+                      key={todo.id}
+                      todo={todo}
+                      selectedDate={selectedDate}
+                      onToggleDone={toggleDone}
+                    />
+                  ))}
+                </List>
+              </TodaySection>
+            )}
+
+            {doneTodos.length > 0 && (
+              <TodaySection title="완료">
+                <List>
+                  {doneTodos.map((todo) => (
+                    <TodayTodoItem
+                      key={todo.id}
+                      todo={todo}
+                      selectedDate={selectedDate}
+                      onToggleDone={toggleDone}
+                    />
+                  ))}
+                </List>
+              </TodaySection>
+            )}
+          </>
+        )}
+      </ScrollArea>
+
+      <AddButton onClick={() => setIsAddOpen(true)}>
+        <Plus size={16} />
+        새 할일
+      </AddButton>
+
+      <Modal
+        isOpen={isAddOpen}
+        setIsOpen={setIsAddOpen}
+        children={
+          <TodoForm
+            initialDueAt={`${selectedDate}T00:00`}
+            onClose={() => setIsAddOpen(false)}
+          />
+        }
+      />
+    </Container>
+  );
+};
+
+export default TodayPage;
+```
+
+- [ ] **Step 4: 테스트 재실행해서 통과 확인**
+
+Run: `cd client && npx vitest run src/features/today/pages/__tests__/todayPage.test.tsx`
+Expected: PASS (모든 테스트)
+
+- [ ] **Step 5: 전체 유닛 테스트 + 타입체크 + 린트 실행**
+
+Run: `cd client && npm run test && npx tsc --noEmit && npm run lint`
+Expected: 전부 통과 (다른 파일에서 `todayPage.styles`의 `Container`/`List` export를 참조하는 곳이 없는지도 이 과정에서 함께 확인됨)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/features/today/pages/todayPage.tsx client/src/features/today/pages/__tests__/todayPage.test.tsx
+git commit -m "feat: 오늘 페이지에 하단 고정 할 일 추가 버튼 연결"
+```
+
+---
+
+### Task 3: 로컬 브라우저로 실제 동작 확인
+
+**Files:** 없음 (코드 변경 없는 수동 검증 태스크)
+
+**Interfaces:**
+- Consumes: Task 2에서 완성된 `TodayPage`
+- Produces: 없음
+
+- [ ] **Step 1: 개발 서버 실행 확인**
+
+Run: `cd client && npm run dev` (이미 실행 중이면 생략)
+
+- [ ] **Step 2: 할 일이 있는 상태에서 확인**
+
+브라우저로 `/today` 접속. 할 일이 1개 이상 있는 날짜에서 하단에 "새 할일" 버튼이 항상 보이는지, `WeekStrip`/`DailyProgress`는 상단에 고정되고 리스트만 스크롤되는지 확인.
+
+- [ ] **Step 3: 버튼 클릭 → 모달 → 마감일 기본값 확인**
+
+"새 할일" 버튼 클릭 후 모달이 열리고, 마감일 입력 필드에 현재 선택된 날짜가 기본값으로 채워져 있는지 확인. 다른 날짜(예: WeekStrip에서 다음 날짜)를 선택한 뒤 다시 버튼을 눌러 마감일 기본값이 바뀌는지 확인.
+
+- [ ] **Step 4: 할 일이 없는 상태에서 확인**
+
+할 일이 없는 날짜로 이동해 EmptyState 안내 문구만 보이고 자체 액션 버튼은 없는지, 하단 고정 버튼은 여전히 보이는지 확인.
+
+- [ ] **Step 5: 모바일 너비에서 확인**
+
+브라우저 창 너비를 480px 이하로 줄이거나 개발자 도구 반응형 모드로 전환해, 버튼 높이가 44px로 줄어들고 하단 탭바와 겹치지 않는지 확인.

--- a/docs/superpowers/specs/2026-07-31-today-page-add-todo-design.md
+++ b/docs/superpowers/specs/2026-07-31-today-page-add-todo-design.md
@@ -2,7 +2,12 @@
 
 - 대상 파일: `client/src/features/today/pages/todayPage.tsx`, `client/src/features/today/pages/todayPage.styles.tsx`
 - 작성일: 2026-07-31
-- 상태: 사용자 승인 완료 — 구현 계획 수립 대기
+- 상태: **폐기됨 — `2026-07-31-today-page-fab-button.md`로 대체됨 (2026-07-31)**
+
+> **[대체 공지, 2026-07-31]** 이 문서에서 결정한 "목록 페이지와 동일한 하단 고정 풀와이드 바" 설계는 구현 후 사용자 검토 결과 데스크톱/태블릿에서 어색하다는 피드백을 받아 폐기되었다.
+> 오늘 페이지의 할 일 추가 버튼은 이제 화면 크기와 무관하게 통일된 FAB(Floating Action Button) 패턴으로 전환한다.
+> 최신 설계는 [`2026-07-31-today-page-fab-button.md`](./2026-07-31-today-page-fab-button.md)를 참조할 것. 이 문서는 변경 배경 기록용으로만 보존한다.
+
 
 ## 1. 문제 정의
 

--- a/docs/superpowers/specs/2026-07-31-today-page-add-todo-design.md
+++ b/docs/superpowers/specs/2026-07-31-today-page-add-todo-design.md
@@ -1,0 +1,57 @@
+# 오늘 페이지 상시 노출 할 일 추가 버튼 설계
+
+- 대상 파일: `client/src/features/today/pages/todayPage.tsx`, `client/src/features/today/pages/todayPage.styles.tsx`
+- 작성일: 2026-07-31
+- 상태: 사용자 승인 완료 — 구현 계획 수립 대기
+
+## 1. 문제 정의
+
+메인 화면인 "오늘" 페이지(`/today`)는 할 일이 하나도 없을 때만 `EmptyState`의 "새 할 일 추가" 버튼을 통해 투두를 추가할 수 있다. 할 일이 하나라도 있으면(`hasTodos === true`) `EmptyState` 자체가 렌더링되지 않으므로, 이 버튼도 함께 사라진다. 즉 오늘 화면에서 가장 흔한 상태(할 일이 이미 있는 평상시)에는 투두를 추가할 진입점이 화면 어디에도 없다.
+
+로컬 개발 서버(`/today`)에서 실제로 확인한 결과, 할 일 3건이 있는 상태에서 화면 전체를 스크롤해봐도 추가 버튼이 전혀 노출되지 않음을 확인했다.
+
+목록 페이지(`todoList.tsx`)는 리스트가 비어있든 아니든 `TodoListContainer`(height:100%, flex column) 하단에 `AddButton`이 항상 고정 노출되어 이런 문제가 없다. 오늘 페이지만 이 패턴에서 벗어나 있다.
+
+이 문제는 PM/UX 검토에서도 "메인 화면의 핵심 기능 결손"으로 분류되었고, 목록 페이지와 동일한 하단 고정 버튼 패턴을 적용하는 것으로 방향을 정했다(플로팅 오버레이 FAB는 채택하지 않음 — 목록 페이지의 `AddButton`이 실제로는 `position: fixed` 오버레이가 아니라 flex 레이아웃으로 하단에 고정되는 방식임을 확인했고, 동일 패턴을 재사용하는 쪽이 앱 전체의 일관성 측면에서 더 낫다고 판단).
+
+## 2. 결정된 설계
+
+### 레이아웃 재구성
+
+`todayPage.tsx`의 `Container`를 `todoList.tsx`의 `TodoListContainer`와 동일한 구조로 바꾼다:
+
+- `Container`: `height: 100%; display: flex; flex-direction: column` (기존 `overflow-y: auto`는 제거하고 아래 `ScrollArea`로 이동)
+- `WeekStrip`, `DailyProgress`는 `Container` 최상단에 위치, 스크롤 영역 밖에 고정
+- 신규 `ScrollArea` (`flex: 1; overflow-y: auto`)가 로딩 스켈레톤 / 에러 `EmptyState` / 빈 상태 `EmptyState` / 할 일 리스트(`TodaySection` 2개)를 감싼다
+- 신규 `AddButton`(목록 페이지의 `AddButton`과 시각적으로 동일한 스타일 — `colors.brand.primary` 배경, 데스크톱 48px / `media.mobile` 44px 높이, full-width, `border-radius: var(--border-radius-lg, 10px)`)을 `ScrollArea` 바깥, `Container`의 마지막 자식으로 배치. 로딩/에러/빈 상태/리스트 상태와 무관하게 **항상** 렌더링된다(목록 페이지 `AddButton`과 동일한 조건 없음 방식)
+
+### 버튼 동작
+
+- 클릭 시 기존 `isAddOpen` state를 `true`로 설정 — 이미 존재하는 `Modal` + `TodoForm` 흐름을 그대로 재사용
+- `TodoForm`에 `initialDueAt={`${selectedDate}T00:00`}`를 전달한다. `calendar.tsx`가 이미 쓰고 있는 것과 동일한 패턴으로, `WeekStrip`에서 현재 선택된 날짜(`selectedDate`, `YYYY-MM-DD` 형식)를 새 할 일의 마감일 기본값으로 채운다
+- 버튼 라벨/아이콘은 목록 페이지와 통일: `<Plus size={16} /> 새 할일`
+
+### EmptyState 변경
+
+- "오늘 할 일이 없습니다" `EmptyState`(현재 `actionLabel="새 할 일 추가"`, `actionIcon={Plus}`, `onAction={() => setIsAddOpen(true)}`)에서 `actionLabel`/`actionIcon`/`onAction` prop을 제거한다. 하단에 상시 노출되는 `AddButton`과 중복되는 CTA를 없애기 위함이며, 안내 문구(`title`/`description`)는 그대로 유지한다
+- "할 일을 불러오지 못했습니다" 에러 상태 `EmptyState`의 "다시 시도"(`onAction={() => useGetTodos.refetch()}`) 액션은 변경하지 않는다 — 재시도라는 별개 목적의 액션이므로 하단 추가 버튼과 중복되지 않는다
+
+## 3. 범위
+
+### 변경 대상
+
+- `client/src/features/today/pages/todayPage.tsx` — 레이아웃 구조 변경(`ScrollArea`로 감싸기), 신규 `AddButton` 추가 및 클릭 핸들러, `TodoForm`에 `initialDueAt` 전달, "빈 상태" `EmptyState`의 action prop 제거
+- `client/src/features/today/pages/todayPage.styles.tsx` — `ScrollArea`, `AddButton` styled-component 신규 추가
+- `todayPage` 관련 기존 테스트(빈 상태 `EmptyState`의 액션 버튼 클릭을 검증하는 테스트 등) — 새 하단 버튼 기준으로 갱신
+
+### 범위 밖 (변경하지 않음)
+
+- 데스크톱/모바일 브레이크포인트별 다른 처리 없음 — 버튼은 항상 동일한 방식으로 렌더링되고, 반응형은 기존 `media.mobile` 스타일만 재사용(목록 페이지 `AddButton`과 동일)
+- 새로운 공용(shared) 버튼 컴포넌트 추출은 하지 않는다 — 목록 페이지와 마찬가지로 각 feature가 자신의 스타일을 소유하는 기존 컨벤션을 따른다
+- `WeekStrip`, `DailyProgress`, `TodaySection`, `TodayTodoItem` 등 기존 컴포넌트의 내부 로직/스타일은 변경하지 않는다 — 오늘 페이지 레이아웃 컨테이너 구조와 추가 버튼만 다룬다
+- `todoList.tsx`의 `AddButton`을 직접 수정하거나 리팩터링하지 않는다
+
+## 4. 검증
+
+- 유닛/컴포넌트 테스트: 할 일이 있는 상태에서도 하단 `AddButton`이 렌더링되는지, 클릭 시 `Modal`이 열리고 `TodoForm`에 `initialDueAt`이 `selectedDate` 기준으로 전달되는지, 로딩/에러 상태에서도 버튼이 계속 노출되는지, 빈 상태 `EmptyState`에 더 이상 action 버튼이 없는지
+- 로컬 개발 서버(`npm run dev`)에서 오늘 화면을 직접 열어 할 일이 있는 상태/없는 상태 양쪽에서 버튼 동작과 레이아웃(상단 고정/리스트만 스크롤/하단 고정)을 육안으로 확인

--- a/docs/superpowers/specs/2026-07-31-today-page-fab-button.md
+++ b/docs/superpowers/specs/2026-07-31-today-page-fab-button.md
@@ -1,0 +1,223 @@
+# 오늘 페이지 할 일 추가 버튼 — FAB(Floating Action Button) 전환 설계
+
+- 대상 파일: `client/src/features/today/pages/todayPage.tsx`, `client/src/features/today/pages/todayPage.styles.tsx`
+- 작성일: 2026-07-31
+- 상태: 사용자 검토 대기 (승인 시 `ui-ux-improver`가 구현)
+- **이 문서는 `2026-07-31-today-page-add-todo-design.md`를 대체한다.** 해당 문서는 폐기됨(문서 상단에 대체 표시 추가함).
+
+## 0. 변경 배경 (왜 다시 설계하는가)
+
+이전 스펙(`2026-07-31-today-page-add-todo-design.md`)에 따라 오늘 페이지에 목록 페이지(`todoList.tsx`)와 동일한 "하단 고정 풀와이드 바" 형태의 `AddButton`을 구현·커밋 완료했다(구현 커밋 `754ad28`, `74f757a`, 버그 수정 `24b1a17`). 이 스펙은 "플로팅 오버레이 FAB는 채택하지 않는다"고 명시적으로 결정했었다.
+
+사용자가 로컬 dev 서버에서 실제 구현 결과를 확인한 뒤 피드백을 줬다: 모바일 크기에서는 하단 풀와이드 바가 수긍이 가지만, 태블릿/데스크톱처럼 화면이 넓어지면 화면 전체 폭을 가로지르는 두꺼운 바가 어색하다는 것이다. 이에 대해 "① 모바일만 바 유지 + 태블릿/데스크톱은 FAB로 반응형 분기" / "② 전 화면 폭에서 FAB로 통일" 두 옵션을 제시했고, 사용자는 **② 전체 통일(모든 화면 크기에서 FAB)**을 선택했다.
+
+즉 이번 스펙의 결론은 이전 스펙의 정반대다: 하단 고정 풀와이드 바를 걷어내고, 모바일/태블릿/데스크톱 구분 없이 동일한 FAB 하나로 통일한다.
+
+## 1. 결정된 설계 개요
+
+- 기존에 구현된 레이아웃 골격(`Container` → `WeekStrip`/`DailyProgress`(상단 고정) → `ScrollArea`(스크롤 영역) → `List`)은 **그대로 유지**한다.
+- `ScrollArea` 바깥에 flex 흐름으로 배치되던 풀와이드 `AddButton`을 제거하고, 대신 `Container` 우하단에 **`position: absolute`로 오버레이되는 원형/필(pill) 플로팅 버튼 `Fab`**를 추가한다.
+- 클릭 시 동작(모달 오픈, `initialDueAt` 전달)은 **변경 없음**.
+- 화면 크기별 분기(모바일 전용 vs 데스크톱 전용 스타일)는 두지 않는다 — 오직 화면 가장자리에 가까울 때의 여백 값만 아주 소폭 다르다(4번 항목 참조). 버튼의 모양·크기·라벨·색상은 모든 화면 크기에서 동일하다.
+
+## 2. FAB 스타일 스펙
+
+### 2.1 형태: 아이콘 + 라벨을 유지하는 필(pill) 버튼
+
+원형 아이콘 전용 FAB가 아니라 **아이콘(`Plus`) + 라벨("새 할일")을 유지한 pill 형태**를 채택한다.
+
+이유:
+- "할 일 추가"는 상시 노출되는 주요 액션이며, 아이콘만으로는 최초 사용자에게 의미가 완전히 명확하지 않다. 라벨을 남기면 별도 `aria-label` 설계 없이도 버튼의 텍스트 콘텐츠 자체가 접근성 이름(accessible name)이 된다.
+- 기존 목록 페이지 `AddButton`, 이전 오늘 페이지 구현과 동일하게 `<Plus size={16} /> 새 할일` 마크업을 그대로 재사용할 수 있어 변경 범위가 작다.
+- Gmail의 "편지쓰기" 버튼처럼 라벨이 있는 pill FAB는 데스크톱에서도 어색하지 않은, 이미 널리 쓰이는 패턴이다.
+
+### 2.2 크기/스타일 — 모든 화면 크기 공통(분기 없음)
+
+```
+height: 48px;
+padding: 0 20px;
+border-radius: 24px;              /* height/2, 완전한 pill */
+display: flex;
+align-items: center;
+justify-content: center;
+gap: 8px;
+background-color: ${colors.brand.primary};  /* 기존 AddButton과 동일 토큰 재사용 */
+color: white;
+font-size: 14px;
+font-weight: 500;
+border: none;
+cursor: pointer;
+box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
+```
+
+- `width`는 `auto` — 풀와이드였던 기존 버튼과 달리 콘텐츠(아이콘+라벨+패딩)에 맞춰 크기가 정해진다.
+- 높이 48px는 CLAUDE.md의 "모든 인터랙티브 요소 최소 44px" 기준을 충족한다.
+- 모바일 전용 축소 높이(기존 44px)는 **적용하지 않는다** — "전체 통일" 결정에 따라 화면 크기와 무관하게 48px 고정.
+- 아이콘: `<Plus size={16} />` (기존과 동일, 변경 없음)
+- 색상: `colors.brand.primary` 재사용(신규 토큰 불필요). hover 배경은 기존 `AddButton`과 동일하게 `#0d5e49` 리터럴 값을 그대로 재사용한다(기존 코드도 토큰이 아닌 리터럴이므로 새로 토큰화하지 않음).
+
+### 2.3 인터랙션 상태
+
+```
+&:hover {
+  background-color: #0d5e49;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+  transform: translateY(-1px);
+}
+
+&:active {
+  transform: translateY(0) scale(0.97);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+&:focus-visible {
+  outline: 2px solid ${colors.brand.secondary};
+  outline-offset: 2px;
+}
+```
+
+- `:focus-visible` 아웃라인은 기존 `AddButton`에는 없던 스타일이지만, FAB는 화면 위에 떠 있는 독립적인 오버레이 요소가 되므로 키보드 포커스 시 위치를 명확히 알 수 있도록 신규로 추가한다.
+
+## 3. 배치 방식 (position, 좌표, z-index)
+
+### 3.1 `position: absolute` — `fixed`가 아니라 `absolute`를 쓰는 이유 (중요, 반드시 이대로 구현)
+
+`todayPage.styles.tsx`의 `Container`에 `position: relative;`를 추가하고, `Fab`는 그 안에서 `position: absolute`로 배치한다. **`position: fixed`(뷰포트 기준)는 채택하지 않는다.**
+
+근거 — 앱 레이아웃 구조(`client/src/App.tsx`, `client/src/App.styles.tsx`) 확인 결과:
+
+- 모바일/태블릿(`useMediaQuery("tablet")`, 즉 **너비 ≤ 768px** — `breakpoints.tablet` 기준. `todayPage.styles.tsx`가 지금까지 버튼 크기 분기에 써온 `media.mobile`(≤480px)과는 다른 기준이니 혼동하지 말 것)에서는 `<Main>`이 `padding-bottom: ${BOTTOM_TAB_BAR_HEIGHT}px`(65px)를 이미 갖고 있다. 오늘 페이지의 `Container`(`height: 100%`)는 이 `Main`의 콘텐츠 박스 안에 렌더링되므로, `Container`의 하단 경계는 이미 `BottomTabBar`(65px, `position:fixed;bottom:0;z-index:10`) 바로 위에서 끝난다.
+- 데스크톱(> 768px)에서는 `BottomTabBar` 대신 일반 문서 흐름의 `<Footer />`가 `ContentContainer`(SNB+Main을 감싸는 영역) 바로 다음 형제로 렌더링된다. `Footer`는 `position:fixed`가 아니지만, 상위 `Container`가 `height: 100vh`인 flex column이라 실질적으로 뷰포트 하단에 고정된 것처럼 보인다. `Footer`의 실제 높이(패딩 16px×2 + 텍스트 한 줄 ≈ 50~55px)는 어디에도 상수로 정의돼 있지 않다 — 이 값에 의존한 하드코딩된 `bottom` 오프셋을 만들면 Footer 스타일이 바뀔 때마다 깨진다.
+- 반면 `Container`에 `position: relative`를 주고 `Fab`를 그 안에서 `position: absolute; bottom: 24px; right: 24px`로 배치하면, `Fab`는 **오늘 페이지 자신의 콘텐츠 박스 기준**으로 위치가 정해진다. 이 콘텐츠 박스는 모바일/태블릿에서는 이미 `Main`의 `padding-bottom`만큼 탭바 위에서 끝나고, 데스크톱에서는 `Footer` 바로 앞에서 끝난다. 즉 **탭바/Footer의 정확한 높이를 몰라도, `Container` 하나의 경계 안에서만 24px 오프셋을 주면 두 레이아웃 모두에서 자동으로 안전하다.**
+- SNB(데스크톱 전용 좌측 사이드바, `client/src/layouts/snb/snb.tsx`)는 `right` 기준 배치와 무관하다 — SNB는 화면 왼쪽에, `Fab`는 `Container`(Main 콘텐츠 영역) 오른쪽 끝에 붙으므로 SNB의 열림/닫힘 폭(200px/40px)과 무관하게 절대 겹치지 않는다.
+
+**구현 시 반드시 확인할 것**: `Container`에 `position: relative`를 빠뜨리면 `Fab`의 `position: absolute`가 상위의 포지셔닝된 조상(현재 체인에는 없음 → 뷰포트 기준으로 계산됨, 사실상 `fixed`와 동일하게 동작)까지 거슬러 올라가 위에서 설명한 안전장치가 모두 무효화되고 Footer/탭바와 실제로 겹치게 된다.
+
+### 3.2 좌표
+
+```
+Container {
+  position: relative;   /* 신규 추가 */
+  /* display: flex; flex-direction: column; height: 100%; 기존 유지 */
+}
+
+Fab {
+  position: absolute;
+  bottom: 24px;
+  right: 24px;
+
+  ${media.mobile} {   /* ≤480px: 화면 여백이 좁으므로만 소폭 축소, 모양/크기/z-index는 동일 */
+    bottom: 16px;
+    right: 16px;
+  }
+}
+```
+
+- `media.mobile`(480px) 분기는 탭바 회피 목적이 **아니다**(그건 이미 `Container` 콘텐츠 박스 경계로 해결됨) — 순수하게 좁은 화면에서 가장자리 여백을 8px 그리드에 맞춰 24px→16px로 줄이는 시각적 미세조정이다.
+
+### 3.3 z-index
+
+```
+z-index: 2;
+```
+
+- `TodayTodoItem`(`todayTodoItem.styles.tsx`) 내부에 로컬 `z-index: 1`(항목 자체 배지/체크박스 겹침 처리용)이 이미 존재하므로, `Fab`가 리스트 항목보다 위에 그려지도록 그보다 큰 값을 명시적으로 지정한다.
+- `BottomTabBar`(`z-index: 10`)와는 애초에 `Container` 경계 안에서 배치가 끝나 시각적으로 겹칠 일이 없으므로 그 값과 직접 비교할 필요는 없지만, 혹시 모를 레이아웃 변경에 대비해 `10`보다 낮은 안전한 값(`2`)을 유지한다.
+- `Modal`(`ModalBackground z-index: 10000`, `ModalContainer z-index: 1000`)은 `Fab`보다 항상 위에 그려져야 하며, 이미 두 값 모두 `2`보다 훨씬 크므로 별도 조치 불필요.
+
+## 4. 탭바/Footer/SNB와의 관계 요약표
+
+| 화면 크기 | 하단 요소 | Fab와의 관계 |
+|---|---|---|
+| ≤ 768px (모바일·태블릿, `BottomTabBar` 노출) | `BottomTabBar`, `position:fixed`, 65px, `z-index:10` | `Container`가 이미 `Main`의 `padding-bottom:65px`만큼 탭바 위에서 끝남 → `Fab`는 그 안에서 `bottom:24px`(또는 480px 이하에서 16px) 추가 여백만 가지면 됨. 탭바 위에 40~49px가량의 여유 간격이 생김 |
+| > 768px (데스크톱, SNB+Footer 노출) | `Footer`(일반 흐름, 사실상 뷰포트 하단 고정처럼 보임), `SNB`(좌측, 폭 40~200px) | `Fab`는 `Container`(Main 콘텐츠 영역) 경계 안에서 `bottom:24px; right:24px` → Footer 시작 지점보다 24px 위에서 끝나 절대 겹치지 않음. `right` 기준 배치라 좌측 SNB와는 애초에 무관 |
+
+## 5. 스크롤 컨테이너(`ScrollArea`)와의 관계
+
+- `Fab`는 `ScrollArea`의 자식이 아니라 `Container`의 자식(스크롤 영역 밖)이다 — 리스트를 스크롤해도 `Fab`는 화면(정확히는 `Container` 콘텐츠 박스) 우하단에 고정된 채로 유지된다.
+- 이전 풀와이드 바 버전과의 핵심 차이: 이전에는 `AddButton`이 `Container`의 flex 흐름에 참여해 자기 높이(48px)만큼 공간을 차지했고, `ScrollArea`(`flex:1`)는 그 나머지 높이만 사용했다. `Fab`는 `position: absolute`로 흐름에서 완전히 빠지므로 **`ScrollArea`는 `Container`의 전체 높이를 다시 차지하게 되고, 리스트를 끝까지 스크롤하면 마지막 항목이 `Fab` 아래에 시각적으로 겹칠 수 있다.** 이는 FAB 패턴에서 흔히 나타나는 정상적인 트레이드오프(예: Gmail 편지쓰기 버튼이 메일 목록 마지막 줄과 겹치는 것과 동일)이며 버그가 아니다.
+- 다만 마지막 항목이 `Fab`에 완전히 가려 탭할 수 없게 되는 것은 막아야 하므로, `ScrollArea`에 하단 여유 패딩을 추가한다:
+
+```
+ScrollArea {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 88px;   /* Fab 높이 48px + 오프셋 24px + 여유 16px */
+}
+```
+
+  - 모바일에서 오프셋이 16px로 줄어도(48+16+16=80px) 88px 패딩이 이를 충분히 덮으므로 화면 크기별로 이 값을 분기하지 않는다(통일 원칙 유지, 여분 16~24px 정도의 하단 공백은 시각적으로 무해함).
+
+## 6. 인터랙션 — 변경 없음
+
+- 클릭 시 `isAddOpen` state를 `true`로 설정하는 기존 로직 그대로 유지.
+- 기존 `Modal` + `TodoForm` 흐름 그대로 재사용.
+- `TodoForm`에 `initialDueAt={`${selectedDate}T00:00`}` 전달 방식 변경 없음.
+- 버튼 라벨/아이콘: `<Plus size={16} /> 새 할일` 변경 없음.
+- hover/active/focus-visible 스타일은 2.3절 참조(신규 추가, 이전 풀와이드 바에는 없던 `:focus-visible`/`:active` 스타일 추가).
+
+## 7. 목록 페이지(`todoList.tsx`)와의 일관성 — 의도된 트레이드오프
+
+- 이번 스코프는 오늘 페이지(`todayPage.tsx`/`todayPage.styles.tsx`)로 한정한다. 목록 페이지의 `AddButton`(하단 고정 풀와이드 바)은 **건드리지 않는다.**
+- 그 결과 앱 안에 "할 일 추가" 버튼 패턴이 두 가지(오늘 페이지: 우하단 FAB / 목록 페이지: 하단 풀와이드 바) 공존하게 된다. 이는 **의도된 트레이드오프**다 — 오늘 페이지는 캘린더형 위젯(`WeekStrip`, `DailyProgress`)이 상단을 차지해 화면이 이미 여러 구역으로 나뉘어 있어 FAB가 자연스럽고, 목록 페이지는 단일 리스트+정렬/필터 UI 위주라 풀와이드 바가 여전히 자연스럽다는 판단이나, 이번 스펙에서 목록 페이지 쪽을 재검증하지는 않았다.
+- 목록 페이지도 동일 패턴(FAB)으로 통일할지 여부는 **이번 스코프 밖**이며, 사용자가 별도로 요청하지 않는 한 목록 페이지는 수정하지 않는다.
+
+## 8. 범위
+
+### 변경 대상
+
+- `client/src/features/today/pages/todayPage.styles.tsx`
+  - `Container`에 `position: relative;` 추가
+  - `ScrollArea`에 `padding-bottom: 88px;` 추가
+  - `AddButton`(풀와이드 바) 제거, `Fab`(pill 플로팅 버튼) 신규 추가 — 2절/3절 스타일 그대로
+  - `List`는 변경 없음
+- `client/src/features/today/pages/todayPage.tsx`
+  - `AddButton` import를 `Fab`로 교체, JSX에서 렌더 위치를 `Container`의 마지막 자식으로 유지(단, 흐름이 아닌 오버레이이므로 DOM 순서상 `ScrollArea` 다음에 두되 시각적으로는 겹쳐 그려짐 — DOM 순서 자체는 그대로 둬도 무방)
+  - 클릭 핸들러, `Modal`/`TodoForm` 연결 로직은 변경 없음
+- `client/src/features/today/pages/__tests__/todayPage.test.tsx`
+  - 텍스트 기반 쿼리(`screen.getByText('새 할일')`)로 작성된 기존 테스트는 대부분 그대로 통과해야 한다(라벨 텍스트 유지). 스타일/포지셔닝 관련 스냅샷·클래스명 의존 테스트가 있다면 갱신 필요(현재는 없는 것으로 확인됨)
+
+### 범위 밖 (변경하지 않음)
+
+- `todoList.tsx`, `todoList.styles.tsx`의 `AddButton`(풀와이드 바) — 일절 수정하지 않음
+- `WeekStrip`, `DailyProgress`, `TodaySection`, `TodayTodoItem` 등 오늘 페이지 하위 컴포넌트의 내부 로직/스타일
+- `EmptyState`의 action prop 제거 등 이전 스펙에서 이미 반영된 변경 사항 — 그대로 유지(되돌리지 않음)
+- `App.tsx`/`App.styles.tsx`/`BottomTabBar`/`Footer`/`SNB` — 레이아웃 상수(`BOTTOM_TAB_BAR_HEIGHT` 등)를 참조만 하고 수정하지 않음
+- 새로운 공용(shared) FAB 컴포넌트 추출 — 하지 않는다. 오늘 페이지가 자신의 스타일을 소유하는 기존 컨벤션을 따른다(목록 페이지 `AddButton`과 마찬가지로 feature-scoped)
+
+## 9. 접근성 요구사항
+
+- `Fab`는 시각적 텍스트("새 할일")를 그대로 유지하므로 별도 `aria-label` 없이도 접근성 이름이 확보된다. 별도 `aria-label` prop을 추가하지 않는다(라벨 텍스트와 중복되는 aria-label은 오히려 스크린리더 중복 안내를 유발할 수 있음).
+- `Plus` 아이콘은 장식적 요소이므로 스크린리더가 이중으로 읽지 않도록 유지한다(lucide-react 아이콘은 기본적으로 `aria-hidden`을 설정하지 않으므로, 구현 시 `<Plus size={16} aria-hidden="true" />`로 명시하는 것을 권장 — 필수는 아니나 접근성 향상을 위해 권장).
+- `:focus-visible` 스타일(2.3절)은 키보드 사용자가 화면에 떠 있는 `Fab`의 포커스 위치를 시각적으로 인지할 수 있도록 반드시 포함한다.
+- 버튼 높이 48px는 CLAUDE.md의 "모든 인터랙티브 요소 최소 44px" 요구사항을 충족한다.
+
+## 10. 애니메이션/트랜지션 명세
+
+- `transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;`
+- hover: `translateY(-1px)` + 그림자 확대(0 6px 16px rgba(0,0,0,0.2))로 "떠오르는" 느낌
+- active(press): `translateY(0) scale(0.97)` + 그림자 축소(0 2px 8px rgba(0,0,0,0.15))로 눌림 피드백
+- 모달 오픈/클로즈 트랜지션은 기존 `Modal` 컴포넌트 것을 그대로 사용, 신규 트랜지션 추가하지 않음
+
+## 11. 검증
+
+- 유닛/컴포넌트 테스트: 기존 `todayPage.test.tsx`의 텍스트 기반 쿼리(`getByText('새 할일')`, 클릭 → 모달 오픈, `initialDueAt` 전달 등)는 라벨을 유지하므로 대부분 수정 없이 통과해야 한다. 다만 로딩/에러/빈 상태에서도 버튼이 "항상 렌더링"된다는 기존 테스트 의도는 그대로 유지되어야 한다(조건부 렌더링 여전히 없음).
+- 로컬 개발 서버(`npm run dev`)에서 다음을 육안으로 확인:
+  - 모바일 너비(≤480px): `Fab`가 하단 탭바 위 16px 오프셋에 떠 있고 탭바와 절대 겹치지 않는지
+  - 태블릿 너비(481~768px): 탭바 위 24px 오프셋에서 동일하게 확인
+  - 데스크톱 너비(>768px): `Fab`가 화면 우하단에 뜨고, `Footer`와 겹치지 않는지, 좌측 `SNB`(열림/닫힘 두 상태 모두)와 무관하게 위치가 흔들리지 않는지
+  - 리스트를 끝까지 스크롤했을 때 마지막 항목이 `Fab`에 완전히 가려 탭 불가능한 상태가 되지 않는지(`ScrollArea` 하단 패딩 88px가 적용됐는지)
+  - `Fab` hover/active/focus-visible 상태가 각각 명세대로 보이는지
+  - 클릭 → 모달 오픈 → `initialDueAt`이 현재 선택된 날짜로 채워지는지(기존과 동일 동작 재확인)
+
+## 12. ui-ux-improver에게 전달할 사항
+
+- **가장 중요한 구현 디테일**: `Container`에 `position: relative`를 빠뜨리지 말 것 (3.1절 — 이걸 빠뜨리면 `Fab`가 뷰포트 기준으로 계산되어 데스크톱에서 Footer와 겹치는 회귀가 발생한다).
+- `position: fixed`가 아니라 `position: absolute`를 쓰는 것이 이번 스펙의 핵심 결정이다. 일반적인 "FAB는 fixed"라는 직관과 다르므로 구현 중 임의로 `fixed`로 바꾸지 말 것.
+- `media.mobile`(480px)과 `media.tablet`(768px, 이 컴포넌트에서 직접 쓰이진 않지만 `BottomTabBar` 노출 기준)을 혼동하지 말 것 — 이 스펙에서 `media.mobile` 분기는 탭바 회피가 아니라 순수 여백 미세조정 목적이다.
+- `ScrollArea`의 `padding-bottom: 88px` 추가를 빠뜨리지 말 것 — 없으면 리스트 마지막 항목이 `Fab`에 가려 탭이 안 되는 실사용 버그가 된다.
+- 기존 `todayPage.test.tsx`의 텍스트 기반 쿼리는 대부분 그대로 재사용 가능하나, 구현 후 전체 테스트를 재실행해 회귀가 없는지 반드시 확인할 것.
+- 목록 페이지(`todoList.tsx`)는 이번 스코프가 아니므로 손대지 말 것(7절).


### PR DESCRIPTION
## Summary
- 오늘 페이지(`/today`)는 할 일이 하나라도 있으면 새 할 일을 추가할 진입점이 화면에서 사라지는 버그가 있었음 — 목록 페이지처럼 상시 노출되는 추가 버튼을 붙임
- 처음엔 목록 페이지와 동일한 하단 고정 풀와이드 바로 구현했으나, 실제 화면 확인 후 데스크톱/태블릿에서 어색하다는 피드백을 받아 화면 크기 구분 없이 통일된 우하단 FAB(pill) 형태로 최종 전환
- 구현 도중 발견한 별개 버그도 함께 수정: 하단 탭바 높이 상수(`BOTTOM_TAB_BAR_HEIGHT`)가 실제 렌더링 높이보다 작아 앱 전체에서 고정 UI가 탭바에 살짝 가려지던 문제

## Changes
- `todayPage.tsx` / `todayPage.styles.tsx`: 레이아웃을 `Container`(상단 고정 WeekStrip/DailyProgress) → `ScrollArea`(내부 스크롤) 구조로 재구성, 우하단 `Fab` 버튼 추가 (클릭 시 기존 `Modal`+`TodoForm` 재사용, `initialDueAt`으로 선택된 날짜 전달)
- "오늘 할 일이 없습니다" `EmptyState`의 자체 액션 버튼 제거 (하단 FAB와 중복 방지, 에러 상태의 "다시 시도" 액션은 유지)
- `bottomTabBar.styles.tsx`: `BOTTOM_TAB_BAR_HEIGHT` 57px → 65px (실측 렌더링 높이에 맞춰 보정, 앱 전체 모바일 화면에 영향)
- 승인된 스펙/계획 문서(`docs/superpowers/specs`, `docs/superpowers/plans`) 포함

## Test plan
- [x] `npm run test` (client 315 / server 3 전부 통과)
- [x] `npx tsc --noEmit` 에러 없음
- [x] `npm run lint` 에러 0
- [x] `todayPage.test.tsx` 20개 테스트로 로딩/에러/빈 상태/리스트 상태 전부에서 버튼 상시 노출, 클릭 시 모달 오픈, 날짜 변경 시 `initialDueAt` 갱신 검증
- [x] 로컬 브라우저 실측(Playwright, e2e 로그인)으로 480px/768px 폭에서 탭바-버튼 겹침 없음 확인
- [ ] 데스크톱 폭에서 Footer와 FAB 겹침 여부 최종 육안 재확인 권장 (에뮬레이터 환경 이슈로 자동 검증은 부분적으로만 완료됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)