### PR TITLE
feat: done 할 일 아카이빙 (archived 플래그, 루트 단위 30일)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -18,16 +18,22 @@ const App = () => {
   const [isopen, setIsOpen] = useState(true);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const isMobile = useMediaQuery("tablet");
-  const { useExtendIndefiniteRecurringSeries } = useTodo();
+  const { useExtendIndefiniteRecurringSeries, useSweepArchivedTodos } = useTodo();
   const hasExtendedRef = useRef(false);
+  const hasSweptRef = useRef(false);
 
   // 인증된 레이아웃(App) 마운트 시 1회, 무기한 반복 시리즈들의 남은 인스턴스를
   // 오늘 기준으로 이어서 채운다. 세션 중 재마운트되어도 다시 실행되지 않도록
   // ref로 막는다(라우트 이동으로는 App이 재마운트되지 않지만 방어적으로 둔다).
   useEffect(() => {
-    if (hasExtendedRef.current) return;
-    hasExtendedRef.current = true;
-    useExtendIndefiniteRecurringSeries.mutate();
+    if (!hasExtendedRef.current) {
+      hasExtendedRef.current = true;
+      useExtendIndefiniteRecurringSeries.mutate();
+    }
+    if (!hasSweptRef.current) {
+      hasSweptRef.current = true;
+      useSweepArchivedTodos.mutate();
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/client/src/features/todo/api/__tests__/recurringTodoApi.test.ts
+++ b/client/src/features/todo/api/__tests__/recurringTodoApi.test.ts
@@ -174,7 +174,9 @@ describe("createRecurringTodo", () => {
 
   it("생성한 각 인스턴스에 archived: false를 명시적으로 채운다", async () => {
     const { getDocs, writeBatch } = await import("firebase/firestore");
-    vi.mocked(getDocs).mockResolvedValueOnce(emptyDocsSnapshot);
+    vi.mocked(getDocs).mockResolvedValueOnce(
+      emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+    );
     const batch = makeBatch();
     vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
 
@@ -503,8 +505,12 @@ describe("editRecurringSeries", () => {
   it("재생성한 인스턴스에 archived: false를 명시적으로 채운다", async () => {
     const { getDocs, writeBatch } = await import("firebase/firestore");
     vi.mocked(getDocs)
-      .mockResolvedValueOnce(emptyDocsSnapshot) // 시리즈 조회 결과 없음 → 전부 재생성
-      .mockResolvedValueOnce(emptyDocsSnapshot); // getNextRootOrder
+      .mockResolvedValueOnce(
+        emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+      ) // 시리즈 조회 결과 없음 → 전부 재생성
+      .mockResolvedValueOnce(
+        emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+      ); // getNextRootOrder
     const batch = makeBatch();
     vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
 

--- a/client/src/features/todo/api/__tests__/recurringTodoApi.test.ts
+++ b/client/src/features/todo/api/__tests__/recurringTodoApi.test.ts
@@ -172,6 +172,24 @@ describe("createRecurringTodo", () => {
     });
   });
 
+  it("생성한 각 인스턴스에 archived: false를 명시적으로 채운다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    vi.mocked(getDocs).mockResolvedValueOnce(emptyDocsSnapshot);
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { createRecurringTodo } = await import("../todoApi");
+    await createRecurringTodo(
+      makeTodo({ recurrence: dailyRule, startAt: "2026-07-10T09:00:00" }),
+      new Date("2026-07-13T00:00:00"),
+    );
+
+    expect(batch.set).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ archived: false }),
+    );
+  });
+
   it("생성한 인스턴스 문서 ID는 {recurrenceId}_{날짜} 형태로 결정론적이다 (멀티탭/멀티기기 동시 생성 시 중복 방지)", async () => {
     const { getDocs, writeBatch } = await import("firebase/firestore");
     vi.mocked(getDocs).mockResolvedValueOnce(
@@ -480,6 +498,32 @@ describe("editRecurringSeries", () => {
     expect(batch.delete).toHaveBeenCalledTimes(1);
     expect(batch.set).toHaveBeenCalled();
     expect(batch.commit).toHaveBeenCalledTimes(1);
+  });
+
+  it("재생성한 인스턴스에 archived: false를 명시적으로 채운다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(emptyDocsSnapshot) // 시리즈 조회 결과 없음 → 전부 재생성
+      .mockResolvedValueOnce(emptyDocsSnapshot); // getNextRootOrder
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { editRecurringSeries } = await import("../todoApi");
+    await editRecurringSeries(
+      makeTodo({
+        id: "series-1",
+        recurrenceId: "rec-1",
+        recurrence: dailyRule,
+        startAt: "2026-07-10T09:00:00",
+        dueAt: "2026-07-10T09:00:00",
+      }),
+      new Date("2026-07-13T00:00:00"),
+    );
+
+    expect(batch.set).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ archived: false }),
+    );
   });
 
   it("재생성되는 인스턴스 문서 ID도 {recurrenceId}_{날짜} 형태로 결정론적이다", async () => {

--- a/client/src/features/todo/api/__tests__/sweepArchivedTodos.test.ts
+++ b/client/src/features/todo/api/__tests__/sweepArchivedTodos.test.ts
@@ -142,6 +142,41 @@ describe("sweepArchivedTodos", () => {
     expect(batch.commit).toHaveBeenCalledTimes(1);
   });
 
+  it("반복 시리즈 인스턴스(parentId: null)도 별도 처리 없이 루트 규칙을 그대로 적용받아 archived 처리한다", async () => {
+    // 반복 시리즈 인스턴스는 항상 parentId: null(루트)로 생성된다(buildRecurringInstanceId).
+    // sweepArchivedTodos는 recurrence/recurrenceId 여부를 특별 취급하지 않고 parentId===null
+    // 문서를 전부 동일한 루트 쿼리 대상으로 다루므로, done된 지 30일 지난 반복 인스턴스도
+    // 일반 단독 투두와 동일하게 archived 처리되어야 한다(스펙 7절).
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const recurringInstance = makeTodo({
+      id: "series-1_2026-06-01",
+      status: "done",
+      doneAt: "2026-06-01T00:00:00.000Z",
+      recurrenceId: "series-1",
+      recurrence: { type: "daily", endType: "indefinite" },
+    });
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(
+        toDocSnapshot([recurringInstance]) as ReturnType<typeof getDocs> extends Promise<infer T>
+          ? T
+          : never,
+      ) // 루트 조회
+      .mockResolvedValueOnce(
+        emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+      ); // 자식 조회(반복 인스턴스는 자식이 없음)
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { sweepArchivedTodos } = await import("../todoApi");
+    await sweepArchivedTodos();
+
+    expect(batch.update).toHaveBeenCalledWith(
+      { id: "series-1_2026-06-01" },
+      expect.objectContaining({ archived: true }),
+    );
+    expect(batch.commit).toHaveBeenCalledTimes(1);
+  });
+
   it("루트 조회 결과가 없으면(진행 중인 프로젝트뿐이면) batch를 만들지 않는다", async () => {
     // 형제 서브태스크 중 하나가 40일 전 done이어도, 나머지가 진행 중이라 루트 자체가
     // done이 아니면 Firestore 쿼리(status=="done") 조건에 애초에 걸리지 않는다 —

--- a/client/src/features/todo/api/__tests__/sweepArchivedTodos.test.ts
+++ b/client/src/features/todo/api/__tests__/sweepArchivedTodos.test.ts
@@ -218,6 +218,74 @@ describe("sweepArchivedTodos", () => {
     expect(where).toHaveBeenCalledWith("doneAt", "<", "2026-04-11T00:00:00.000Z");
   });
 
+  it("대상 write 수가 Firestore batch 500 상한을 넘으면 여러 batch로 나눠 commit한다 (루트 200개 x 자식 3개 = 800 write)", async () => {
+    // 배포 시점에 이미 30일 넘은 완료 프로젝트가 다수 누적돼 있을 수 있으므로, 단일
+    // writeBatch에 전부 몰아넣으면 500 상한을 넘겨 commit() 전체가 실패할 수 있다.
+    // 루트+자식을 한 그룹으로 묶어 400(여유를 둔 청크 크기) 단위로 나눠 커밋해야 한다.
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const ROOT_COUNT = 200;
+    const CHILDREN_PER_ROOT = 3;
+    const roots = Array.from({ length: ROOT_COUNT }, (_, i) =>
+      makeTodo({ id: `root-${i}`, status: "done", doneAt: "2026-06-01T00:00:00.000Z" }),
+    );
+    const childrenByRoot = roots.map((root, i) =>
+      Array.from({ length: CHILDREN_PER_ROOT }, (_, j) =>
+        makeTodo({ id: `child-${i}-${j}`, parentId: root.id, status: "done" }),
+      ),
+    );
+
+    let callIndex = 0;
+    vi.mocked(getDocs).mockImplementation(async () => {
+      const currentCall = callIndex;
+      callIndex += 1;
+      if (currentCall === 0) {
+        return toDocSnapshot(roots) as ReturnType<typeof getDocs> extends Promise<infer T>
+          ? T
+          : never;
+      }
+      const rootIndex = currentCall - 1;
+      return toDocSnapshot(childrenByRoot[rootIndex]) as ReturnType<
+        typeof getDocs
+      > extends Promise<infer T>
+        ? T
+        : never;
+    });
+
+    const batches: ReturnType<typeof makeBatch>[] = [];
+    vi.mocked(writeBatch).mockImplementation(() => {
+      const b = makeBatch();
+      batches.push(b);
+      return b as unknown as ReturnType<typeof writeBatch>;
+    });
+
+    const { sweepArchivedTodos } = await import("../todoApi");
+    await sweepArchivedTodos();
+
+    const totalWrites = ROOT_COUNT * (1 + CHILDREN_PER_ROOT); // 800
+    expect(totalWrites).toBeGreaterThan(500);
+
+    // 400(그룹 크기 4의 배수) 단위로 정확히 2개 배치로 나뉘어야 한다.
+    expect(batches.length).toBe(2);
+    batches.forEach((b) => expect(b.commit).toHaveBeenCalledTimes(1));
+
+    const totalUpdateCalls = batches.reduce((sum, b) => sum + b.update.mock.calls.length, 0);
+    expect(totalUpdateCalls).toBe(totalWrites);
+    expect(batches[0].update.mock.calls.length).toBe(400);
+    expect(batches[1].update.mock.calls.length).toBe(400);
+
+    // 그룹(루트+자식) 경계에서 배치가 쪼개지지 않았는지 확인: 한 루트의 자식들은
+    // 반드시 그 루트와 같은 배치에 있어야 한다.
+    const batchIndexOf = (id: string) =>
+      batches.findIndex((b) => b.update.mock.calls.some((call) => (call[0] as { id: string }).id === id));
+
+    expect(batchIndexOf("root-99")).toBe(0);
+    expect(batchIndexOf("child-99-0")).toBe(0);
+    expect(batchIndexOf("child-99-2")).toBe(0);
+    expect(batchIndexOf("root-100")).toBe(1);
+    expect(batchIndexOf("child-100-0")).toBe(1);
+    expect(batchIndexOf("child-100-2")).toBe(1);
+  });
+
   it("인증되지 않은 경우 에러를 던져야 한다", async () => {
     const firebase = await import("@/shared/lib/firebase");
     Object.defineProperty(firebase.auth, "currentUser", { value: null, configurable: true });

--- a/client/src/features/todo/api/__tests__/sweepArchivedTodos.test.ts
+++ b/client/src/features/todo/api/__tests__/sweepArchivedTodos.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Todo } from "../../types/todo.type";
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(new Date("2026-07-10T00:00:00.000Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+vi.mock("@/shared/lib/firebase", () => ({
+  db: {},
+  auth: {
+    currentUser: { uid: "test-user-id" },
+  },
+  googleProvider: {},
+}));
+
+vi.mock("firebase/firestore", () => ({
+  collection: vi.fn(() => ({})),
+  addDoc: vi.fn(),
+  getDocs: vi.fn(),
+  doc: vi.fn(() => ({})),
+  updateDoc: vi.fn(),
+  deleteDoc: vi.fn(),
+  query: vi.fn(() => ({})),
+  where: vi.fn(() => ({})),
+  getDoc: vi.fn(),
+  writeBatch: vi.fn(),
+}));
+
+const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
+  id: "todo-1",
+  userId: "test-user-id",
+  title: "테스트 할 일",
+  status: "todo",
+  priority: "medium",
+  startAt: null,
+  dueAt: null,
+  doneAt: null,
+  parentId: null,
+  order: 0,
+  recurrence: null,
+  recurrenceId: null,
+  archived: false,
+  createdAt: "2026-06-14T00:00:00.000Z",
+  updatedAt: "2026-06-14T00:00:00.000Z",
+  ...overrides,
+});
+
+const toDocSnapshot = (todos: Todo[]) => ({
+  docs: todos.map((t) => ({
+    id: t.id,
+    ref: { id: t.id },
+    data: () => {
+      const { id: _id, ...rest } = t;
+      return rest;
+    },
+  })),
+});
+
+const emptyDocsSnapshot: { docs: { id: string; ref: { id: string }; data: () => Record<string, unknown> }[] } = {
+  docs: [],
+};
+
+const makeBatch = () => ({
+  set: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  commit: vi.fn().mockResolvedValue(undefined),
+});
+
+const resetFirestoreMocks = async () => {
+  const { getDocs, writeBatch } = await import("firebase/firestore");
+  vi.mocked(getDocs).mockReset();
+  vi.mocked(writeBatch).mockReset();
+};
+
+describe("sweepArchivedTodos", () => {
+  beforeEach(async () => {
+    await resetFirestoreMocks();
+    const firebase = await import("@/shared/lib/firebase");
+    Object.assign(firebase.auth, { currentUser: { uid: "test-user-id" } });
+  });
+
+  it("자식 없는 단독 투두가 done된 지 30일 넘었으면 archived 처리한다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const root = makeTodo({
+      id: "solo-1",
+      status: "done",
+      doneAt: "2026-06-01T00:00:00.000Z", // 39일 전
+    });
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(
+        toDocSnapshot([root]) as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+      ) // 루트 조회
+      .mockResolvedValueOnce(
+        emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+      ); // 자식 조회(없음)
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { sweepArchivedTodos } = await import("../todoApi");
+    await sweepArchivedTodos();
+
+    expect(batch.update).toHaveBeenCalledWith(
+      { id: "solo-1" },
+      expect.objectContaining({ archived: true }),
+    );
+    expect(batch.commit).toHaveBeenCalledTimes(1);
+  });
+
+  it("프로젝트(자식 있음) 전체가 done된 지 30일 넘었으면 루트+자식 전부 archived 처리한다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const root = makeTodo({
+      id: "project-1",
+      status: "done",
+      doneAt: "2026-06-01T00:00:00.000Z",
+    });
+    const child1 = makeTodo({ id: "child-1", parentId: "project-1", status: "done" });
+    const child2 = makeTodo({ id: "child-2", parentId: "project-1", status: "done" });
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(
+        toDocSnapshot([root]) as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+      )
+      .mockResolvedValueOnce(
+        toDocSnapshot([child1, child2]) as ReturnType<typeof getDocs> extends Promise<infer T>
+          ? T
+          : never,
+      );
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { sweepArchivedTodos } = await import("../todoApi");
+    await sweepArchivedTodos();
+
+    expect(batch.update).toHaveBeenCalledWith({ id: "project-1" }, expect.objectContaining({ archived: true }));
+    expect(batch.update).toHaveBeenCalledWith({ id: "child-1" }, expect.objectContaining({ archived: true }));
+    expect(batch.update).toHaveBeenCalledWith({ id: "child-2" }, expect.objectContaining({ archived: true }));
+    expect(batch.commit).toHaveBeenCalledTimes(1);
+  });
+
+  it("루트 조회 결과가 없으면(진행 중인 프로젝트뿐이면) batch를 만들지 않는다", async () => {
+    // 형제 서브태스크 중 하나가 40일 전 done이어도, 나머지가 진행 중이라 루트 자체가
+    // done이 아니면 Firestore 쿼리(status=="done") 조건에 애초에 걸리지 않는다 —
+    // 즉 이 케이스는 루트 쿼리가 빈 결과를 반환하는 것으로 자연스럽게 표현된다.
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    vi.mocked(getDocs).mockResolvedValueOnce(
+      emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+    );
+
+    const { sweepArchivedTodos } = await import("../todoApi");
+    await sweepArchivedTodos();
+
+    expect(writeBatch).not.toHaveBeenCalled();
+  });
+
+  it("기본 기준일(30일)로 cutoff를 계산해 doneAt 범위 쿼리에 사용한다", async () => {
+    const { getDocs, where } = await import("firebase/firestore");
+    vi.mocked(getDocs).mockResolvedValueOnce(
+      emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+    );
+
+    const { sweepArchivedTodos } = await import("../todoApi");
+    await sweepArchivedTodos();
+
+    // 2026-07-10 기준 30일 전 = 2026-06-10
+    expect(where).toHaveBeenCalledWith("doneAt", "<", "2026-06-10T00:00:00.000Z");
+  });
+
+  it("cutoffDays 인자를 넘기면 그 기준으로 cutoff를 계산한다", async () => {
+    const { getDocs, where } = await import("firebase/firestore");
+    vi.mocked(getDocs).mockResolvedValueOnce(
+      emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+    );
+
+    const { sweepArchivedTodos } = await import("../todoApi");
+    await sweepArchivedTodos(90);
+
+    // 2026-07-10 기준 90일 전 = 2026-04-11
+    expect(where).toHaveBeenCalledWith("doneAt", "<", "2026-04-11T00:00:00.000Z");
+  });
+
+  it("인증되지 않은 경우 에러를 던져야 한다", async () => {
+    const firebase = await import("@/shared/lib/firebase");
+    Object.defineProperty(firebase.auth, "currentUser", { value: null, configurable: true });
+
+    const { sweepArchivedTodos } = await import("../todoApi");
+    await expect(sweepArchivedTodos()).rejects.toThrow("Not authenticated");
+
+    Object.defineProperty(firebase.auth, "currentUser", {
+      value: { uid: "test-user-id" },
+      configurable: true,
+    });
+  });
+});

--- a/client/src/features/todo/api/__tests__/todoApi.test.ts
+++ b/client/src/features/todo/api/__tests__/todoApi.test.ts
@@ -126,6 +126,56 @@ describe('todoApi', () => {
     })
   })
 
+  describe('createTodo', () => {
+    beforeEach(async () => {
+      vi.clearAllMocks()
+      const firebase = await import('@/shared/lib/firebase')
+      Object.assign(firebase.auth, { currentUser: { uid: 'test-user-id' } })
+    })
+
+    it('생성한 문서에 archived: false를 명시적으로 채워야 한다', async () => {
+      const { getDocs, addDoc, query, where } = await import('firebase/firestore')
+      const { createTodo } = await import('../todoApi')
+
+      vi.mocked(getDocs).mockResolvedValueOnce({
+        docs: [],
+      } as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never)
+      vi.mocked(query).mockReturnValue({} as ReturnType<typeof query>)
+      vi.mocked(where).mockReturnValue({} as ReturnType<typeof where>)
+      vi.mocked(addDoc).mockResolvedValueOnce({ id: 'new-1' } as Awaited<ReturnType<typeof addDoc>>)
+
+      await createTodo(makeTodo({ title: '새 할일' }))
+
+      expect(addDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ archived: false }),
+      )
+    })
+  })
+
+  describe('createChildTodo', () => {
+    beforeEach(async () => {
+      vi.clearAllMocks()
+      const firebase = await import('@/shared/lib/firebase')
+      Object.assign(firebase.auth, { currentUser: { uid: 'test-user-id' } })
+    })
+
+    it('생성한 하위 할 일에 archived: false를 명시적으로 채워야 한다', async () => {
+      const { addDoc, updateDoc } = await import('firebase/firestore')
+      const { createChildTodo } = await import('../todoApi')
+
+      vi.mocked(addDoc).mockResolvedValueOnce({ id: 'child-1' } as Awaited<ReturnType<typeof addDoc>>)
+      vi.mocked(updateDoc).mockResolvedValueOnce(undefined)
+
+      await createChildTodo('parent-1', { title: '하위 할일' }, [])
+
+      expect(addDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ archived: false }),
+      )
+    })
+  })
+
   describe('getSearchTodoList', () => {
     beforeEach(async () => {
       vi.clearAllMocks()

--- a/client/src/features/todo/api/__tests__/todoApi.test.ts
+++ b/client/src/features/todo/api/__tests__/todoApi.test.ts
@@ -65,6 +65,29 @@ describe('todoApi', () => {
       expect(result[1].order).toBe(1)
     })
 
+    it('archived: true인 문서는 결과에서 제외해야 한다', async () => {
+      const { getDocs, query, where } = await import('firebase/firestore')
+      const { getTodos } = await import('../todoApi')
+
+      const mockDocs = [
+        { id: 'active-1', data: () => ({ ...makeTodo({ order: 0 }), id: undefined, archived: false }) },
+        { id: 'archived-1', data: () => ({ ...makeTodo({ order: 1, status: 'done' }), id: undefined, archived: true }) },
+      ]
+
+      vi.mocked(getDocs).mockResolvedValueOnce({
+        docs: mockDocs,
+      } as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never)
+      vi.mocked(query).mockReturnValue({} as ReturnType<typeof query>)
+      vi.mocked(where).mockReturnValue({} as ReturnType<typeof where>)
+
+      await getTodos()
+
+      // getTodos는 archived 필터링을 클라이언트가 아니라 Firestore 쿼리 조건으로 위임한다
+      // (where("archived","==",false)) — mock에서는 Firestore가 실제로 필터링하지 않으므로
+      // "쿼리에 그 조건이 들어갔는지"를 검증한다.
+      expect(where).toHaveBeenCalledWith('archived', '==', false)
+    })
+
     it('order 필드가 없는(undefined) 레거시 문서가 섞여 있어도 나머지 문서는 정상적으로 order 순 정렬되어야 한다', async () => {
       // 비교 함수가 undefined - number = NaN을 반환하면 정렬 전체가 깨지는 회귀
       // 버그가 있었다(order가 있는 문서끼리도 전혀 정렬되지 않음).

--- a/client/src/features/todo/api/__tests__/todoApi.test.ts
+++ b/client/src/features/todo/api/__tests__/todoApi.test.ts
@@ -138,7 +138,7 @@ describe('todoApi', () => {
       const { createTodo } = await import('../todoApi')
 
       vi.mocked(getDocs).mockResolvedValueOnce({
-        docs: [],
+        docs: [] as { id: string; data: () => Record<string, unknown> }[],
       } as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never)
       vi.mocked(query).mockReturnValue({} as ReturnType<typeof query>)
       vi.mocked(where).mockReturnValue({} as ReturnType<typeof where>)

--- a/client/src/features/todo/api/__tests__/todoApiDataIntegrity.test.ts
+++ b/client/src/features/todo/api/__tests__/todoApiDataIntegrity.test.ts
@@ -205,6 +205,36 @@ describe("deleteTodo 연쇄 삭제 (고아 문서/부모 상태 정합성)", () 
     expect(batch.commit).toHaveBeenCalledTimes(1);
   });
 
+  // done 아카이빙(archived 플래그) 도입 회귀 테스트: deleteTodo는 archived 여부를
+  // 전혀 조회/필터링하지 않고 userId+parentId만으로 동작하므로, 이미 archived: true로
+  // 처리된(30일 지난 완료 프로젝트) 문서라도 삭제 요청이 오면 하위까지 그대로 연쇄
+  // 삭제되어야 한다. archived 필터는 getTodos() 조회에만 적용되고 delete 경로에는
+  // 영향이 없어야 한다는 설계 전제(스펙 7절)를 지킨다.
+  it("archived: true로 아카이빙된 루트도 archived가 아닌 문서와 동일하게 하위까지 연쇄 삭제된다", async () => {
+    const { getDoc, getDocs, writeBatch } = await import("firebase/firestore");
+
+    vi.mocked(getDoc).mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ userId: "test-user-id", parentId: null, archived: true }),
+    } as unknown as Awaited<ReturnType<typeof getDoc>>);
+
+    const children = [
+      makeTodo({ id: "child-1", parentId: "archived-root-1", status: "done" }),
+      makeTodo({ id: "child-2", parentId: "archived-root-1", status: "done" }),
+    ];
+    vi.mocked(getDocs).mockResolvedValueOnce(toDocSnapshot(children) as GetDocsResult);
+
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { deleteTodo } = await import("../todoApi");
+
+    await deleteTodo("archived-root-1");
+
+    expect(batch.delete).toHaveBeenCalledTimes(3);
+    expect(batch.commit).toHaveBeenCalledTimes(1);
+  });
+
   it("하위 삭제 시 남은 형제 기준으로 부모 상태를 같은 batch에서 재계산한다", async () => {
     const { getDoc, getDocs, writeBatch } = await import("firebase/firestore");
 

--- a/client/src/features/todo/api/todoApi.ts
+++ b/client/src/features/todo/api/todoApi.ts
@@ -141,6 +141,7 @@ export const createTodo = async (todo: Todo) => {
     parentId: null,
     status: "todo",
     order: maxOrder + 1,
+    archived: false,
   });
   return { ...todo, id: docRef.id };
 };
@@ -343,6 +344,7 @@ export const createChildTodo = async (
     order: maxOrder + 1,
     recurrence: null,
     recurrenceId: null,
+    archived: false,
   });
 
   // 새 하위(todo) 추가 → 상위 상태 재계산
@@ -429,6 +431,7 @@ const createRecurringTodoImpl = async (
       status: "todo" as const,
       doneAt: null,
       parentId: null,
+      archived: false,
       recurrenceId,
       createdAt: now,
       updatedAt: now,
@@ -603,6 +606,7 @@ const editRecurringSeriesImpl = async (
         status: "todo",
         doneAt: null,
         parentId: null,
+        archived: false,
         recurrenceId,
         createdAt: now,
         updatedAt: now,

--- a/client/src/features/todo/api/todoApi.ts
+++ b/client/src/features/todo/api/todoApi.ts
@@ -266,6 +266,53 @@ export const updateToDone = async (id: string) => {
   return mapDocToTodo(docRef.id, { ...existing.data(), status: "done", doneAt: now, updatedAt: now });
 };
 
+/**
+ * 완료된 지 오래된 프로젝트를 기본 조회(getTodos)에서 제외되도록 archived 처리한다.
+ * 앱 진입 시 1회 실행(App.tsx)되는 지연 스윕 — extendIndefiniteRecurringSeries와 같은 자리.
+ *
+ * 판단 기준은 개별 항목의 doneAt이 아니라 **루트(parentId===null)의 doneAt**이다.
+ * 형제 서브태스크가 있는 프로젝트는 하나가 먼저 오래전에 done되고 나머지는 진행
+ * 중일 수 있는데, 그 개별 항목만 먼저 archived되면 getProjectProgress가 참조하는
+ * allTodos에서 조용히 빠져 진행률 계산이 틀어진다. calcParentStatus 불변식상 루트가
+ * done이라는 것은 이미 모든 자식이 done이라는 뜻이므로, 루트가 done된 시점(=전체
+ * 완료 시점)을 기준으로 루트+자식 전체를 한 번에 묶어 archived 처리한다.
+ */
+export const sweepArchivedTodos = async (cutoffDays: number = 30): Promise<void> => {
+  const userId = getUserId();
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - cutoffDays);
+  const cutoffISO = cutoff.toISOString();
+
+  const rootsSnapshot = await getDocs(
+    query(
+      todosRef,
+      where("userId", "==", userId),
+      where("parentId", "==", null),
+      where("status", "==", "done"),
+      where("archived", "==", false),
+      where("doneAt", "<", cutoffISO),
+    ),
+  );
+
+  if (rootsSnapshot.docs.length === 0) return;
+
+  const batch = writeBatch(db);
+  const now = new Date().toISOString();
+
+  for (const rootDoc of rootsSnapshot.docs) {
+    batch.update(rootDoc.ref, { archived: true, updatedAt: now });
+
+    const childrenSnapshot = await getDocs(
+      query(todosRef, where("userId", "==", userId), where("parentId", "==", rootDoc.id)),
+    );
+    childrenSnapshot.docs.forEach((childDoc) => {
+      batch.update(childDoc.ref, { archived: true, updatedAt: now });
+    });
+  }
+
+  await batch.commit();
+};
+
 export const updateTodoDueAt = async (
   id: string,
   dueAt: string | null,

--- a/client/src/features/todo/api/todoApi.ts
+++ b/client/src/features/todo/api/todoApi.ts
@@ -92,7 +92,11 @@ const assertNoRecurrenceParentConflict = (todo: {
 
 export const getTodos = async () => {
   const userId = getUserId();
-  const q = query(todosRef, where("userId", "==", userId));
+  const q = query(
+    todosRef,
+    where("userId", "==", userId),
+    where("archived", "==", false),
+  );
   const snapshot = await getDocs(q);
   return snapshot.docs
     .map((doc) => mapDocToTodo(doc.id, doc.data()))

--- a/client/src/features/todo/api/todoApi.ts
+++ b/client/src/features/todo/api/todoApi.ts
@@ -277,6 +277,12 @@ export const updateToDone = async (id: string) => {
  * done이라는 것은 이미 모든 자식이 done이라는 뜻이므로, 루트가 done된 시점(=전체
  * 완료 시점)을 기준으로 루트+자식 전체를 한 번에 묶어 archived 처리한다.
  */
+// Firestore writeBatch는 1건당 최대 500 write까지 허용한다. 신규 기능이 아니라 기존
+// 서비스에 소급 적용되는 스윕이라 배포 시점에 이미 30일 넘은 완료 프로젝트가 다수
+// 누적돼 있을 수 있으므로, 상한 근처까지 채우지 않고 여유를 둔다(backfillArchivedField.ts
+// 스크립트와 동일한 값).
+const SWEEP_BATCH_SIZE = 400;
+
 export const sweepArchivedTodos = async (cutoffDays: number = 30): Promise<void> => {
   const userId = getUserId();
   const cutoff = new Date();
@@ -296,21 +302,47 @@ export const sweepArchivedTodos = async (cutoffDays: number = 30): Promise<void>
 
   if (rootsSnapshot.docs.length === 0) return;
 
-  const batch = writeBatch(db);
   const now = new Date().toISOString();
 
-  for (const rootDoc of rootsSnapshot.docs) {
-    batch.update(rootDoc.ref, { archived: true, updatedAt: now });
+  // 루트 하나 + 그 자식 전체를 하나의 논리적 그룹으로 취급해 청크를 나눈다. 그룹을
+  // 쪼개면 한 프로젝트의 자식 일부만 archived되고 나머지는 안 되는 상태가 생길 수
+  // 있으므로, 그룹 도중에는 절대 commit하지 않고 그룹과 그룹 사이에서만 나눈다.
+  let batch: ReturnType<typeof writeBatch> | null = null;
+  let pendingWrites = 0;
 
+  const commitPending = async () => {
+    if (batch && pendingWrites > 0) {
+      await batch.commit();
+    }
+    batch = null;
+    pendingWrites = 0;
+  };
+
+  for (const rootDoc of rootsSnapshot.docs) {
     const childrenSnapshot = await getDocs(
       query(todosRef, where("userId", "==", userId), where("parentId", "==", rootDoc.id)),
     );
+    const groupSize = 1 + childrenSnapshot.docs.length;
+
+    // 이 그룹을 더하면 상한을 넘는 경우, 그룹을 쪼개는 대신 지금까지 쌓인 배치를
+    // 먼저 commit하고 새 배치에서 이 그룹을 시작한다. 한 루트가 400개 넘는 자식을
+    // 갖는 극단적 케이스는 다루지 않는다(이 프로젝트 규모에서 사실상 없다고 가정).
+    if (pendingWrites > 0 && pendingWrites + groupSize > SWEEP_BATCH_SIZE) {
+      await commitPending();
+    }
+
+    if (!batch) batch = writeBatch(db);
+    batch.update(rootDoc.ref, { archived: true, updatedAt: now });
     childrenSnapshot.docs.forEach((childDoc) => {
-      batch.update(childDoc.ref, { archived: true, updatedAt: now });
+      (batch as ReturnType<typeof writeBatch>).update(childDoc.ref, {
+        archived: true,
+        updatedAt: now,
+      });
     });
+    pendingWrites += groupSize;
   }
 
-  await batch.commit();
+  await commitPending();
 };
 
 export const updateTodoDueAt = async (

--- a/client/src/features/todo/hooks/__tests__/useTodo.test.tsx
+++ b/client/src/features/todo/hooks/__tests__/useTodo.test.tsx
@@ -28,6 +28,7 @@ vi.mock('../../api', () => ({
   editRecurringSeries: vi.fn(),
   deleteRecurringSeries: vi.fn(),
   extendIndefiniteRecurringSeries: vi.fn(),
+  sweepArchivedTodos: vi.fn(),
   reorderTodos: vi.fn(),
 }))
 
@@ -502,6 +503,70 @@ describe('useTodo 훅', () => {
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         expect.stringContaining('반복 할 일 호라이즌 확장 실패'),
+        error,
+      )
+
+      consoleErrorSpy.mockRestore()
+    })
+  })
+
+  describe('useSweepArchivedTodos', () => {
+    it('done 아카이빙 스윕 mutation이 정의되어 있어야 한다', () => {
+      const { result } = renderHook(() => useTodo(), {
+        wrapper: createWrapper(),
+      })
+
+      expect(result.current.useSweepArchivedTodos).toBeDefined()
+      expect(typeof result.current.useSweepArchivedTodos.mutate).toBe('function')
+    })
+
+    it('성공 시 todos 쿼리를 무효화해야 한다', async () => {
+      const { getTodos, sweepArchivedTodos } = await import('../../api')
+
+      vi.mocked(getTodos).mockResolvedValue([])
+      vi.mocked(sweepArchivedTodos).mockResolvedValueOnce(undefined)
+
+      const { result } = renderHook(() => useTodo(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.useGetTodos.isSuccess).toBe(true)
+      })
+
+      result.current.useSweepArchivedTodos.mutate()
+
+      await waitFor(() => {
+        expect(result.current.useSweepArchivedTodos.isSuccess).toBe(true)
+      })
+
+      expect(vi.mocked(sweepArchivedTodos)).toHaveBeenCalled()
+    })
+
+    it('실패 시 사용자에게는 알리지 않되 콘솔에는 에러를 남겨야 한다', async () => {
+      const { getTodos, sweepArchivedTodos } = await import('../../api')
+
+      vi.mocked(getTodos).mockResolvedValue([])
+      const error = new Error('permission-denied')
+      vi.mocked(sweepArchivedTodos).mockRejectedValueOnce(error)
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const { result } = renderHook(() => useTodo(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.useGetTodos.isSuccess).toBe(true)
+      })
+
+      result.current.useSweepArchivedTodos.mutate()
+
+      await waitFor(() => {
+        expect(result.current.useSweepArchivedTodos.isError).toBe(true)
+      })
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('done 아카이빙 스윕 실패'),
         error,
       )
 

--- a/client/src/features/todo/hooks/useTodo.ts
+++ b/client/src/features/todo/hooks/useTodo.ts
@@ -13,6 +13,7 @@ import {
   editRecurringSeries,
   deleteRecurringSeries,
   extendIndefiniteRecurringSeries,
+  sweepArchivedTodos,
   reorderTodos,
 } from "../api";
 
@@ -214,6 +215,19 @@ export const useTodo = () => {
     },
   });
 
+  // 앱 진입 시 1회 호출해 30일 지난 완료 프로젝트를 archived 처리한다(App.tsx).
+  // extendIndefiniteRecurringSeries와 동일한 이유로 사용자 액션이 아닌 백그라운드
+  // 유지보수이므로 조용히 넘어가고, 실패는 콘솔에만 남긴다.
+  const useSweepArchivedTodos = useMutation({
+    mutationFn: () => sweepArchivedTodos(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["todos"] });
+    },
+    onError: (error) => {
+      console.error("done 아카이빙 스윕 실패:", error);
+    },
+  });
+
   return {
     useCreateTodo,
     useUpdateTodo,
@@ -227,6 +241,7 @@ export const useTodo = () => {
     useEditRecurringSeries,
     useDeleteRecurringSeries,
     useExtendIndefiniteRecurringSeries,
+    useSweepArchivedTodos,
   };
 };
 

--- a/client/src/features/todo/types/todo.type.ts
+++ b/client/src/features/todo/types/todo.type.ts
@@ -31,6 +31,9 @@ interface Todo {
   recurrence: RecurrenceRule | null;
   /** 같은 반복 시리즈에 속한 인스턴스들을 묶는 그룹 id. 반복 아니면 null. */
   recurrenceId: string | null;
+  /** 기본 조회(getTodos)에서 제외할지 여부. true면 30일 지난 완료 프로젝트(루트+자식)로 간주.
+   *  기존 문서엔 필드가 없을 수 있어 optional — 없으면 archived 아닌 것으로 취급한다. */
+  archived?: boolean;
 }
 
 /** 칸반 같은 컬럼 내 드래그 재정렬 시 bulk write할 order 변경분. */

--- a/docs/superpowers/plans/2026-08-01-done-todo-archiving.md
+++ b/docs/superpowers/plans/2026-08-01-done-todo-archiving.md
@@ -1,0 +1,861 @@
+# done 할 일 아카이빙 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `getTodos()`가 done 항목을 무한정 전량 불러오는 문제를, 30일 지난 완료 프로젝트를 `archived` 플래그로 기본 조회에서 제외하는 방식으로 해결한다.
+
+**Architecture:** Todo 문서에 `archived?: boolean` 필드를 추가하고 `getTodos()`에 `where("archived", "==", false)` 필터를 건다. 앱 진입 시 1회 실행되는 `sweepArchivedTodos()`가 done된 지 30일 지난 **루트 프로젝트(및 그 자식 전체)**를 찾아 batch로 `archived: true`를 채운다(개별 항목의 doneAt이 아니라 루트 기준 — 형제 서브태스크 진행률 계산 보호). 기존 문서에는 `archived` 필드가 없으므로, 필터 배포 전 1회성 백필 마이그레이션 스크립트로 `archived: false`를 채워야 한다.
+
+**Tech Stack:** React, TypeScript, Firebase Firestore(`firebase/firestore` v9 modular SDK), TanStack Query, Vitest. 마이그레이션 스크립트는 `firebase-admin` + `tsx`.
+
+## Global Constraints
+
+- 스펙 문서: `docs/superpowers/specs/2026-08-01-done-todo-archiving-design.md`
+- 아카이빙 판단은 **루트의 `doneAt`** 기준(30일)이지 개별 항목의 `doneAt`이 아니다 — 형제 서브태스크가 있는 진행 중 프로젝트의 진행률 계산(`getProjectProgress`)이 깨지지 않아야 한다.
+- 테스트에서 시스템 날짜를 절대값으로 하드코딩하지 말고 `vi.useFakeTimers({ toFake: ["Date"] })` + `vi.setSystemTime(...)`으로 고정한다(이 프로젝트 기존 컨벤션, CI가 UTC라 타임존도 함께 고려).
+- 모든 client 명령은 `client/` 디렉토리에서 실행한다(`npm run test`, `npm run lint`, `npm run build`).
+- "완료 보관함" 조회 UI는 이번 스코프 밖 — 만들지 않는다.
+- 삭제(하드 delete) 기능은 이번 스코프 밖 — 추가하지 않는다.
+- `getTodoDetail`(단건 조회)에는 `archived` 필터를 추가하지 않는다 — 아카이빙된 항목의 직링크도 계속 열려야 한다. `createTodo`/`createChildTodo`/`getNextRootOrder`의 order 계산용 쿼리(`parentId == null`)에도 `archived` 필터를 추가하지 않는다(정확성에 영향 없음).
+
+---
+
+### Task 1: Todo 타입에 `archived` 필드 추가 + `getTodos()` 필터링
+
+**Files:**
+- Modify: `client/src/features/todo/types/todo.type.ts`
+- Modify: `client/src/features/todo/api/todoApi.ts:93-100` (`getTodos`)
+- Test: `client/src/features/todo/api/__tests__/todoApi.test.ts`
+
+**Interfaces:**
+- Produces: `Todo.archived?: boolean` — 이후 모든 태스크가 이 필드를 읽고 쓴다. **선택적(optional) 필드로 추가한다** — 필수로 만들면 이 프로젝트의 14개 테스트 파일에 흩어진 `makeTodo`류 팩토리를 전부 고쳐야 하는데, `archived`는 UI/비즈니스 로직 어디에서도 읽지 않고 오직 `getTodos()`의 쿼리 조건으로만 쓰이는 내부 최적화 필드이므로 그 churn은 불필요하다. `mapDocToTodo`도 이미 `{ id, ...data } as Todo`로 런타임 강제를 하지 않는다.
+- Produces: `getTodos(): Promise<Todo[]>` — 시그니처는 기존과 동일(변경 없음), 반환 결과에서 `archived === true`인 문서만 빠진다.
+
+- [ ] **Step 1: Todo 타입에 필드 추가**
+
+`client/src/features/todo/types/todo.type.ts`의 `Todo` 인터페이스에 다음 필드를 `recurrenceId` 다음 줄에 추가한다:
+
+```ts
+  /** 기본 조회(getTodos)에서 제외할지 여부. true면 30일 지난 완료 프로젝트(루트+자식)로 간주.
+   *  기존 문서엔 필드가 없을 수 있어 optional — 없으면 archived 아닌 것으로 취급한다. */
+  archived?: boolean;
+```
+
+- [ ] **Step 2: 실패하는 테스트 작성**
+
+`client/src/features/todo/api/__tests__/todoApi.test.ts`의 `describe('getTodos', ...)` 블록 안, 기존 첫 번째 `it` 다음에 추가:
+
+```ts
+    it('archived: true인 문서는 결과에서 제외해야 한다', async () => {
+      const { getDocs, query, where } = await import('firebase/firestore')
+      const { getTodos } = await import('../todoApi')
+
+      const mockDocs = [
+        { id: 'active-1', data: () => ({ ...makeTodo({ order: 0 }), id: undefined, archived: false }) },
+        { id: 'archived-1', data: () => ({ ...makeTodo({ order: 1, status: 'done' }), id: undefined, archived: true }) },
+      ]
+
+      vi.mocked(getDocs).mockResolvedValueOnce({
+        docs: mockDocs,
+      } as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never)
+      vi.mocked(query).mockReturnValue({} as ReturnType<typeof query>)
+      vi.mocked(where).mockReturnValue({} as ReturnType<typeof where>)
+
+      await getTodos()
+
+      // getTodos는 archived 필터링을 클라이언트가 아니라 Firestore 쿼리 조건으로 위임한다
+      // (where("archived","==",false)) — mock에서는 Firestore가 실제로 필터링하지 않으므로
+      // "쿼리에 그 조건이 들어갔는지"를 검증한다.
+      expect(where).toHaveBeenCalledWith('archived', '==', false)
+    })
+```
+
+- [ ] **Step 3: 테스트 실행해서 실패 확인**
+
+Run (in `client/`): `npm run test -- todoApi.test.ts`
+Expected: FAIL — `where` was not called with `('archived', '==', false)`
+
+- [ ] **Step 4: `getTodos()`에 필터 추가**
+
+`client/src/features/todo/api/todoApi.ts:93-100`을 다음으로 교체:
+
+```ts
+export const getTodos = async () => {
+  const userId = getUserId();
+  const q = query(
+    todosRef,
+    where("userId", "==", userId),
+    where("archived", "==", false),
+  );
+  const snapshot = await getDocs(q);
+  return snapshot.docs
+    .map((doc) => mapDocToTodo(doc.id, doc.data()))
+    .sort((a, b) => normalizeOrder(a.order) - normalizeOrder(b.order));
+};
+```
+
+- [ ] **Step 5: 테스트 실행해서 통과 확인**
+
+Run: `npm run test -- todoApi.test.ts`
+Expected: PASS (전체 `todoApi.test.ts` 스위트, 기존 테스트 포함 모두 통과)
+
+- [ ] **Step 6: 커밋**
+
+```bash
+cd client
+git add src/features/todo/types/todo.type.ts src/features/todo/api/todoApi.ts src/features/todo/api/__tests__/todoApi.test.ts
+git commit -m "feat: Todo에 archived 필드 추가, getTodos()에서 archived 문서 제외"
+```
+
+---
+
+### Task 2: 신규 문서 생성 4곳에 `archived: false` 채우기
+
+**Files:**
+- Modify: `client/src/features/todo/api/todoApi.ts` (`createTodo`, `createChildTodo`, `createRecurringTodoImpl`, `editRecurringSeriesImpl`)
+- Test: `client/src/features/todo/api/__tests__/todoApi.test.ts`, `client/src/features/todo/api/__tests__/recurringTodoApi.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1의 `Todo.archived?: boolean`
+- Produces: 4개 생성 경로 모두 `addDoc`/`batch.set`에 넘기는 데이터에 `archived: false`가 포함됨 — Task 3(sweep)이 archived 여부로 대상을 가리므로, 새 문서가 이 필드 없이 생성되면 `getTodos()`의 `archived == false` 필터에 걸려 화면에 영원히 안 보이는 조용한 버그가 된다.
+
+- [ ] **Step 1: `createTodo` 실패하는 테스트 작성**
+
+`client/src/features/todo/api/__tests__/todoApi.test.ts` 파일에 `describe('createTodo', ...)` 블록을 `describe('getTodos', ...)` 다음에 추가:
+
+```ts
+  describe('createTodo', () => {
+    beforeEach(async () => {
+      vi.clearAllMocks()
+      const firebase = await import('@/shared/lib/firebase')
+      Object.assign(firebase.auth, { currentUser: { uid: 'test-user-id' } })
+    })
+
+    it('생성한 문서에 archived: false를 명시적으로 채워야 한다', async () => {
+      const { getDocs, addDoc, query, where } = await import('firebase/firestore')
+      const { createTodo } = await import('../todoApi')
+
+      vi.mocked(getDocs).mockResolvedValueOnce({
+        docs: [],
+      } as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never)
+      vi.mocked(query).mockReturnValue({} as ReturnType<typeof query>)
+      vi.mocked(where).mockReturnValue({} as ReturnType<typeof where>)
+      vi.mocked(addDoc).mockResolvedValueOnce({ id: 'new-1' } as Awaited<ReturnType<typeof addDoc>>)
+
+      await createTodo(makeTodo({ title: '새 할일' }))
+
+      expect(addDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ archived: false }),
+      )
+    })
+  })
+```
+
+- [ ] **Step 2: 테스트 실행해서 실패 확인**
+
+Run: `npm run test -- todoApi.test.ts`
+Expected: FAIL — `addDoc`에 넘긴 객체에 `archived` 키가 없음
+
+- [ ] **Step 3: `createTodo`에 `archived: false` 추가**
+
+`client/src/features/todo/api/todoApi.ts:132-140`의 `addDoc` 호출을 수정:
+
+```ts
+  const docRef = await addDoc(todosRef, {
+    ...todoData,
+    userId,
+    createdAt: now,
+    updatedAt: now,
+    parentId: null,
+    status: "todo",
+    order: maxOrder + 1,
+    archived: false,
+  });
+```
+
+- [ ] **Step 4: 테스트 실행해서 통과 확인**
+
+Run: `npm run test -- todoApi.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: `createChildTodo`에 동일하게 적용 + 테스트**
+
+`todoApi.test.ts`에 테스트 추가:
+
+```ts
+  describe('createChildTodo', () => {
+    beforeEach(async () => {
+      vi.clearAllMocks()
+      const firebase = await import('@/shared/lib/firebase')
+      Object.assign(firebase.auth, { currentUser: { uid: 'test-user-id' } })
+    })
+
+    it('생성한 하위 할 일에 archived: false를 명시적으로 채워야 한다', async () => {
+      const { addDoc, updateDoc } = await import('firebase/firestore')
+      const { createChildTodo } = await import('../todoApi')
+
+      vi.mocked(addDoc).mockResolvedValueOnce({ id: 'child-1' } as Awaited<ReturnType<typeof addDoc>>)
+      vi.mocked(updateDoc).mockResolvedValueOnce(undefined)
+
+      await createChildTodo('parent-1', { title: '하위 할일' }, [])
+
+      expect(addDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ archived: false }),
+      )
+    })
+  })
+```
+
+`client/src/features/todo/api/todoApi.ts:332-342`의 `addDoc` 호출에 `archived: false,` 를 `recurrenceId: null,` 다음 줄에 추가.
+
+Run: `npm run test -- todoApi.test.ts` → PASS 확인.
+
+- [ ] **Step 6: `createRecurringTodoImpl` 실패하는 테스트 작성**
+
+`client/src/features/todo/api/__tests__/recurringTodoApi.test.ts`의 `describe('createRecurringTodo', ...)` 블록 안에 테스트 추가(기존 "생성할 dueDates 개수만큼..." 테스트 바로 다음):
+
+```ts
+  it('생성한 각 인스턴스에 archived: false를 명시적으로 채운다', async () => {
+    const { getDocs, writeBatch } = await import('firebase/firestore');
+    vi.mocked(getDocs).mockResolvedValueOnce(emptyDocsSnapshot);
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { createRecurringTodo } = await import('../todoApi');
+    await createRecurringTodo(
+      makeTodo({ recurrence: dailyRule, startAt: '2026-07-10T09:00:00' }),
+      new Date('2026-07-13T00:00:00'),
+    );
+
+    expect(batch.set).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ archived: false }),
+    );
+  });
+```
+
+- [ ] **Step 7: 테스트 실행해서 실패 확인**
+
+Run: `npm run test -- recurringTodoApi.test.ts`
+Expected: FAIL
+
+- [ ] **Step 8: `createRecurringTodoImpl`에 `archived: false` 추가**
+
+`client/src/features/todo/api/todoApi.ts:413-436`의 `instanceData` 객체에 `archived: false,`를 `parentId: null,` 다음 줄에 추가.
+
+- [ ] **Step 9: 테스트 실행해서 통과 확인**
+
+Run: `npm run test -- recurringTodoApi.test.ts`
+Expected: PASS
+
+- [ ] **Step 10: `editRecurringSeriesImpl` 재생성 경로에도 동일하게 테스트+구현**
+
+`recurringTodoApi.test.ts`의 `describe('editRecurringSeries', ...)` 안, "미래 todo 인스턴스는 삭제 후 새 규칙으로 재생성한다" 테스트 다음에 추가:
+
+```ts
+  it('재생성한 인스턴스에 archived: false를 명시적으로 채운다', async () => {
+    const { getDocs, writeBatch } = await import('firebase/firestore');
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(emptyDocsSnapshot) // 시리즈 조회 결과 없음 → 전부 재생성
+      .mockResolvedValueOnce(emptyDocsSnapshot); // getNextRootOrder
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { editRecurringSeries } = await import('../todoApi');
+    await editRecurringSeries(
+      makeTodo({
+        id: 'series-1',
+        recurrenceId: 'rec-1',
+        recurrence: dailyRule,
+        startAt: '2026-07-10T09:00:00',
+        dueAt: '2026-07-10T09:00:00',
+      }),
+      new Date('2026-07-13T00:00:00'),
+    );
+
+    expect(batch.set).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ archived: false }),
+    );
+  });
+```
+
+`client/src/features/todo/api/todoApi.ts:590-608`의 `batch.set` 두 번째 인자 객체에 `archived: false,`를 `parentId: null,` 다음 줄에 추가.
+
+Run: `npm run test -- recurringTodoApi.test.ts`
+Expected: PASS
+
+- [ ] **Step 11: 전체 테스트 스위트 실행**
+
+Run: `npm run test`
+Expected: 전체 PASS (기존 315개 + 이번 태스크에서 추가한 테스트)
+
+- [ ] **Step 12: 커밋**
+
+```bash
+cd client
+git add src/features/todo/api/todoApi.ts src/features/todo/api/__tests__/todoApi.test.ts src/features/todo/api/__tests__/recurringTodoApi.test.ts
+git commit -m "feat: 신규 Todo 문서 생성 4곳에 archived: false 명시"
+```
+
+---
+
+### Task 3: `sweepArchivedTodos()` 구현
+
+**Files:**
+- Modify: `client/src/features/todo/api/todoApi.ts`
+- Test: `client/src/features/todo/api/__tests__/sweepArchivedTodos.test.ts` (신규)
+
+**Interfaces:**
+- Consumes: `todosRef`, `getUserId()`, `mapDocToTodo` (todoApi.ts 내부 기존 헬퍼)
+- Produces: `sweepArchivedTodos(cutoffDays?: number): Promise<void>` — Task 4의 `useSweepArchivedTodos` 훅이 이 함수를 감싼다. 기본값 `cutoffDays = 30`.
+
+- [ ] **Step 1: 신규 테스트 파일 작성 — 실패하는 테스트들**
+
+`client/src/features/todo/api/__tests__/sweepArchivedTodos.test.ts` 신규 생성:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Todo } from "../../types/todo.type";
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(new Date("2026-07-10T00:00:00.000Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+vi.mock("@/shared/lib/firebase", () => ({
+  db: {},
+  auth: {
+    currentUser: { uid: "test-user-id" },
+  },
+  googleProvider: {},
+}));
+
+vi.mock("firebase/firestore", () => ({
+  collection: vi.fn(() => ({})),
+  addDoc: vi.fn(),
+  getDocs: vi.fn(),
+  doc: vi.fn(() => ({})),
+  updateDoc: vi.fn(),
+  deleteDoc: vi.fn(),
+  query: vi.fn(() => ({})),
+  where: vi.fn(() => ({})),
+  getDoc: vi.fn(),
+  writeBatch: vi.fn(),
+}));
+
+const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
+  id: "todo-1",
+  userId: "test-user-id",
+  title: "테스트 할 일",
+  status: "todo",
+  priority: "medium",
+  startAt: null,
+  dueAt: null,
+  doneAt: null,
+  parentId: null,
+  order: 0,
+  recurrence: null,
+  recurrenceId: null,
+  archived: false,
+  createdAt: "2026-06-14T00:00:00.000Z",
+  updatedAt: "2026-06-14T00:00:00.000Z",
+  ...overrides,
+});
+
+const toDocSnapshot = (todos: Todo[]) => ({
+  docs: todos.map((t) => ({
+    id: t.id,
+    ref: { id: t.id },
+    data: () => {
+      const { id: _id, ...rest } = t;
+      return rest;
+    },
+  })),
+});
+
+const emptyDocsSnapshot = { docs: [] };
+
+const makeBatch = () => ({
+  set: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  commit: vi.fn().mockResolvedValue(undefined),
+});
+
+const resetFirestoreMocks = async () => {
+  const { getDocs, writeBatch } = await import("firebase/firestore");
+  vi.mocked(getDocs).mockReset();
+  vi.mocked(writeBatch).mockReset();
+};
+
+describe("sweepArchivedTodos", () => {
+  beforeEach(async () => {
+    await resetFirestoreMocks();
+    const firebase = await import("@/shared/lib/firebase");
+    Object.assign(firebase.auth, { currentUser: { uid: "test-user-id" } });
+  });
+
+  it("자식 없는 단독 투두가 done된 지 30일 넘었으면 archived 처리한다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const root = makeTodo({
+      id: "solo-1",
+      status: "done",
+      doneAt: "2026-06-01T00:00:00.000Z", // 39일 전
+    });
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(toDocSnapshot([root])) // 루트 조회
+      .mockResolvedValueOnce(emptyDocsSnapshot); // 자식 조회(없음)
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { sweepArchivedTodos } = await import("../todoApi");
+    await sweepArchivedTodos();
+
+    expect(batch.update).toHaveBeenCalledWith(
+      { id: "solo-1" },
+      expect.objectContaining({ archived: true }),
+    );
+    expect(batch.commit).toHaveBeenCalledTimes(1);
+  });
+
+  it("프로젝트(자식 있음) 전체가 done된 지 30일 넘었으면 루트+자식 전부 archived 처리한다", async () => {
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    const root = makeTodo({
+      id: "project-1",
+      status: "done",
+      doneAt: "2026-06-01T00:00:00.000Z",
+    });
+    const child1 = makeTodo({ id: "child-1", parentId: "project-1", status: "done" });
+    const child2 = makeTodo({ id: "child-2", parentId: "project-1", status: "done" });
+    vi.mocked(getDocs)
+      .mockResolvedValueOnce(toDocSnapshot([root]))
+      .mockResolvedValueOnce(toDocSnapshot([child1, child2]));
+    const batch = makeBatch();
+    vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+    const { sweepArchivedTodos } = await import("../todoApi");
+    await sweepArchivedTodos();
+
+    expect(batch.update).toHaveBeenCalledWith({ id: "project-1" }, expect.objectContaining({ archived: true }));
+    expect(batch.update).toHaveBeenCalledWith({ id: "child-1" }, expect.objectContaining({ archived: true }));
+    expect(batch.update).toHaveBeenCalledWith({ id: "child-2" }, expect.objectContaining({ archived: true }));
+    expect(batch.commit).toHaveBeenCalledTimes(1);
+  });
+
+  it("루트 조회 결과가 없으면(진행 중인 프로젝트뿐이면) batch를 만들지 않는다", async () => {
+    // 형제 서브태스크 중 하나가 40일 전 done이어도, 나머지가 진행 중이라 루트 자체가
+    // done이 아니면 Firestore 쿼리(status=="done") 조건에 애초에 걸리지 않는다 —
+    // 즉 이 케이스는 루트 쿼리가 빈 결과를 반환하는 것으로 자연스럽게 표현된다.
+    const { getDocs, writeBatch } = await import("firebase/firestore");
+    vi.mocked(getDocs).mockResolvedValueOnce(emptyDocsSnapshot);
+
+    const { sweepArchivedTodos } = await import("../todoApi");
+    await sweepArchivedTodos();
+
+    expect(writeBatch).not.toHaveBeenCalled();
+  });
+
+  it("기본 기준일(30일)로 cutoff를 계산해 doneAt 범위 쿼리에 사용한다", async () => {
+    const { getDocs, where } = await import("firebase/firestore");
+    vi.mocked(getDocs).mockResolvedValueOnce(emptyDocsSnapshot);
+
+    const { sweepArchivedTodos } = await import("../todoApi");
+    await sweepArchivedTodos();
+
+    // 2026-07-10 기준 30일 전 = 2026-06-10
+    expect(where).toHaveBeenCalledWith("doneAt", "<", "2026-06-10T00:00:00.000Z");
+  });
+
+  it("cutoffDays 인자를 넘기면 그 기준으로 cutoff를 계산한다", async () => {
+    const { getDocs, where } = await import("firebase/firestore");
+    vi.mocked(getDocs).mockResolvedValueOnce(emptyDocsSnapshot);
+
+    const { sweepArchivedTodos } = await import("../todoApi");
+    await sweepArchivedTodos(90);
+
+    // 2026-07-10 기준 90일 전 = 2026-04-11
+    expect(where).toHaveBeenCalledWith("doneAt", "<", "2026-04-11T00:00:00.000Z");
+  });
+
+  it("인증되지 않은 경우 에러를 던져야 한다", async () => {
+    const firebase = await import("@/shared/lib/firebase");
+    Object.defineProperty(firebase.auth, "currentUser", { value: null, configurable: true });
+
+    const { sweepArchivedTodos } = await import("../todoApi");
+    await expect(sweepArchivedTodos()).rejects.toThrow("Not authenticated");
+
+    Object.defineProperty(firebase.auth, "currentUser", {
+      value: { uid: "test-user-id" },
+      configurable: true,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행해서 실패 확인**
+
+Run: `npm run test -- sweepArchivedTodos.test.ts`
+Expected: FAIL — `sweepArchivedTodos`가 `todoApi.ts`에 없어 import 에러
+
+- [ ] **Step 3: `sweepArchivedTodos` 구현**
+
+`client/src/features/todo/api/todoApi.ts`에 `updateToDone` 함수(기존 253-262줄) 다음에 추가:
+
+```ts
+/**
+ * 완료된 지 오래된 프로젝트를 기본 조회(getTodos)에서 제외되도록 archived 처리한다.
+ * 앱 진입 시 1회 실행(App.tsx)되는 지연 스윕 — extendIndefiniteRecurringSeries와 같은 자리.
+ *
+ * 판단 기준은 개별 항목의 doneAt이 아니라 **루트(parentId===null)의 doneAt**이다.
+ * 형제 서브태스크가 있는 프로젝트는 하나가 먼저 오래전에 done되고 나머지는 진행
+ * 중일 수 있는데, 그 개별 항목만 먼저 archived되면 getProjectProgress가 참조하는
+ * allTodos에서 조용히 빠져 진행률 계산이 틀어진다. calcParentStatus 불변식상 루트가
+ * done이라는 것은 이미 모든 자식이 done이라는 뜻이므로, 루트가 done된 시점(=전체
+ * 완료 시점)을 기준으로 루트+자식 전체를 한 번에 묶어 archived 처리한다.
+ */
+export const sweepArchivedTodos = async (cutoffDays: number = 30): Promise<void> => {
+  const userId = getUserId();
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - cutoffDays);
+  const cutoffISO = cutoff.toISOString();
+
+  const rootsSnapshot = await getDocs(
+    query(
+      todosRef,
+      where("userId", "==", userId),
+      where("parentId", "==", null),
+      where("status", "==", "done"),
+      where("archived", "==", false),
+      where("doneAt", "<", cutoffISO),
+    ),
+  );
+
+  if (rootsSnapshot.empty) return;
+
+  const batch = writeBatch(db);
+  const now = new Date().toISOString();
+
+  for (const rootDoc of rootsSnapshot.docs) {
+    batch.update(rootDoc.ref, { archived: true, updatedAt: now });
+
+    const childrenSnapshot = await getDocs(
+      query(todosRef, where("userId", "==", userId), where("parentId", "==", rootDoc.id)),
+    );
+    childrenSnapshot.docs.forEach((childDoc) => {
+      batch.update(childDoc.ref, { archived: true, updatedAt: now });
+    });
+  }
+
+  await batch.commit();
+};
+```
+
+- [ ] **Step 4: 테스트 실행해서 통과 확인**
+
+Run: `npm run test -- sweepArchivedTodos.test.ts`
+Expected: PASS (7개 테스트 전부)
+
+- [ ] **Step 5: 전체 테스트 스위트 + lint 실행**
+
+Run: `npm run test && npm run lint`
+Expected: 전체 PASS, lint 에러 없음
+
+- [ ] **Step 6: 커밋**
+
+```bash
+cd client
+git add src/features/todo/api/todoApi.ts src/features/todo/api/__tests__/sweepArchivedTodos.test.ts
+git commit -m "feat: sweepArchivedTodos 구현 — 루트 단위로 30일 지난 완료 프로젝트 archived 처리"
+```
+
+---
+
+### Task 4: `useSweepArchivedTodos` 훅 + App.tsx 연동
+
+**Files:**
+- Modify: `client/src/features/todo/hooks/useTodo.ts`
+- Modify: `client/src/App.tsx`
+- Test: `client/src/features/todo/hooks/__tests__/useTodo.test.tsx`
+
+**Interfaces:**
+- Consumes: Task 3의 `sweepArchivedTodos(cutoffDays?: number): Promise<void>`
+- Produces: `useTodo().useSweepArchivedTodos` — `useMutation` 객체, `.mutate()` 호출 시 성공하면 `["todos"]` 쿼리 invalidate, 실패하면 콘솔에 에러 로그(사용자에게는 알리지 않음).
+
+- [ ] **Step 1: 훅 mock에 `sweepArchivedTodos` 추가**
+
+`client/src/features/todo/hooks/__tests__/useTodo.test.tsx:18-32`의 `vi.mock('../../api', ...)` 객체에 `sweepArchivedTodos: vi.fn(),`를 `extendIndefiniteRecurringSeries: vi.fn(),` 다음 줄에 추가. (이 mock은 실제 모듈을 부분적으로 대체하는 게 아니라 전체를 대체하는 객체 리터럴이므로, 새 export를 여기 추가하지 않으면 훅 코드가 `sweepArchivedTodos`를 import할 때 `undefined`가 되어 다음 단계 테스트가 실패한다.)
+
+- [ ] **Step 2: 실패하는 테스트 작성**
+
+`useTodo.test.tsx`의 `describe('useExtendIndefiniteRecurringSeries', ...)` 블록 다음(511줄 직전, `describe('useTodo 훅', ...)`가 닫히기 전)에 추가:
+
+```ts
+  describe('useSweepArchivedTodos', () => {
+    it('done 아카이빙 스윕 mutation이 정의되어 있어야 한다', () => {
+      const { result } = renderHook(() => useTodo(), {
+        wrapper: createWrapper(),
+      })
+
+      expect(result.current.useSweepArchivedTodos).toBeDefined()
+      expect(typeof result.current.useSweepArchivedTodos.mutate).toBe('function')
+    })
+
+    it('성공 시 todos 쿼리를 무효화해야 한다', async () => {
+      const { getTodos, sweepArchivedTodos } = await import('../../api')
+
+      vi.mocked(getTodos).mockResolvedValue([])
+      vi.mocked(sweepArchivedTodos).mockResolvedValueOnce(undefined)
+
+      const { result } = renderHook(() => useTodo(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.useGetTodos.isSuccess).toBe(true)
+      })
+
+      result.current.useSweepArchivedTodos.mutate()
+
+      await waitFor(() => {
+        expect(result.current.useSweepArchivedTodos.isSuccess).toBe(true)
+      })
+
+      expect(vi.mocked(sweepArchivedTodos)).toHaveBeenCalled()
+    })
+
+    it('실패 시 사용자에게는 알리지 않되 콘솔에는 에러를 남겨야 한다', async () => {
+      const { getTodos, sweepArchivedTodos } = await import('../../api')
+
+      vi.mocked(getTodos).mockResolvedValue([])
+      const error = new Error('permission-denied')
+      vi.mocked(sweepArchivedTodos).mockRejectedValueOnce(error)
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const { result } = renderHook(() => useTodo(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.useGetTodos.isSuccess).toBe(true)
+      })
+
+      result.current.useSweepArchivedTodos.mutate()
+
+      await waitFor(() => {
+        expect(result.current.useSweepArchivedTodos.isError).toBe(true)
+      })
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('done 아카이빙 스윕 실패'),
+        error,
+      )
+
+      consoleErrorSpy.mockRestore()
+    })
+  })
+```
+
+- [ ] **Step 3: 테스트 실행해서 실패 확인**
+
+Run: `npm run test -- useTodo.test.tsx`
+Expected: FAIL — `result.current.useSweepArchivedTodos`가 `undefined`
+
+- [ ] **Step 4: `useTodo.ts`에 훅 추가**
+
+`client/src/features/todo/hooks/useTodo.ts`의 import 목록(3-17줄)에 `sweepArchivedTodos,`를 `extendIndefiniteRecurringSeries,` 다음 줄에 추가하고, `useExtendIndefiniteRecurringSeries`(207-215줄) 다음에 새 훅을 추가:
+
+```ts
+  // 앱 진입 시 1회 호출해 30일 지난 완료 프로젝트를 archived 처리한다(App.tsx).
+  // extendIndefiniteRecurringSeries와 동일한 이유로 사용자 액션이 아닌 백그라운드
+  // 유지보수이므로 조용히 넘어가고, 실패는 콘솔에만 남긴다.
+  const useSweepArchivedTodos = useMutation({
+    mutationFn: () => sweepArchivedTodos(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["todos"] });
+    },
+    onError: (error) => {
+      console.error("done 아카이빙 스윕 실패:", error);
+    },
+  });
+```
+
+그리고 `return { ... }` 객체(217-230줄)에 `useSweepArchivedTodos,`를 `useExtendIndefiniteRecurringSeries,` 다음 줄에 추가.
+
+- [ ] **Step 5: 테스트 실행해서 통과 확인**
+
+Run: `npm run test -- useTodo.test.tsx`
+Expected: PASS
+
+- [ ] **Step 6: App.tsx에 연동**
+
+`client/src/App.tsx`를 수정한다. 21줄:
+
+```ts
+  const { useExtendIndefiniteRecurringSeries, useSweepArchivedTodos } = useTodo();
+```
+
+22줄 다음(`hasExtendedRef` 다음)에 추가:
+
+```ts
+  const hasSweptRef = useRef(false);
+```
+
+27-32줄의 `useEffect` 안, `useExtendIndefiniteRecurringSeries.mutate();` 다음 줄에 추가:
+
+```ts
+    if (!hasSweptRef.current) {
+      hasSweptRef.current = true;
+      useSweepArchivedTodos.mutate();
+    }
+```
+
+(두 유지보수 작업을 하나의 `useEffect`에 같이 둔다 — 둘 다 "앱 진입 시 1회, 실패해도 조용히" 성격이 동일하고 서로 의존하지 않는다.)
+
+- [ ] **Step 7: 전체 테스트 + 빌드 확인**
+
+Run: `npm run test && npm run build`
+Expected: 전체 PASS, 빌드 에러 없음
+
+- [ ] **Step 8: 커밋**
+
+```bash
+cd client
+git add src/features/todo/hooks/useTodo.ts src/features/todo/hooks/__tests__/useTodo.test.tsx src/App.tsx
+git commit -m "feat: 앱 진입 시 done 아카이빙 스윕 자동 실행"
+```
+
+---
+
+### Task 5: 1회성 백필 마이그레이션 스크립트
+
+**Files:**
+- Create: `scripts/backfillArchivedField.ts`
+- Modify: `package.json`(루트) — devDependency 및 실행 스크립트 추가
+
+**Interfaces:**
+- Consumes: 없음(독립 실행 스크립트, 앱 코드와 런타임 의존성 없음)
+- Produces: 프로덕션 Firestore의 `todos` 컬렉션 전체 문서에 `archived` 필드가 없으면 `archived: false`를 채움. **이 스크립트는 Task 1의 `getTodos()` 필터를 프로덕션에 배포하기 전에 반드시 먼저 실행해야 한다** — 순서를 지키지 않으면 기존 데이터가 전부 화면에서 사라진다.
+
+- [ ] **Step 1: 의존성 추가**
+
+레포 루트(`/Users/river/tododo`)의 `package.json`에 devDependency 추가:
+
+```bash
+npm install --save-dev firebase-admin tsx
+```
+
+`package.json`의 `"scripts"`에 추가:
+
+```json
+    "backfill:archived": "tsx scripts/backfillArchivedField.ts"
+```
+
+- [ ] **Step 2: 스크립트 작성**
+
+`scripts/backfillArchivedField.ts` 신규 생성:
+
+```ts
+/**
+ * 1회성 마이그레이션: todos 컬렉션에서 archived 필드가 없는 문서에만 archived: false를 채운다.
+ * 이미 필드가 있는 문서는 건드리지 않으므로 재실행해도 안전하다(멱등).
+ *
+ * 실행 전 GOOGLE_APPLICATION_CREDENTIALS 환경변수에 서비스 계정 키 파일 경로를 설정해야 한다.
+ * (Firebase 콘솔 > 프로젝트 설정 > 서비스 계정 > 새 비공개 키 생성)
+ *
+ * 사용법:
+ *   GOOGLE_APPLICATION_CREDENTIALS=./service-account.json npm run backfill:archived -- --dry-run
+ *   GOOGLE_APPLICATION_CREDENTIALS=./service-account.json npm run backfill:archived
+ */
+import { initializeApp, applicationDefault } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+const isDryRun = process.argv.includes("--dry-run");
+const BATCH_SIZE = 400; // Firestore batch 쓰기 상한(500) 아래 여유
+
+const run = async () => {
+  initializeApp({ credential: applicationDefault() });
+  const db = getFirestore();
+
+  const snapshot = await db.collection("todos").get();
+  const needsBackfill = snapshot.docs.filter((doc) => doc.data().archived === undefined);
+
+  console.log(`전체 문서 ${snapshot.size}개 중 백필 대상 ${needsBackfill.length}개`);
+
+  if (isDryRun) {
+    console.log("--dry-run 모드: 실제 쓰기는 수행하지 않음");
+    return;
+  }
+
+  if (needsBackfill.length === 0) {
+    console.log("백필 대상 없음, 종료");
+    return;
+  }
+
+  for (let i = 0; i < needsBackfill.length; i += BATCH_SIZE) {
+    const chunk = needsBackfill.slice(i, i + BATCH_SIZE);
+    const batch = db.batch();
+    chunk.forEach((doc) => {
+      batch.update(doc.ref, { archived: false });
+    });
+    await batch.commit();
+    console.log(`${i + chunk.length}/${needsBackfill.length} 완료`);
+  }
+
+  console.log("백필 완료");
+};
+
+run().catch((error) => {
+  console.error("백필 실패:", error);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 3: Firestore 에뮬레이터로 검증**
+
+이 스크립트는 Admin SDK로 실제 인프라를 직접 변경하는 1회성 운영 스크립트라, 이 프로젝트의 Vitest 유닛 테스트 스위트에 편입하지 않는다(스코프 밖 로직과 mock 인프라를 새로 만드는 비용 대비 실익이 낮음 — YAGNI). 대신 이 저장소에 이미 설정되어 있는 Firestore 에뮬레이터(`firebase.json`의 `emulators.firestore`, 포트 8080)로 실제에 가깝게 검증한다.
+
+터미널 1:
+
+```bash
+firebase emulators:start --only firestore
+```
+
+터미널 2 — 에뮬레이터에 `archived` 필드 없는 더미 문서와 있는 더미 문서를 섞어 넣은 뒤 스크립트 실행:
+
+```bash
+export FIRESTORE_EMULATOR_HOST=localhost:8080
+export GOOGLE_APPLICATION_CREDENTIALS=  # 에뮬레이터는 인증 불필요, 빈 값으로 둔다
+npm run backfill:archived -- --dry-run
+```
+
+Expected 출력: "백필 대상 N개" (N > 0이면 필드 없는 문서를 정상 탐지한 것)
+
+```bash
+npm run backfill:archived
+```
+
+Expected 출력: "백필 완료". 이후 다시 실행해도 "백필 대상 없음, 종료"가 떠야 한다(멱등성 확인).
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add package.json package-lock.json scripts/backfillArchivedField.ts
+git commit -m "chore: archived 필드 1회성 백필 마이그레이션 스크립트 추가"
+```
+
+---
+
+## 배포 체크리스트 (코드 작업 완료 후, 사람이 직접 수행)
+
+이 순서를 반드시 지킨다. 순서가 바뀌면 프로덕션의 기존 할 일이 전부 화면에서 사라지는 사고가 난다.
+
+1. **Firestore 복합 인덱스 생성**: Task 3의 `sweepArchivedTodos` 쿼리(`userId`+`parentId`+`status`+`archived`+`doneAt` 범위)에 필요한 복합 인덱스를 Firebase 콘솔에서 미리 생성한다. (첫 실행 시 콘솔 에러 로그에 뜨는 생성 링크를 따라가도 된다.)
+2. **프로덕션 백필 실행**: `GOOGLE_APPLICATION_CREDENTIALS`를 프로덕션 서비스 계정 키로 설정하고 `npm run backfill:archived -- --dry-run`으로 먼저 대상 수를 확인한 뒤, `npm run backfill:archived`로 실제 실행한다.
+3. **백필 완료 확인 후에만** 이 브랜치를 `main`에 머지/배포한다(`main` push 시 Firebase Hosting 자동 배포되므로, 백필 전에 머지하면 안 된다).

--- a/docs/superpowers/specs/2026-08-01-done-todo-archiving-design.md
+++ b/docs/superpowers/specs/2026-08-01-done-todo-archiving-design.md
@@ -1,0 +1,157 @@
+# done 할 일 아카이빙 — 쿼리 최적화 설계
+
+- 대상 파일: `client/src/features/todo/api/todoApi.ts`, `client/src/features/todo/hooks/useTodo.ts`, `client/src/App.tsx`, `firestore.rules`(필요 시), 신규 1회성 마이그레이션 스크립트
+- 작성일: 2026-08-01
+- 상태: 사용자 검토 대기 (승인 시 `writing-plans` → `frontend-developer`가 구현)
+
+## 0. 배경
+
+`getTodos()`(`client/src/features/todo/api/todoApi.ts:93-100`)는 `userId`로만 필터링해 사용자의 모든 Todo 문서(todo/doing/done 전체)를 한 번에 가져온다. 이 결과 하나(TanStack Query 키 `["todos"]`)를 목록/칸반/캘린더/오늘/검색 화면이 전부 공유한다(`useTodo.ts` 확인). done이 삭제되지 않고 계속 쌓이면, 활성 작업량과 무관하게 앱 진입 시마다 다운로드/파싱/정렬해야 하는 문서 수가 계속 늘어난다.
+
+당초 "삭제" 여부를 논의했으나, 프로젝트 진행률(`getProjectProgress`) 같은 UI가 완료 이력에 의존하고 있어 원본 데이터를 지우지 않기로 했다. 대신 **기본 조회에서 오래된 done을 제외(아카이빙)**하는 쪽으로 방향을 잡았다.
+
+### 핵심 제약 (설계 과정에서 발견)
+
+`getProjectProgress`/`getProjectSubtaskInfo`(`client/src/features/todo/utils/projectUtils.ts`)는 `parentId`로 형제 서브태스크를 찾아 done 비율을 계산한다. 목록 페이지는 이미 done인 **루트** 프로젝트만 화면에서 제외하므로(`todoList.tsx:57,78` `filter(todo => todo.status !== "done")`), 진행 중인 프로젝트(루트가 아직 done 아님)는 서브태스크가 아무리 오래전에 done됐어도 계속 화면에 필요하다.
+
+따라서 **개별 항목의 `doneAt` 단독 기준으로 시간창 필터를 걸면 안 된다.** 형제 서브태스크 중 하나가 먼저 오래전에 끝나고 나머지는 진행 중인 프로젝트가 있으면, 그 항목이 쿼리에서 빠지는 순간 진행률 계산(`total`, `doneCount`)이 조용히 틀어진다. 아카이빙 판단은 **루트 프로젝트 전체 단위**(루트+그 자식들)로 묶어서, 루트 자신이 done이 된 시점(=`calcParentStatus`가 이미 계산해주는, 모든 자식이 done이 된 바로 그 시점) 기준으로만 해야 한다.
+
+## 1. 결정된 설계 개요
+
+- Todo 문서에 `archived: boolean` 필드를 추가한다.
+- `getTodos()`에 `where("archived", "==", false)` 조건을 추가한다. 이 함수 하나가 모든 화면의 데이터 소스이므로, 여기 한 곳만 고치면 전체에 자동 반영된다.
+- 신규 함수 `sweepArchivedTodos()`: 앱 진입 시 1회, 루트가 done된 지 30일 지난 항목을 찾아 루트+그 자식 전체에 `archived: true`를 batch write한다.
+- 서버/크론이 없는 프로젝트 구조상, 기존 `extendIndefiniteRecurringSeries`(App.tsx 마운트 시 1회 호출, 실패해도 조용히 넘어가고 콘솔에만 로그, 다음 접속 때 재시도)와 완전히 같은 패턴을 그대로 따른다.
+- 완료 이력을 다시 조회하는 "완료 보관함" 화면은 **이번 스코프에 포함하지 않는다.** 이번 작업은 쿼리 구조 개선까지만 다루고, 조회 UI는 별도 백로그로 남긴다.
+
+## 2. 데이터 모델 변경
+
+```ts
+interface Todo {
+  // ...기존 필드 동일
+  archived: boolean; // 신규. 기본값 false. true면 기본 조회(getTodos)에서 제외됨
+}
+```
+
+- `archived`는 "완료됨"과 별개 개념이다. `status`는 사용자가 보는 작업 상태(todo/doing/done)를 뜻하고, `archived`는 순수하게 "기본 목록 쿼리에 포함할지"를 뜻하는 내부 최적화용 플래그다. `archived: true`인 문서는 항상 `status: "done"`이지만 역은 성립하지 않는다(done이어도 30일 안 지났으면 archived는 false).
+
+## 3. 쿼리 변경
+
+```ts
+export const getTodos = async () => {
+  const userId = getUserId();
+  const q = query(
+    todosRef,
+    where("userId", "==", userId),
+    where("archived", "==", false),
+  );
+  const snapshot = await getDocs(q);
+  return snapshot.docs
+    .map((doc) => mapDocToTodo(doc.id, doc.data()))
+    .sort((a, b) => normalizeOrder(a.order) - normalizeOrder(b.order));
+};
+```
+
+`getSearchTodoList`는 내부적으로 `getTodos()`를 호출하므로 자동으로 같이 적용된다. `getTodoDetail`(단건 조회, id로 직접 조회)은 아카이빙 여부와 무관하게 항상 조회 가능해야 하므로 필터를 추가하지 않는다 — 아카이빙된 항목의 상세 페이지 직링크 등은 계속 열려야 한다.
+
+`createTodo`/`getNextRootOrder`의 order 계산용 쿼리(`parentId == null`)는 `archived` 필터를 추가하지 않는다. 아카이빙된 done 루트가 order 계산에 섞여도(둘 다 `Math.max`로만 쓰임) 정확성에 영향이 없다.
+
+## 4. 스윕 메커니즘
+
+```ts
+export const sweepArchivedTodos = async (
+  cutoffDays: number = 30,
+): Promise<void> => {
+  const userId = getUserId();
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - cutoffDays);
+  const cutoffISO = cutoff.toISOString();
+
+  const rootsSnapshot = await getDocs(
+    query(
+      todosRef,
+      where("userId", "==", userId),
+      where("parentId", "==", null),
+      where("status", "==", "done"),
+      where("archived", "==", false),
+      where("doneAt", "<", cutoffISO),
+    ),
+  );
+
+  if (rootsSnapshot.empty) return;
+
+  const batch = writeBatch(db);
+  const now = new Date().toISOString();
+
+  for (const rootDoc of rootsSnapshot.docs) {
+    batch.update(rootDoc.ref, { archived: true, updatedAt: now });
+
+    const childrenSnapshot = await getDocs(
+      query(
+        todosRef,
+        where("userId", "==", userId),
+        where("parentId", "==", rootDoc.id),
+      ),
+    );
+    childrenSnapshot.docs.forEach((childDoc) => {
+      batch.update(childDoc.ref, { archived: true, updatedAt: now });
+    });
+  }
+
+  await batch.commit();
+};
+```
+
+- 자식 조회 시 `status`/`archived` 조건을 걸지 않는다 — 루트가 done이라는 것은 `calcParentStatus` 불변식상 모든 자식이 이미 done이라는 뜻이므로, 자식의 현재 상태를 다시 확인할 필요 없이 전부 archived 처리한다.
+- `useTodo.ts`에 `useSweepArchivedTodos` 훅을 `useExtendIndefiniteRecurringSeries`와 동일한 형태(성공 시 `["todos"]` invalidate, 실패 시 `console.error`)로 추가하고, `App.tsx`에서 마운트 시 같이 호출한다.
+
+## 5. 신규 문서 생성 시 `archived` 필드
+
+다음 4개 생성 경로 모두 문서 생성 시 `archived: false`를 명시적으로 채운다: `createTodo`, `createChildTodo`, `createRecurringTodoImpl`(인스턴스 batch.set), `editRecurringSeriesImpl`(재생성 batch.set). 필드를 빠뜨리면 해당 문서가 `getTodos()`의 `archived == false` 필터에 걸려 화면에서 영원히 안 보이게 되므로, 이 4곳 전부 빠짐없이 확인해야 한다.
+
+## 6. 마이그레이션/롤아웃
+
+- **문제**: Firestore의 `where("archived", "==", false)`는 `archived` 필드가 아예 없는 기존 문서를 결과에서 제외한다. 필터부터 배포하면 지금까지 쌓인 데이터가 전부(done 여부 무관) 화면에서 사라진다.
+- **백필**: Firebase Admin SDK로 1회성 스크립트를 작성해 `todos` 컬렉션 전체를 순회, `archived` 필드가 없는 문서에만 batch로 `archived: false`를 채운다. 이미 필드가 있는 문서는 건드리지 않아 재실행해도 안전(멱등)하다.
+- **배포 순서**: ① 백필 스크립트 실행 및 완료 확인 → ② `getTodos()` 필터 배포. 순서를 반드시 지킨다.
+- **Firestore 복합 인덱스**: `sweepArchivedTodos()`의 쿼리(`userId` + `parentId` + `status` + `archived` + `doneAt` 범위)에 새 복합 인덱스가 필요하다. 이 저장소는 `firestore.indexes.json`을 관리하지 않고 콘솔 기반으로 보이므로(`firebase.json`엔 `rules`만 등록), 첫 배포 후 Firestore 콘솔 에러에 뜨는 인덱스 생성 링크를 사용하거나 배포 전 콘솔에서 미리 생성해둔다.
+
+## 7. 엣지케이스
+
+- 자식 없는 단독 투두, done 30일+ 경과 → archived
+- 프로젝트(자식 있음), 모든 자식 done & 루트 done 30일+ 경과 → 루트+자식 전부 archived
+- 프로젝트 진행 중(자식 하나가 40일 전 done, 형제는 아직 todo/doing이라 루트는 done 아님) → **아무것도 archived 안 됨**
+- 새로 만든 투두는 `archived: false`가 명시적으로 찍혀 있어야 함(5절 4곳)
+- 마이그레이션 스크립트 재실행 시 이미 필드 있는 문서는 스킵(멱등성)
+- `deleteTodo`는 `archived` 여부와 무관하게 항상 동작해야 함(현재 코드는 필터 없이 id로 직접 삭제하므로 영향 없음 — 회귀 없는지만 확인)
+- 반복 시리즈 인스턴스는 항상 `parentId: null`(루트)이므로 별도 처리 없이 루트 규칙을 그대로 적용받음
+
+## 8. 테스트
+
+- `sweepArchivedTodos` 유닛 테스트: 위 엣지케이스를 모두 커버. **시스템 날짜를 절대값으로 하드코딩하지 말고 `vi.setSystemTime` 등으로 mock**해서 고정한다(이 프로젝트 기존 테스트 컨벤션 — CI가 UTC 환경이라 타임존도 함께 고려).
+- `getTodos` 유닛 테스트: `archived: true` 문서가 결과에서 빠지는지 확인하는 케이스 추가.
+- 신규 문서 생성 4곳 각각에 `archived: false`가 찍히는지 확인하는 케이스 추가(기존 테스트에 필드 하나 추가하는 정도).
+
+## 9. 범위
+
+### 변경 대상
+
+- `client/src/features/todo/types/todo.type.ts` — `Todo`에 `archived: boolean` 추가
+- `client/src/features/todo/api/todoApi.ts` — `getTodos` 필터 추가, `sweepArchivedTodos` 신규, `createTodo`/`createChildTodo`/`createRecurringTodoImpl`/`editRecurringSeriesImpl`에 `archived: false` 추가
+- `client/src/features/todo/hooks/useTodo.ts` — `useSweepArchivedTodos` 훅 추가
+- `client/src/App.tsx` — 마운트 시 `useSweepArchivedTodos` 호출 추가
+- 신규 1회성 마이그레이션 스크립트(리포지토리 내 위치는 구현 단계에서 결정 — 예: `scripts/backfill-archived-field.ts`)
+
+### 범위 밖 (변경하지 않음)
+
+- "완료 보관함" 등 archived 항목을 다시 조회하는 UI — 백로그
+- `server/`, `docker-compose.yml` — CLAUDE.md 정책상 무관
+- 삭제(하드 delete) 정책 — 이번 설계는 보관을 전제로 하며 삭제 기능을 추가하지 않는다
+- 아카이빙 기준 기간(30일)을 사용자가 설정에서 바꾸는 기능 — 하지 않는다(YAGNI)
+
+## 10. 다음 담당자(frontend-developer)에게 전달할 사항
+
+- **배포 순서를 반드시 지킬 것**: 마이그레이션 백필 → `getTodos()` 필터 배포. 순서가 바뀌면 기존 데이터가 전부 사라지는 사고가 난다(6절).
+- 아카이빙 판단은 개별 항목의 `doneAt`이 아니라 **루트의 `doneAt`**을 기준으로 한다 — 형제 서브태스크가 있는 프로젝트의 진행률 계산이 깨지지 않으려면 이 규칙을 반드시 지켜야 한다(0절 핵심 제약).
+- 신규 문서 생성 경로 4곳(5절) 중 하나라도 `archived: false`를 빠뜨리면 그 문서는 영원히 목록에 안 보이는 조용한 버그가 된다 — 구현 후 전체 테스트와 함께 실제로 새 할 일을 만들어 목록에 뜨는지 육안 확인 권장.
+- `sweepArchivedTodos()`의 신규 복합 인덱스(userId+parentId+status+archived+doneAt)는 로컬 개발 중 Firestore 콘솔 에러로 나타날 수 있다 — 에러 메시지의 인덱스 생성 링크를 그대로 따라가면 된다.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,1028 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
+        "firebase-admin": "^14.2.0",
         "husky": "^9.1.7",
-        "lint-staged": "^16.2.7"
+        "lint-staged": "^16.2.7",
+        "tsx": "^4.23.1"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.4.tgz",
+      "integrity": "sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.5.tgz",
+      "integrity": "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/logger": "0.5.1"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.5.tgz",
+      "integrity": "sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.4.tgz",
+      "integrity": "sha512-tLpOaaCol9ugUIYp2R3CbWPPA8Ajg/papX/XHEy8U52b/QXH3BbX8tTJX9aShDCjp+9sMAxMLD94i7lresdugQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.15.2",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.4.tgz",
+      "integrity": "sha512-D+j4+8uhGtNd1tVD+X+c8JrC4ppStGJKyujSQt2NPwdN26QcCk0BeIxue+UqspHkHiFHyQOimwlzjLewGq6S+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.4",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.2",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.5.tgz",
+      "integrity": "sha512-m2KZDNXrg8DBzXWQNbbrjOhsJnM+ctsSFaDYKrqj1gEetQ8BSAwRuMUdeWLM9a6qPBgOvOA+o09j1BSEzdFqOg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.4",
+        "@firebase/database": "1.1.4",
+        "@firebase/database-types": "1.0.21",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.2",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-compat": "0.x"
+      },
+      "peerDependenciesMeta": {
+        "@firebase/app": {
+          "optional": true
+        },
+        "@firebase/app-compat": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.21.tgz",
+      "integrity": "sha512-SX1jUqhttKgg/m9dYRTvqU9QvucBooziWfA986r4cpsbi4zlsvewe424j3Vpduwd6DG1MSAMfBVT2VqA61FnkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.5",
+        "@firebase/util": "1.15.2"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.1.tgz",
+      "integrity": "sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.2.tgz",
+      "integrity": "sha512-974pWIZVLDMc5GW5YAsj8y0XxULxIy/sPUy7tsxmWbF93KRIyh9xpuHlh0zDL+shUcf5nHDjFOg9YLiQ763eiA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@google-cloud/firestore": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-8.7.0.tgz",
+      "integrity": "sha512-EvMpZQUXkTRdweSvOu6VL6EEQwHjHAgWz2UYZR+Mj6Ao52S+TWieHbSn15jiNnEw8F8RhbZj7IGXZ1PFB1eA+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "fast-deep-equal": "^3.1.3",
+        "functional-red-black-tree": "^1.0.1",
+        "google-gax": "^5.0.1",
+        "protobufjs": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/paginator": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+      "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+      "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
+      "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.21.0.tgz",
+      "integrity": "sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "<4.1.0",
+        "abort-controller": "^3.0.0",
+        "async-retry": "^1.3.3",
+        "duplexify": "^4.1.3",
+        "fast-xml-parser": "^5.3.4",
+        "gaxios": "^6.0.2",
+        "google-auth-library": "^9.6.3",
+        "html-entities": "^2.5.2",
+        "mime": "^3.0.0",
+        "p-limit": "^3.0.1",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@types/caseless": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/request": {
+      "version": "2.48.13",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
+      "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.5"
+      }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ansi-escapes": {
@@ -55,6 +1075,100 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -66,6 +1180,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/cli-cursor": {
@@ -101,12 +1237,160 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "14.0.2",
@@ -118,12 +1402,126 @@
         "node": ">=20"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -138,12 +1536,223 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -158,6 +1767,191 @@
         "node": ">=8"
       }
     },
+    "node_modules/firebase-admin": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-14.2.0.tgz",
+      "integrity": "sha512-zfs5PdccEgjX479bbMmz95Rqc7ttQ4LV3qkGFlPiqOaOu/suBZc3fG52Qzn2hQjiSHkBM4NP2AZV5r2NvAt0TQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fastify/busboy": "^3.0.0",
+        "@firebase/database-compat": "^2.1.4",
+        "@firebase/database-types": "^1.0.20",
+        "fast-deep-equal": "^3.1.1",
+        "google-auth-library": "^10.6.2",
+        "jsonwebtoken": "^9.0.0",
+        "jwks-rsa": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "optionalDependencies": {
+        "@google-cloud/firestore": "^8.6.0",
+        "@google-cloud/storage": "^7.19.0"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.0.tgz",
+      "integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
@@ -169,6 +1963,417 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/gaxios": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.0.tgz",
+      "integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/google-gax": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.8.tgz",
+      "integrity": "sha512-M4vpZcXQIC1gqIVGQ7eaU3jXQA6zecStyTXu514TYfThlgSurYJOxHZo9fzU6hAgwPWvuEynAVHWyaIk80VeEA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@grpc/grpc-js": "^1.12.6",
+        "@grpc/proto-loader": "^0.8.0",
+        "duplexify": "^4.1.3",
+        "google-auth-library": "10.5.0",
+        "google-logging-utils": "1.1.3",
+        "node-fetch": "^3.3.2",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "3.0.4",
+        "protobufjs": "^7.5.4",
+        "retry-request": "^8.0.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/gaxios": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.0.tgz",
+      "integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-auth-library": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^8.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/google-gax/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/google-gax/node_modules/retry-request": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.4.tgz",
+      "integrity": "sha512-pI6/7eabUYkZxamkOq0g0uMxKLLGnjzhefY+vL8bVXag5rto4OU2YBTPytWLuHH7aEKD6fn7kJycQfid0Mwnkw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/teeny-request": {
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.4.tgz",
+      "integrity": "sha512-R1Cg4Vu0UULeDfHL/kjABLaTW++9yD/B6n2g48y5dJ04hsEaxcfmAqbNDzNsbqAYJyIpZafjklLG9YxRu9uzOg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/husky": {
@@ -186,6 +2391,14 @@
       "funding": {
         "url": "https://github.com/sponsors/typicode"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "5.1.0",
@@ -212,6 +2425,149 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.6.tgz",
+      "integrity": "sha512-HwMtbJjMw8rC8dUTwCNilHJD+fxTeKM3JV1eprSmTjS41qwXSSt6exJXgyPK1QOu0jB9eDYLESRDkB3qaT3jnw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jwks-rsa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-4.1.0.tgz",
+      "integrity": "sha512-sbkByqyATKYJP5F4RXj03N5TUNC0QLTjCAZvwTzC4BwJZ8e0/cWxN8YROnyUth2g1/ONWi4eSFHeu6oYalrc3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "^9.0.4",
+        "debug": "^4.3.4",
+        "jose": "^6.1.3",
+        "limiter": "^1.1.5",
+        "lru-cache": "^11.0.0",
+        "lru-memoizer": "^3.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >= 23.0.0"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==",
+      "dev": true
     },
     "node_modules/lint-staged": {
       "version": "16.2.7",
@@ -256,6 +2612,70 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/log-update": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
@@ -276,6 +2696,46 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lru-memoizer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-3.0.0.tgz",
+      "integrity": "sha512-m83w/cYXLdUIboKSPxzPAGfYnk+vqeDYXuoSrQRw1q+yVEd8IXhvMufN8Q5TIPe7e2jyX4SRNrDJI2Skw1yznQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "^11.0.1"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -288,6 +2748,45 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-function": {
@@ -303,6 +2802,41 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nano-spawn": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz",
@@ -314,6 +2848,71 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -331,6 +2930,85 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -358,6 +3036,72 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/proto3-json-serializer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
+      "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "protobufjs": "^7.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -375,12 +3119,115 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/retry-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
+      "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/request": "^2.48.8",
+        "extend": "^3.0.2",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
@@ -412,6 +3259,36 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-argv": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
@@ -439,6 +3316,67 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
@@ -455,6 +3393,104 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
+    },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/teeny-request": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
+      "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.9",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/teeny-request/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -466,6 +3502,143 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/wrap-ansi": {
@@ -486,6 +3659,103 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
@@ -504,6 +3774,42 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yaml": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
@@ -518,6 +3824,111 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "prepare": "husky"
+    "prepare": "husky",
+    "backfill:archived": "tsx scripts/backfillArchivedField.ts"
   },
   "repository": {
     "type": "git",
@@ -20,7 +21,9 @@
   },
   "homepage": "https://github.com/SwimmingRiver/ToDoDo#readme",
   "devDependencies": {
+    "firebase-admin": "^14.2.0",
     "husky": "^9.1.7",
-    "lint-staged": "^16.2.7"
+    "lint-staged": "^16.2.7",
+    "tsx": "^4.23.1"
   }
 }

--- a/scripts/backfillArchivedField.ts
+++ b/scripts/backfillArchivedField.ts
@@ -1,0 +1,53 @@
+/**
+ * 1회성 마이그레이션: todos 컬렉션에서 archived 필드가 없는 문서에만 archived: false를 채운다.
+ * 이미 필드가 있는 문서는 건드리지 않으므로 재실행해도 안전하다(멱등).
+ *
+ * 실행 전 GOOGLE_APPLICATION_CREDENTIALS 환경변수에 서비스 계정 키 파일 경로를 설정해야 한다.
+ * (Firebase 콘솔 > 프로젝트 설정 > 서비스 계정 > 새 비공개 키 생성)
+ *
+ * 사용법:
+ *   GOOGLE_APPLICATION_CREDENTIALS=./service-account.json npm run backfill:archived -- --dry-run
+ *   GOOGLE_APPLICATION_CREDENTIALS=./service-account.json npm run backfill:archived
+ */
+import { initializeApp, applicationDefault } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+const isDryRun = process.argv.includes("--dry-run");
+const BATCH_SIZE = 400; // Firestore batch 쓰기 상한(500) 아래 여유
+
+const run = async () => {
+  initializeApp({ credential: applicationDefault() });
+  const db = getFirestore();
+
+  const snapshot = await db.collection("todos").get();
+  const needsBackfill = snapshot.docs.filter((doc) => doc.data().archived === undefined);
+
+  console.log(`전체 문서 ${snapshot.size}개 중 백필 대상 ${needsBackfill.length}개`);
+
+  if (isDryRun) {
+    console.log("--dry-run 모드: 실제 쓰기는 수행하지 않음");
+    return;
+  }
+
+  if (needsBackfill.length === 0) {
+    console.log("백필 대상 없음, 종료");
+    return;
+  }
+
+  for (let i = 0; i < needsBackfill.length; i += BATCH_SIZE) {
+    const chunk = needsBackfill.slice(i, i + BATCH_SIZE);
+    const batch = db.batch();
+    chunk.forEach((doc) => {
+      batch.update(doc.ref, { archived: false });
+    });
+    await batch.commit();
+    console.log(`${i + chunk.length}/${needsBackfill.length} 완료`);
+  }
+
+  console.log("백필 완료");
+};
+
+run().catch((error) => {
+  console.error("백필 실패:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- `Todo`에 `archived` 필드 추가, `getTodos()` 조회 시 archived 문서 제외
- 신규 문서 생성 4곳(`createTodo`/`createChildTodo`/`createRecurringTodoImpl`/`editRecurringSeriesImpl`)에 `archived: false` 명시
- `sweepArchivedTodos()` 구현 — 완료된 지 30일 지난 항목을 **루트 단위**로 판단해 루트+자식 함께 archived 처리
- `useSweepArchivedTodos` 훅을 앱 진입 시 자동 실행하도록 연동
- 1회성 백필 스크립트(`scripts/backfillArchivedField.ts`) 추가 — 기존 문서에 `archived: false` 채움
- 배치 write가 Firestore 500건 상한을 넘지 않도록 그룹(루트+자식) 단위로 청크 분할

## 설계 근거
- 스펙: `docs/done-archiving` 구현 계획 및 쿼리 최적화 설계 문서 (커밋 3a40d06, 406edc2)
- 아카이빙 기준: 프로젝트(루트) 전체가 완료 후 30일 지나야 루트+자식 모두 archived. 진행 중인 자식이 있으면 archived 안 됨.

## 배포 전 필수 체크리스트 (계획 문서 기준, 사람이 직접 확인 필요)
- [ ] Firestore 복합 인덱스 생성
- [ ] 프로덕션 백필 스크립트 실행 (`scripts/backfillArchivedField.ts`)
- [ ] Firestore 에뮬레이터에서 최종 동작 검증 (이번 브랜치에서 미실행)
- [ ] 백필 완료 확인 후에만 머지 — 순서가 바뀌면 기존 할 일이 화면에서 사라질 수 있음

## Test plan
- [x] `npm run test` — 36 files / 332 tests 전부 PASS (엣지케이스: deleteTodo archived 무관 동작, 반복 시리즈 인스턴스 루트 규칙, 500-write 상한 청크 분할 포함)
- [x] `npm run lint`, `npm run build` 통과
- [ ] Firestore 에뮬레이터 수동 검증 (미실행, 머지 전 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)