### PR TITLE
지난 미완료 반복 투두 archived 처리 및 밀린 회차 배지

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -18,9 +18,14 @@ const App = () => {
   const [isopen, setIsOpen] = useState(true);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const isMobile = useMediaQuery("tablet");
-  const { useExtendIndefiniteRecurringSeries, useSweepArchivedTodos } = useTodo();
+  const {
+    useExtendIndefiniteRecurringSeries,
+    useSweepArchivedTodos,
+    useSweepOverdueRecurringTodos,
+  } = useTodo();
   const hasExtendedRef = useRef(false);
   const hasSweptRef = useRef(false);
+  const hasSweptOverdueRecurringRef = useRef(false);
 
   // 인증된 레이아웃(App) 마운트 시 1회, 무기한 반복 시리즈들의 남은 인스턴스를
   // 오늘 기준으로 이어서 채운다. 세션 중 재마운트되어도 다시 실행되지 않도록
@@ -33,6 +38,10 @@ const App = () => {
     if (!hasSweptRef.current) {
       hasSweptRef.current = true;
       useSweepArchivedTodos.mutate();
+    }
+    if (!hasSweptOverdueRecurringRef.current) {
+      hasSweptOverdueRecurringRef.current = true;
+      useSweepOverdueRecurringTodos.mutate();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/client/src/features/kanban/components/kanbanColumn.tsx
+++ b/client/src/features/kanban/components/kanbanColumn.tsx
@@ -1,6 +1,7 @@
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { useDroppable } from "@dnd-kit/core";
 import type { Todo } from "@/features/todo";
+import { getRecurringMissedCount } from "@/features/todo";
 import KanbanItem from "./kanbanItem";
 import {
   KanbanColumn as KanbanColumnStyled,
@@ -89,6 +90,7 @@ const KanbanColumn = ({
                 key={todo.id}
                 todo={todo}
                 parentTitle={getParentTitle(todo.parentId)}
+                recurringMissedCount={getRecurringMissedCount(allTodos, todo)}
                 onNavigate={onNavigate}
                 isMobile={isMobile}
                 onStatusChange={onStatusChange}

--- a/client/src/features/kanban/components/kanbanItem.tsx
+++ b/client/src/features/kanban/components/kanbanItem.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type { Todo } from "@/features/todo";
-import { RecurrenceBadge } from "@/shared";
+import { RecurrenceBadge, RecurrenceMissedBadge } from "@/shared";
 import KanbanCardMenu from "./kanbanCardMenu";
 import type { Status } from "./kanbanColumn";
 import {
@@ -16,6 +16,7 @@ import {
 interface KanbanItemProps {
   todo: Todo;
   parentTitle?: string;
+  recurringMissedCount?: number;
   onNavigate: (id: string) => void;
   isMobile?: boolean;
   onStatusChange?: (todo: Todo, status: Status) => void;
@@ -24,6 +25,7 @@ interface KanbanItemProps {
 const KanbanItem = ({
   todo,
   parentTitle,
+  recurringMissedCount = 0,
   onNavigate,
   isMobile = false,
   onStatusChange,
@@ -87,6 +89,9 @@ const KanbanItem = ({
         <ItemTitleRow>
           <ItemTitle>{todo.title}</ItemTitle>
           {todo.recurrenceId != null && <RecurrenceBadge />}
+          {todo.recurrenceId != null && (
+            <RecurrenceMissedBadge count={recurringMissedCount} />
+          )}
         </ItemTitleRow>
         {isMobile && onStatusChange && (
           <KanbanCardMenu status={todo.status} onSelect={handleStatusSelect} />

--- a/client/src/features/todo/api/__tests__/sweepOverdueRecurringTodos.test.ts
+++ b/client/src/features/todo/api/__tests__/sweepOverdueRecurringTodos.test.ts
@@ -1,0 +1,378 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Todo } from "../../types/todo.type";
+
+vi.mock("@/shared/lib/firebase", () => ({
+  db: {},
+  auth: {
+    currentUser: { uid: "test-user-id" },
+  },
+  googleProvider: {},
+}));
+
+vi.mock("firebase/firestore", () => ({
+  collection: vi.fn(() => ({})),
+  addDoc: vi.fn(),
+  getDocs: vi.fn(),
+  doc: vi.fn(() => ({})),
+  updateDoc: vi.fn(),
+  deleteDoc: vi.fn(),
+  query: vi.fn(() => ({})),
+  where: vi.fn(() => ({})),
+  getDoc: vi.fn(),
+  writeBatch: vi.fn(),
+}));
+
+const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
+  id: "todo-1",
+  userId: "test-user-id",
+  title: "테스트 할 일",
+  status: "todo",
+  priority: "medium",
+  startAt: null,
+  dueAt: null,
+  doneAt: null,
+  parentId: null,
+  order: 0,
+  recurrence: null,
+  recurrenceId: null,
+  archived: false,
+  createdAt: "2026-06-14T00:00:00.000Z",
+  updatedAt: "2026-06-14T00:00:00.000Z",
+  ...overrides,
+});
+
+const toDocSnapshot = (todos: Todo[]) => ({
+  docs: todos.map((t) => ({
+    id: t.id,
+    ref: { id: t.id },
+    data: () => {
+      const { id: _id, ...rest } = t;
+      return rest;
+    },
+  })),
+});
+
+const emptyDocsSnapshot: {
+  docs: { id: string; ref: { id: string }; data: () => Record<string, unknown> }[];
+} = { docs: [] };
+
+const makeBatch = () => ({
+  set: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  commit: vi.fn().mockResolvedValue(undefined),
+});
+
+const resetFirestoreMocks = async () => {
+  const { getDocs, writeBatch } = await import("firebase/firestore");
+  vi.mocked(getDocs).mockReset();
+  vi.mocked(writeBatch).mockReset();
+};
+
+const dailyRule = { type: "daily" as const, endType: "indefinite" as const };
+
+describe("sweepOverdueRecurringTodos", () => {
+  beforeEach(async () => {
+    await resetFirestoreMocks();
+    const firebase = await import("@/shared/lib/firebase");
+    Object.assign(firebase.auth, { currentUser: { uid: "test-user-id" } });
+  });
+
+  describe("기본 동작 (기본 TZ, setup.ts가 강제하는 Asia/Seoul 기준)", () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date("2026-07-10T09:00:00"));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("아직 overdueArchived 안 된 여러 지난 미완료 인스턴스를 한 번에 overdueArchived: true로 처리한다", async () => {
+      const { getDocs, writeBatch } = await import("firebase/firestore");
+      const overdue1 = makeTodo({
+        id: "series-1_2026-07-01",
+        status: "todo",
+        dueAt: "2026-07-01T09:00:00.000Z",
+        recurrenceId: "series-1",
+        recurrence: dailyRule,
+      });
+      const overdue2 = makeTodo({
+        id: "series-1_2026-07-05",
+        status: "todo",
+        dueAt: "2026-07-05T09:00:00.000Z",
+        recurrenceId: "series-1",
+        recurrence: dailyRule,
+      });
+      vi.mocked(getDocs).mockResolvedValueOnce(
+        toDocSnapshot([overdue1, overdue2]) as ReturnType<typeof getDocs> extends Promise<
+          infer T
+        >
+          ? T
+          : never,
+      );
+      const batch = makeBatch();
+      vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+      const { sweepOverdueRecurringTodos } = await import("../todoApi");
+      await sweepOverdueRecurringTodos();
+
+      expect(batch.update).toHaveBeenCalledWith(
+        { id: "series-1_2026-07-01" },
+        expect.objectContaining({ overdueArchived: true }),
+      );
+      expect(batch.update).toHaveBeenCalledWith(
+        { id: "series-1_2026-07-05" },
+        expect.objectContaining({ overdueArchived: true }),
+      );
+      expect(batch.update).toHaveBeenCalledTimes(2);
+      expect(batch.commit).toHaveBeenCalledTimes(1);
+    });
+
+    it("이미 overdueArchived: true인 문서는 재처리 대상에서 제외한다", async () => {
+      const { getDocs, writeBatch } = await import("firebase/firestore");
+      const alreadyArchived = makeTodo({
+        id: "series-1_2026-07-01",
+        status: "todo",
+        dueAt: "2026-07-01T09:00:00.000Z",
+        recurrenceId: "series-1",
+        recurrence: dailyRule,
+        overdueArchived: true,
+      });
+      const notYetArchived = makeTodo({
+        id: "series-1_2026-07-05",
+        status: "todo",
+        dueAt: "2026-07-05T09:00:00.000Z",
+        recurrenceId: "series-1",
+        recurrence: dailyRule,
+      });
+      vi.mocked(getDocs).mockResolvedValueOnce(
+        toDocSnapshot([alreadyArchived, notYetArchived]) as ReturnType<
+          typeof getDocs
+        > extends Promise<infer T>
+          ? T
+          : never,
+      );
+      const batch = makeBatch();
+      vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+      const { sweepOverdueRecurringTodos } = await import("../todoApi");
+      await sweepOverdueRecurringTodos();
+
+      // 이미 archived된 문서는 batch.update 호출 대상에 아예 포함되지 않아야 한다.
+      expect(batch.update).toHaveBeenCalledTimes(1);
+      expect(batch.update).toHaveBeenCalledWith(
+        { id: "series-1_2026-07-05" },
+        expect.objectContaining({ overdueArchived: true }),
+      );
+    });
+
+    it("dueAt이 아직 지나지 않은 미래 인스턴스는 대상에서 제외하고, 대상이 하나도 없으면 batch를 만들지 않는다", async () => {
+      const { getDocs, writeBatch } = await import("firebase/firestore");
+      const futureInstance = makeTodo({
+        id: "series-1_2026-08-01",
+        status: "todo",
+        dueAt: "2026-08-01T09:00:00.000Z",
+        recurrenceId: "series-1",
+        recurrence: dailyRule,
+      });
+      vi.mocked(getDocs).mockResolvedValueOnce(
+        toDocSnapshot([futureInstance]) as ReturnType<typeof getDocs> extends Promise<infer T>
+          ? T
+          : never,
+      );
+
+      const { sweepOverdueRecurringTodos } = await import("../todoApi");
+      await sweepOverdueRecurringTodos();
+
+      expect(writeBatch).not.toHaveBeenCalled();
+    });
+
+    it("recurrenceId가 없는(반복 아닌) todo는 dueAt이 지났어도 대상에서 제외한다", async () => {
+      const { getDocs, writeBatch } = await import("firebase/firestore");
+      const plainOverdue = makeTodo({
+        id: "plain-1",
+        status: "todo",
+        dueAt: "2026-07-01T09:00:00.000Z",
+        recurrenceId: null,
+        recurrence: null,
+      });
+      vi.mocked(getDocs).mockResolvedValueOnce(
+        toDocSnapshot([plainOverdue]) as ReturnType<typeof getDocs> extends Promise<infer T>
+          ? T
+          : never,
+      );
+
+      const { sweepOverdueRecurringTodos } = await import("../todoApi");
+      await sweepOverdueRecurringTodos();
+
+      expect(writeBatch).not.toHaveBeenCalled();
+    });
+
+    it("userId + status == todo 로만 쿼리해서 done/doing 상태 문서는 애초에 조회 대상에 포함하지 않는다", async () => {
+      const { getDocs, where, writeBatch } = await import("firebase/firestore");
+      vi.mocked(getDocs).mockResolvedValueOnce(
+        emptyDocsSnapshot as ReturnType<typeof getDocs> extends Promise<infer T> ? T : never,
+      );
+
+      const { sweepOverdueRecurringTodos } = await import("../todoApi");
+      await sweepOverdueRecurringTodos();
+
+      expect(where).toHaveBeenCalledWith("userId", "==", "test-user-id");
+      expect(where).toHaveBeenCalledWith("status", "==", "todo");
+      expect(writeBatch).not.toHaveBeenCalled();
+    });
+
+    it("대상 수가 SWEEP_BATCH_SIZE(400)를 넘으면 여러 batch로 나눠 commit한다", async () => {
+      const { getDocs, writeBatch } = await import("firebase/firestore");
+      const TARGET_COUNT = 450;
+      const targets = Array.from({ length: TARGET_COUNT }, (_, i) =>
+        makeTodo({
+          id: `series-1_2026-06-${String((i % 28) + 1).padStart(2, "0")}-${i}`,
+          status: "todo",
+          dueAt: "2026-07-01T09:00:00.000Z",
+          recurrenceId: "series-1",
+          recurrence: dailyRule,
+        }),
+      );
+      vi.mocked(getDocs).mockResolvedValueOnce(
+        toDocSnapshot(targets) as ReturnType<typeof getDocs> extends Promise<infer T>
+          ? T
+          : never,
+      );
+      const batches: ReturnType<typeof makeBatch>[] = [];
+      vi.mocked(writeBatch).mockImplementation(() => {
+        const b = makeBatch();
+        batches.push(b);
+        return b as unknown as ReturnType<typeof writeBatch>;
+      });
+
+      const { sweepOverdueRecurringTodos } = await import("../todoApi");
+      await sweepOverdueRecurringTodos();
+
+      expect(batches.length).toBe(2);
+      batches.forEach((b) => expect(b.commit).toHaveBeenCalledTimes(1));
+      const totalUpdateCalls = batches.reduce((sum, b) => sum + b.update.mock.calls.length, 0);
+      expect(totalUpdateCalls).toBe(TARGET_COUNT);
+    });
+
+    it("인증되지 않은 경우 에러를 던져야 한다", async () => {
+      const firebase = await import("@/shared/lib/firebase");
+      Object.defineProperty(firebase.auth, "currentUser", { value: null, configurable: true });
+
+      const { sweepOverdueRecurringTodos } = await import("../todoApi");
+      await expect(sweepOverdueRecurringTodos()).rejects.toThrow("Not authenticated");
+
+      Object.defineProperty(firebase.auth, "currentUser", {
+        value: { uid: "test-user-id" },
+        configurable: true,
+      });
+    });
+  });
+
+  // dueAt은 UTC ISO 문자열로 저장된다("로컬 날짜 추출 시 split('T')[0] 금지" 회귀 이력 —
+  // project_dueat_utc_storage 메모). "오늘 지났는가" 판정은 UTC 캘린더 날짜가 아니라
+  // 로컬(TZ) 캘린더 날짜를 기준으로 해야 한다. TZ를 명시적으로 비-UTC로 고정해 실제
+  // 로컬 자정 비교 로직이 맞는지 검증한다. (과거 CI가 UTC로 돌아 타임존 버그가 테스트를
+  // 통과한 채로 숨어있었던 이력이 있다 — feedback_timezone_test_ci_utc 메모)
+  describe("타임존 경계 (UTC 저장값 vs 로컬 자정 판정)", () => {
+    let originalTz: string | undefined;
+
+    beforeEach(() => {
+      originalTz = process.env.TZ;
+    });
+
+    afterEach(() => {
+      process.env.TZ = originalTz;
+      vi.useRealTimers();
+    });
+
+    it("Asia/Seoul(UTC+9)에서 UTC로는 '어제'지만 로컬로는 '오늘'인 dueAt은 overdue로 처리하지 않는다", async () => {
+      process.env.TZ = "Asia/Seoul";
+      vi.useFakeTimers({ toFake: ["Date"] });
+      // 로컬(Seoul) 기준 오늘 = 2026-07-10 09:00 (UTC로는 2026-07-10T00:00:00.000Z)
+      vi.setSystemTime(new Date("2026-07-10T09:00:00"));
+
+      const { getDocs, writeBatch } = await import("firebase/firestore");
+      // UTC 2026-07-09T16:00:00.000Z == Seoul 로컬 2026-07-10T01:00:00 (오늘, 아직 지나지 않음).
+      // split("T")[0]로 순진하게 날짜를 뽑으면 "2026-07-09"(어제)로 오판해 잘못 overdue 처리된다.
+      const dueToday = makeTodo({
+        id: "series-1_boundary",
+        status: "todo",
+        dueAt: "2026-07-09T16:00:00.000Z",
+        recurrenceId: "series-1",
+        recurrence: dailyRule,
+      });
+      vi.mocked(getDocs).mockResolvedValueOnce(
+        toDocSnapshot([dueToday]) as ReturnType<typeof getDocs> extends Promise<infer T>
+          ? T
+          : never,
+      );
+
+      const { sweepOverdueRecurringTodos } = await import("../todoApi");
+      await sweepOverdueRecurringTodos();
+
+      expect(writeBatch).not.toHaveBeenCalled();
+    });
+
+    it("Asia/Seoul(UTC+9)에서 로컬 기준으로도 명확히 어제인 dueAt은 overdue로 처리한다", async () => {
+      process.env.TZ = "Asia/Seoul";
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date("2026-07-10T09:00:00"));
+
+      const { getDocs, writeBatch } = await import("firebase/firestore");
+      // UTC 2026-07-08T16:00:00.000Z == Seoul 로컬 2026-07-09T01:00:00 (어제) → overdue.
+      const overdueYesterday = makeTodo({
+        id: "series-1_yesterday",
+        status: "todo",
+        dueAt: "2026-07-08T16:00:00.000Z",
+        recurrenceId: "series-1",
+        recurrence: dailyRule,
+      });
+      vi.mocked(getDocs).mockResolvedValueOnce(
+        toDocSnapshot([overdueYesterday]) as ReturnType<typeof getDocs> extends Promise<
+          infer T
+        >
+          ? T
+          : never,
+      );
+      const batch = makeBatch();
+      vi.mocked(writeBatch).mockReturnValue(batch as unknown as ReturnType<typeof writeBatch>);
+
+      const { sweepOverdueRecurringTodos } = await import("../todoApi");
+      await sweepOverdueRecurringTodos();
+
+      expect(batch.update).toHaveBeenCalledWith(
+        { id: "series-1_yesterday" },
+        expect.objectContaining({ overdueArchived: true }),
+      );
+    });
+
+    it("America/New_York(음수 오프셋)에서 UTC로는 '오늘'이지만 로컬로는 아직 '내일'이 아닌 dueAt은 overdue로 처리하지 않는다", async () => {
+      process.env.TZ = "America/New_York";
+      vi.useFakeTimers({ toFake: ["Date"] });
+      // 로컬(New_York, EDT=UTC-4) 기준 오늘 = 2026-07-10 09:00 (UTC로는 2026-07-10T13:00:00.000Z)
+      vi.setSystemTime(new Date("2026-07-10T09:00:00"));
+
+      const { getDocs, writeBatch } = await import("firebase/firestore");
+      // UTC 2026-07-11T02:00:00.000Z == New_York 로컬 2026-07-10T22:00:00 (오늘, 아직 지나지 않음).
+      const dueToday = makeTodo({
+        id: "series-1_ny-boundary",
+        status: "todo",
+        dueAt: "2026-07-11T02:00:00.000Z",
+        recurrenceId: "series-1",
+        recurrence: dailyRule,
+      });
+      vi.mocked(getDocs).mockResolvedValueOnce(
+        toDocSnapshot([dueToday]) as ReturnType<typeof getDocs> extends Promise<infer T>
+          ? T
+          : never,
+      );
+
+      const { sweepOverdueRecurringTodos } = await import("../todoApi");
+      await sweepOverdueRecurringTodos();
+
+      expect(writeBatch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/client/src/features/todo/api/todoApi.ts
+++ b/client/src/features/todo/api/todoApi.ts
@@ -345,6 +345,65 @@ export const sweepArchivedTodos = async (cutoffDays: number = 30): Promise<void>
   await commitPending();
 };
 
+/**
+ * 지난 미완료(overdue) 반복 투두 인스턴스를 archived 처리한다. status가 "todo"이고
+ * recurrenceId가 있으며 dueAt이 오늘(로컬 자정 기준) 이전인 인스턴스가 대상이다.
+ * Firestore 문서 자체는 지우지 않고 `overdueArchived: true` 플래그만 세워, 목록/칸반의
+ * 대표 노출(collapseRecurringInstances)에서만 제외한다.
+ *
+ * sweepArchivedTodos(완료 프로젝트 archived)와 별개 필드(overdueArchived)를 사용한다 —
+ * getTodos()의 Firestore 쿼리는 `archived` 필드만 걸러내므로(`where("archived", "==",
+ * false)`), 이 정책에 `archived`를 그대로 재사용하면 캘린더(이 정책 대상에서 제외되어야
+ * 함)도 getTodos() 결과에서 함께 사라진다. overdueArchived는 애플리케이션 레이어
+ * (collapseRecurringInstances)에서만 걸러지므로 캘린더 코드를 전혀 건드리지 않아도 기존
+ * 그대로 렌더링된다.
+ *
+ * editRecurringSeriesImpl의 "done/doing/overdue 인스턴스는 삭제하지 않고 그대로 보존한다"
+ * 계약은 문서 자체를 지우지 않는 것으로 이미 충족되므로(오직 플래그만 세팅), 이 스윕이
+ * 병행 실행돼도 그 계약을 깨지 않는다.
+ *
+ * overdueArchived는 Firestore 쿼리 등호 조건에 쓰지 않는다(기존 문서엔 필드가 아예 없을
+ * 수 있어 `where("overdueArchived", "==", false)`가 그 문서들을 걸러버릴 수 있음 — 별도
+ * 백필 없이도 안전하도록 userId+status만 쿼리하고 나머지는 클라이언트에서 판별한다).
+ *
+ * 반복 인스턴스는 하위 할 일을 가질 수 없다는 상호 배제 원칙(parentId는 항상 null)이라
+ * sweepArchivedTodos처럼 루트+자식을 그룹으로 묶어 청크를 나눌 필요가 없다. 다만 오래
+ * 방치된 계정은 대상 문서 수가 많을 수 있으므로 동일한 SWEEP_BATCH_SIZE 청크 분할
+ * 패턴은 그대로 적용한다.
+ */
+export const sweepOverdueRecurringTodos = async (): Promise<void> => {
+  const userId = getUserId();
+  const todayStart = new Date();
+  todayStart.setHours(0, 0, 0, 0);
+
+  const snapshot = await getDocs(
+    query(todosRef, where("userId", "==", userId), where("status", "==", "todo")),
+  );
+
+  const targets = snapshot.docs.filter((d) => {
+    const data = d.data();
+    if (!data.recurrenceId) return false;
+    if (data.overdueArchived === true) return false;
+    if (!data.dueAt) return false;
+    const due = new Date(data.dueAt as string);
+    due.setHours(0, 0, 0, 0);
+    return due.getTime() < todayStart.getTime();
+  });
+
+  if (targets.length === 0) return;
+
+  const now = new Date().toISOString();
+
+  for (let i = 0; i < targets.length; i += SWEEP_BATCH_SIZE) {
+    const chunk = targets.slice(i, i + SWEEP_BATCH_SIZE);
+    const batch = writeBatch(db);
+    chunk.forEach((d) => {
+      batch.update(d.ref, { overdueArchived: true, updatedAt: now });
+    });
+    await batch.commit();
+  }
+};
+
 export const updateTodoDueAt = async (
   id: string,
   dueAt: string | null,

--- a/client/src/features/todo/components/projectCard.tsx
+++ b/client/src/features/todo/components/projectCard.tsx
@@ -7,7 +7,7 @@ import BottomSheet from "@/shared/ui/bottomSheet/bottomSheet";
 import type { BottomSheetOption } from "@/shared/ui/bottomSheet/bottomSheet";
 import useMediaQuery from "@/shared/hooks/useMediaQuery";
 import { useTodo } from "../hooks";
-import { useToast, RecurrenceBadge } from "@/shared";
+import { useToast, RecurrenceBadge, RecurrenceMissedBadge } from "@/shared";
 import { statusColors, type Status } from "@/styles/statusColors";
 import {
   CardContainer,
@@ -46,8 +46,15 @@ const ProjectCard = ({
   onDelete,
   onAddChild,
 }: ProjectCardProps) => {
-  const { todo, childTodos, progress, subtaskInfo, overdueInfo, isExpanded } =
-    data;
+  const {
+    todo,
+    childTodos,
+    progress,
+    subtaskInfo,
+    overdueInfo,
+    recurringMissedCount,
+    isExpanded,
+  } = data;
 
   const { isOverdue, daysOver } = overdueInfo;
   const isMobile = useMediaQuery("tablet");
@@ -106,6 +113,9 @@ const ProjectCard = ({
               <CardSubtitle>{subtitleText}</CardSubtitle>
             </CardTitleGroup>
             {todo.recurrenceId != null && <RecurrenceBadge />}
+            {todo.recurrenceId != null && (
+              <RecurrenceMissedBadge count={recurringMissedCount} />
+            )}
             {isOverdue && <OverdueBadge>{daysOver}일 초과</OverdueBadge>}
           </CardLeft>
           <CardRight>

--- a/client/src/features/todo/components/todoList.tsx
+++ b/client/src/features/todo/components/todoList.tsx
@@ -6,6 +6,7 @@ import {
   getProjectProgress,
   getProjectSubtaskInfo,
   getProjectOverdue,
+  getRecurringMissedCount,
   collapseRecurringInstances,
 } from "../utils/projectUtils";
 import { useMemo, useState, useCallback } from "react";
@@ -137,6 +138,7 @@ const TodoList = ({ todos }: { todos: Todo[] }) => {
       progress: getProjectProgress(todos, rootTodo.id),
       subtaskInfo: getProjectSubtaskInfo(todos, rootTodo.id),
       overdueInfo: getProjectOverdue(todos, rootTodo),
+      recurringMissedCount: getRecurringMissedCount(todos, rootTodo),
       isExpanded: expandedProjectIds.has(rootTodo.id),
     }));
   }, [todoTree, todos, expandedProjectIds]);
@@ -229,6 +231,7 @@ const TodoList = ({ todos }: { todos: Todo[] }) => {
                   progress: getProjectProgress(todos, todo.id),
                   subtaskInfo: getProjectSubtaskInfo(todos, todo.id),
                   overdueInfo: getProjectOverdue(todos, todo),
+                  recurringMissedCount: getRecurringMissedCount(todos, todo),
                   isExpanded: expandedProjectIds.has(todo.id),
                 };
                 return (

--- a/client/src/features/todo/design/recurringTodo.spec.md
+++ b/client/src/features/todo/design/recurringTodo.spec.md
@@ -16,6 +16,7 @@
 | 자연어 입력 | 스코프 아웃 |
 | 하위 할 일 상호 배제 | 반복 ON ↔ 하위 할 일 기능 비활성 (양방향) |
 | kanban 노출 | 반복 인스턴스는 `dueAt <= 오늘`인 것만 노출, 미래는 캘린더 전용 |
+| 지난 미완료(overdue) 인스턴스 archived 처리 (2026-08-01 개정) | dueAt이 지나도록 완료되지 않은 반복 인스턴스는 하드 삭제하지 않고 archived 처리해 목록/칸반의 대표 노출에서 제외. 캘린더는 이 정책 대상에서 제외(archived 여부와 무관하게 그대로 렌더링). 4-7절 참고 |
 
 필드명(`recurrence`, `recurrenceId` 등)은 아직 미확정이므로 본 스펙은 필드 스키마를 가정하지 않고 **폼 인터랙션 / 모달 / 배지 / 캘린더 표현**에만 집중한다. 아래 의사코드의 `todo.isRecurring`, `todo.recurrenceSummary` 등은 실제 필드명이 아니라 UI 설계 편의상 사용하는 placeholder 표현이다.
 
@@ -414,6 +415,37 @@ kanban에 노출된 각 반복 인스턴스 카드
   → 기한 초과 표시(기존 $overdue 로직)와 독립적으로 동시 표시 가능
     예: 기한 초과 + 반복 인스턴스인 경우 → 빨간 좌측 보더(기존) + RecurrenceBadge(신규) 동시 노출
 ```
+
+### 4-7. 지난 미완료(overdue) 반복 인스턴스 archived 처리 (2026-08-01 개정)
+
+**배경**: 반복 투두 중 완료하지 않은 회차가 dueAt이 지나도 목록/칸반에 계속 "대표"로 노출되는 문제가 있었다(같은 recurrenceId의 인스턴스 중 dueAt이 가장 이른 것을 대표로 고르는 `collapseRecurringInstances`의 특성상, 완료하지 않고 방치하면 그 지난 회차가 영구히 대표 자리를 차지). PM 검토 결과, 하드 삭제(문서 삭제)가 아니라 **archived 처리**로 목록/칸반의 "대표 노출" 후보에서만 제외하는 정책으로 확정되었다(통계/복원 가능성 보존 목적 — Firestore 문서 자체는 절대 삭제하지 않는다).
+
+```
+반복 인스턴스 dueAt이 지남 (오늘 로컬 자정 기준) + status가 여전히 "todo"
+  ↓
+(앱 진입 시 1회, sweepOverdueRecurringTodos — 기존 sweepArchivedTodos/
+ extendIndefiniteRecurringSeries와 같은 자리, App.tsx)
+  ↓
+해당 인스턴스 문서에 overdueArchived: true 플래그 세팅 (문서 삭제 아님)
+  ↓
+collapseRecurringInstances가 이 인스턴스를 대표 후보에서 제외
+  ↓
+같은 시리즈의 다음으로 이른 인스턴스(미래 예정 건 포함)가 새 대표로 노출
+  ↓
+목록(todoList)/칸반(kanbanBoard) 양쪽 모두 새 대표만 카드로 표시
+```
+
+**적용 범위**:
+
+| 화면 | 영향 |
+|---|---|
+| 할 일 목록(`todoList.tsx`) | `collapseRecurringInstances`가 archived된 지난 회차를 제외하고 다음 대표를 노출 |
+| 칸반(`kanbanBoard.tsx`) | 동일하게 `collapseRecurringInstances`를 거치므로 자동 적용. 칸반 전용 노출 필터(`isVisibleInKanban`, dueAt <= 오늘)는 변경 없음 — 이미 지난 인스턴스는 그 필터를 통과하지만, 이후 `collapseRecurringInstances`에서 대표 후보 탈락으로 최종 제외됨 |
+| **캘린더(`dashboard`, FullCalendar)** | **이 정책 대상에서 제외.** 캘린더는 `collapseRecurringInstances`를 거치지 않고 `getTodos()` 원본을 그대로 렌더링하므로, archived 여부와 무관하게 과거/미래 인스턴스가 기존처럼 전부 표시된다 |
+
+**"done 프로젝트 archived"와의 구분**: 완료된 지 30일 지난 프로젝트를 대상으로 하는 기존 `archived` 필드(`sweepArchivedTodos`)와는 다른 필드(`overdueArchived`)를 쓴다. `archived`는 `getTodos()`의 Firestore 쿼리 단계(`where("archived", "==", false)`)에서 걸러지므로 캘린더를 포함한 모든 화면에서 사라지지만, `overdueArchived`는 쿼리 단계에서 걸러지지 않고 `collapseRecurringInstances`(애플리케이션 레이어)에서만 걸러진다 — 그래야 캘린더가 이 정책의 영향을 받지 않을 수 있다.
+
+**기존 계약과의 관계**: `editRecurringSeriesImpl`의 "done/doing/지난 미완료(overdue) 인스턴스는 삭제하지 않고 그대로 보존한다"는 계약(1-2절 확인 모달 카피 "진행 중이거나 완료된 일정, 이미 지난 미완료 일정은 그대로 유지됩니다"와 동일)은 이 정책으로 변경되지 않는다. `overdueArchived`는 표시 여부만 바꾸는 플래그이고 문서 자체는 여전히 보존되므로, 시리즈 수정 시 지난 미완료 인스턴스가 삭제되지 않는다는 기존 보장은 그대로 유지된다.
 
 ---
 

--- a/client/src/features/todo/hooks/__tests__/useTodo.test.tsx
+++ b/client/src/features/todo/hooks/__tests__/useTodo.test.tsx
@@ -29,6 +29,7 @@ vi.mock('../../api', () => ({
   deleteRecurringSeries: vi.fn(),
   extendIndefiniteRecurringSeries: vi.fn(),
   sweepArchivedTodos: vi.fn(),
+  sweepOverdueRecurringTodos: vi.fn(),
   reorderTodos: vi.fn(),
 }))
 
@@ -567,6 +568,70 @@ describe('useTodo 훅', () => {
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         expect.stringContaining('done 아카이빙 스윕 실패'),
+        error,
+      )
+
+      consoleErrorSpy.mockRestore()
+    })
+  })
+
+  describe('useSweepOverdueRecurringTodos', () => {
+    it('반복 할 일 지난 미완료 아카이빙 스윕 mutation이 정의되어 있어야 한다', () => {
+      const { result } = renderHook(() => useTodo(), {
+        wrapper: createWrapper(),
+      })
+
+      expect(result.current.useSweepOverdueRecurringTodos).toBeDefined()
+      expect(typeof result.current.useSweepOverdueRecurringTodos.mutate).toBe('function')
+    })
+
+    it('성공 시 todos 쿼리를 무효화해야 한다', async () => {
+      const { getTodos, sweepOverdueRecurringTodos } = await import('../../api')
+
+      vi.mocked(getTodos).mockResolvedValue([])
+      vi.mocked(sweepOverdueRecurringTodos).mockResolvedValueOnce(undefined)
+
+      const { result } = renderHook(() => useTodo(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.useGetTodos.isSuccess).toBe(true)
+      })
+
+      result.current.useSweepOverdueRecurringTodos.mutate()
+
+      await waitFor(() => {
+        expect(result.current.useSweepOverdueRecurringTodos.isSuccess).toBe(true)
+      })
+
+      expect(vi.mocked(sweepOverdueRecurringTodos)).toHaveBeenCalled()
+    })
+
+    it('실패 시 사용자에게는 알리지 않되 콘솔에는 에러를 남겨야 한다', async () => {
+      const { getTodos, sweepOverdueRecurringTodos } = await import('../../api')
+
+      vi.mocked(getTodos).mockResolvedValue([])
+      const error = new Error('permission-denied')
+      vi.mocked(sweepOverdueRecurringTodos).mockRejectedValueOnce(error)
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const { result } = renderHook(() => useTodo(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.useGetTodos.isSuccess).toBe(true)
+      })
+
+      result.current.useSweepOverdueRecurringTodos.mutate()
+
+      await waitFor(() => {
+        expect(result.current.useSweepOverdueRecurringTodos.isError).toBe(true)
+      })
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('반복 할 일 지난 미완료 아카이빙 스윕 실패'),
         error,
       )
 

--- a/client/src/features/todo/hooks/useTodo.ts
+++ b/client/src/features/todo/hooks/useTodo.ts
@@ -14,6 +14,7 @@ import {
   deleteRecurringSeries,
   extendIndefiniteRecurringSeries,
   sweepArchivedTodos,
+  sweepOverdueRecurringTodos,
   reorderTodos,
 } from "../api";
 
@@ -228,6 +229,19 @@ export const useTodo = () => {
     },
   });
 
+  // 앱 진입 시 1회 호출해 지난 미완료(overdue) 반복 투두 인스턴스를 archived 처리한다
+  // (App.tsx). useSweepArchivedTodos와 동일한 이유로 사용자 액션이 아닌 백그라운드
+  // 유지보수이므로 조용히 넘어가고, 실패는 콘솔에만 남긴다.
+  const useSweepOverdueRecurringTodos = useMutation({
+    mutationFn: () => sweepOverdueRecurringTodos(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["todos"] });
+    },
+    onError: (error) => {
+      console.error("반복 할 일 지난 미완료 아카이빙 스윕 실패:", error);
+    },
+  });
+
   return {
     useCreateTodo,
     useUpdateTodo,
@@ -242,6 +256,7 @@ export const useTodo = () => {
     useDeleteRecurringSeries,
     useExtendIndefiniteRecurringSeries,
     useSweepArchivedTodos,
+    useSweepOverdueRecurringTodos,
   };
 };
 

--- a/client/src/features/todo/index.ts
+++ b/client/src/features/todo/index.ts
@@ -1,6 +1,9 @@
 export { useTodo, useTodoDetail } from "./hooks";
 export type { Todo, RecurrenceRule, TodoReorderUpdate } from "./types";
-export { collapseRecurringInstances } from "./utils/projectUtils";
+export {
+  collapseRecurringInstances,
+  getRecurringMissedCount,
+} from "./utils/projectUtils";
 export { default as TodoList } from "./components/todoList";
 export { default as TodoDetail } from "./components/todoDetail/todoDetail";
 export { default as TodoForm } from "./components/todoForm/todoForm";

--- a/client/src/features/todo/types/todo.type.ts
+++ b/client/src/features/todo/types/todo.type.ts
@@ -34,6 +34,16 @@ interface Todo {
   /** 기본 조회(getTodos)에서 제외할지 여부. true면 30일 지난 완료 프로젝트(루트+자식)로 간주.
    *  기존 문서엔 필드가 없을 수 있어 optional — 없으면 archived 아닌 것으로 취급한다. */
   archived?: boolean;
+  /** 지난 미완료(overdue) 반복 투두 인스턴스가 archived 처리되었는지 여부. true면
+   *  목록/칸반의 대표 노출(collapseRecurringInstances) 후보에서 제외된다.
+   *  위 `archived`와 의도적으로 분리된 별도 필드다 — `archived`는 getTodos()의 Firestore
+   *  쿼리(`where("archived", "==", false)`) 단계에서 걸러지므로, 이 정책에 그대로 재사용하면
+   *  캘린더(이 정책 대상에서 제외되어야 함)도 getTodos() 결과에서 함께 사라져 버린다.
+   *  overdueArchived는 Firestore 쿼리에서는 걸러지지 않고 애플리케이션 레이어
+   *  (collapseRecurringInstances)에서만 걸러지므로, 캘린더는 손대지 않아도 계속 그대로
+   *  렌더링된다. 기존 문서엔 필드가 없을 수 있어 optional — 없으면 archived 아닌 것으로
+   *  취급한다. */
+  overdueArchived?: boolean;
 }
 
 /** 칸반 같은 컬럼 내 드래그 재정렬 시 bulk write할 order 변경분. */

--- a/client/src/features/todo/utils/__tests__/collapseRecurringInstances.test.ts
+++ b/client/src/features/todo/utils/__tests__/collapseRecurringInstances.test.ts
@@ -66,4 +66,74 @@ describe("collapseRecurringInstances", () => {
     const result = collapseRecurringInstances(todos);
     expect(result.map((t) => t.id)).toEqual(["other-1", "other-2", "other-3", "true-representative"]);
   });
+
+  it("overdue 인스턴스가 overdueArchived: true가 되면 대표 후보에서 제외되고, 아직 archived 안 된 미래 인스턴스가 새 대표로 뜬다", () => {
+    const todos = [
+      makeTodo({
+        id: "overdue-archived",
+        recurrenceId: "series-1",
+        dueAt: "2026-07-01T00:00:00.000Z",
+        overdueArchived: true,
+      }),
+      makeTodo({
+        id: "future-1",
+        recurrenceId: "series-1",
+        dueAt: "2026-07-20T00:00:00.000Z",
+      }),
+      makeTodo({
+        id: "future-2-nearer",
+        recurrenceId: "series-1",
+        dueAt: "2026-07-15T00:00:00.000Z",
+      }),
+    ];
+    const result = collapseRecurringInstances(todos);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("future-2-nearer");
+  });
+
+  it("시리즈 내 모든 인스턴스가 overdueArchived 상태면 해당 시리즈는 대표가 없어 결과에서 완전히 빠진다", () => {
+    const todos = [
+      makeTodo({
+        id: "other-series",
+        recurrenceId: "series-b",
+        dueAt: "2026-07-05T00:00:00.000Z",
+      }),
+      makeTodo({
+        id: "all-archived-1",
+        recurrenceId: "series-a",
+        dueAt: "2026-07-01T00:00:00.000Z",
+        overdueArchived: true,
+      }),
+      makeTodo({
+        id: "all-archived-2",
+        recurrenceId: "series-a",
+        dueAt: "2026-07-02T00:00:00.000Z",
+        overdueArchived: true,
+      }),
+    ];
+    const result = collapseRecurringInstances(todos);
+    expect(result.map((t) => t.id)).toEqual(["other-series"]);
+  });
+
+  it("done 상태 인스턴스는 overdueArchived 정책과 무관하게 기존처럼 그대로 대표 후보로 노출된다 (회귀 확인)", () => {
+    // overdueArchived는 sweepOverdueRecurringTodos가 status:"todo"인 문서만 대상으로 세팅하므로
+    // done 인스턴스에는 애초에 붙지 않지만, collapseRecurringInstances 자체가 status를 보고
+    // 분기하지 않는다는 점(overdueArchived 필드 유무만 본다)을 명시적으로 회귀 확인한다.
+    const todos = [
+      makeTodo({
+        id: "done-1",
+        status: "done",
+        recurrenceId: "series-1",
+        dueAt: "2026-07-01T00:00:00.000Z",
+      }),
+      makeTodo({
+        id: "future-1",
+        recurrenceId: "series-1",
+        dueAt: "2026-07-20T00:00:00.000Z",
+      }),
+    ];
+    const result = collapseRecurringInstances(todos);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("done-1");
+  });
 });

--- a/client/src/features/todo/utils/__tests__/projectUtils.test.ts
+++ b/client/src/features/todo/utils/__tests__/projectUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { getProjectOverdue } from '../projectUtils'
+import { getProjectOverdue, getRecurringMissedCount } from '../projectUtils'
 import type { Todo } from '../../types/todo.type'
 
 const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
@@ -132,5 +132,63 @@ describe('getProjectOverdue', () => {
     const result = getProjectOverdue([project], project)
 
     expect(result).toEqual({ isOverdue: false, daysOver: 0 })
+  })
+})
+
+describe('getRecurringMissedCount', () => {
+  it('recurrenceId가 없는(반복 아닌) 할 일이면 0을 반환해야 한다', () => {
+    const todo = makeTodo({ id: 'todo-1', recurrenceId: null })
+
+    expect(getRecurringMissedCount([todo], todo)).toBe(0)
+  })
+
+  it('같은 recurrenceId를 가진 형제 중 overdueArchived === true인 것만 센다', () => {
+    const representative = makeTodo({ id: 'rep', recurrenceId: 'series-1' })
+    const missed1 = makeTodo({
+      id: 'missed-1',
+      recurrenceId: 'series-1',
+      overdueArchived: true,
+    })
+    const missed2 = makeTodo({
+      id: 'missed-2',
+      recurrenceId: 'series-1',
+      overdueArchived: true,
+    })
+    const notArchived = makeTodo({
+      id: 'future',
+      recurrenceId: 'series-1',
+      overdueArchived: false,
+    })
+
+    const result = getRecurringMissedCount(
+      [representative, missed1, missed2, notArchived],
+      representative,
+    )
+
+    expect(result).toBe(2)
+  })
+
+  it('overdueArchived된 형제가 하나도 없으면 0을 반환해야 한다', () => {
+    const representative = makeTodo({ id: 'rep', recurrenceId: 'series-1' })
+    const future = makeTodo({
+      id: 'future',
+      recurrenceId: 'series-1',
+      overdueArchived: false,
+    })
+
+    expect(getRecurringMissedCount([representative, future], representative)).toBe(0)
+  })
+
+  it('다른 recurrenceId를 가진 형제는 세지 않는다', () => {
+    const representative = makeTodo({ id: 'rep', recurrenceId: 'series-1' })
+    const otherSeriesMissed = makeTodo({
+      id: 'other',
+      recurrenceId: 'series-2',
+      overdueArchived: true,
+    })
+
+    expect(
+      getRecurringMissedCount([representative, otherSeriesMissed], representative),
+    ).toBe(0)
   })
 })

--- a/client/src/features/todo/utils/projectUtils.ts
+++ b/client/src/features/todo/utils/projectUtils.ts
@@ -5,12 +5,20 @@ import type { Todo } from "../types";
  * 있으면 그것, 없으면 다음 예정 건) 하나만 남기고 나머지는 목록에서 숨긴다. 반복 아닌
  * 할 일(recurrenceId === null)은 그대로 통과시킨다. 다른 문서를 지우는 게 아니라 이
  * 목록에 렌더링할 대표만 고르는 순수 함수다 — 실제 삭제는 useDeleteRecurringSeries가 담당.
+ *
+ * overdueArchived: true인 인스턴스(sweepOverdueRecurringTodos가 dueAt이 지나 archived
+ * 처리한 지난 미완료 회차)는 대표 후보에서 완전히 제외한다. 그러지 않으면 방치된 overdue
+ * 인스턴스가 영구히 "대표"로 노출되는 문제(이번 정책의 발단)가 그대로 재현된다 — archived된
+ * 회차를 건너뛰면 남은 인스턴스 중 다음으로 이른 것(미래 예정 건 포함)이 자연스럽게 새
+ * 대표가 된다. 이 필드는 캘린더(dashboard)에는 영향을 주지 않는다 — 캘린더는
+ * collapseRecurringInstances를 거치지 않고 getTodos() 원본을 그대로 렌더링한다.
  */
 export function collapseRecurringInstances(todos: Todo[]): Todo[] {
   const representativeByRecurrenceId = new Map<string, Todo>();
 
   for (const todo of todos) {
     if (!todo.recurrenceId) continue;
+    if (todo.overdueArchived) continue;
 
     const existing = representativeByRecurrenceId.get(todo.recurrenceId);
     if (!existing) {
@@ -31,8 +39,14 @@ export function collapseRecurringInstances(todos: Todo[]): Todo[] {
   // 위치가 실제 order 값과 어긋나, 칸반 드래그 재정렬(useKanbanDrag)이 이 카드의
   // over.id를 실제 order(대표의 order)로 찾는데 화면상 위치는 첫 인스턴스의 order
   // 근처로 보여 사용자가 드롭한 자리와 전혀 다른 위치로 카드가 이동하는 버그가 있었다.
+  //
+  // overdueArchived된 인스턴스는 위 루프에서 대표 후보로 고려되지 않았으므로
+  // representativeByRecurrenceId에 값으로 들어있을 수 없다 — 그래서 아래 조건만으로도
+  // 자동으로 걸러지지만, 의도를 명시적으로 드러내기 위해 한 번 더 확인한다.
   return todos.filter(
-    (todo) => !todo.recurrenceId || representativeByRecurrenceId.get(todo.recurrenceId) === todo,
+    (todo) =>
+      !todo.recurrenceId ||
+      (!todo.overdueArchived && representativeByRecurrenceId.get(todo.recurrenceId) === todo),
   );
 }
 

--- a/client/src/features/todo/utils/projectUtils.ts
+++ b/client/src/features/todo/utils/projectUtils.ts
@@ -56,6 +56,7 @@ export interface ProjectCardData {
   progress: number;
   subtaskInfo: { total: number; statusText: string };
   overdueInfo: { isOverdue: boolean; daysOver: number };
+  recurringMissedCount: number;
   isExpanded: boolean;
 }
 
@@ -137,4 +138,20 @@ export function getProjectOverdue(
   );
 
   return { isOverdue: true, daysOver };
+}
+
+// 같은 recurrenceId를 가진 형제 인스턴스 중 overdueArchived === true로 조용히 대표
+// 후보에서 제외된 건수를 센다. collapseRecurringInstances가 화면에는 대표 1건만
+// 남기고 나머지는 숨기기 때문에, 사용자에게 "몇 회차가 밀렸는지" 알려줄 유일한
+// 신호가 이 카운트다 — 일반 투두의 getProjectOverdue(마감 초과 배지)와 같은 목적의
+// 반복 투두 버전. recurrenceId가 없는(반복 아닌) 할 일에는 0을 반환한다.
+export function getRecurringMissedCount(
+  allTodos: Todo[],
+  todo: Todo
+): number {
+  if (!todo.recurrenceId) return 0;
+
+  return allTodos.filter(
+    (t) => t.recurrenceId === todo.recurrenceId && t.overdueArchived === true
+  ).length;
 }

--- a/client/src/shared/ui/index.ts
+++ b/client/src/shared/ui/index.ts
@@ -12,3 +12,5 @@ export { default as BottomSheet } from "./bottomSheet/bottomSheet";
 export type { BottomSheetOption } from "./bottomSheet/bottomSheet";
 export { default as RecurrenceBadge } from "./recurrenceBadge/recurrenceBadge";
 export type { RecurrenceBadgeProps } from "./recurrenceBadge/recurrenceBadge";
+export { default as RecurrenceMissedBadge } from "./recurrenceMissedBadge/recurrenceMissedBadge";
+export type { RecurrenceMissedBadgeProps } from "./recurrenceMissedBadge/recurrenceMissedBadge";

--- a/client/src/shared/ui/recurrenceMissedBadge/recurrenceMissedBadge.styles.tsx
+++ b/client/src/shared/ui/recurrenceMissedBadge/recurrenceMissedBadge.styles.tsx
@@ -1,0 +1,19 @@
+import { styled } from "styled-components";
+import { colors } from "@/styles/colors";
+import { radius } from "@/styles/radius";
+
+// projectCard.styles.tsx의 OverdueBadge와 동일한 시각 패턴(padding/폰트/라운딩/색상)을
+// 그대로 따른다 — 둘 다 "마감이 지났다"는 동일한 톤의 경고 신호이기 때문이다
+// (recurringMissedCount.spec 근거: 최소 버전은 순수 정보 표시).
+export const Badge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px;
+  border-radius: ${radius.md};
+  background: ${colors.danger.background};
+  color: ${colors.danger.text};
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+  flex-shrink: 0;
+`;

--- a/client/src/shared/ui/recurrenceMissedBadge/recurrenceMissedBadge.tsx
+++ b/client/src/shared/ui/recurrenceMissedBadge/recurrenceMissedBadge.tsx
@@ -1,0 +1,23 @@
+import { Badge } from "./recurrenceMissedBadge.styles";
+
+interface RecurrenceMissedBadgeProps {
+  /** 같은 반복 시리즈에서 조용히 archived 처리된(overdueArchived) 지난 회차 수 */
+  count: number;
+}
+
+/**
+ * 반복 할 일의 대표 카드 옆에, 같은 시리즈에서 사용자 모르게 건너뛴(overdueArchived)
+ * 지난 회차가 몇 건인지 보여주는 배지. collapseRecurringInstances가 이 인스턴스들을
+ * 화면에서 완전히 숨기기 때문에(recurringOverdueArchiving 스펙), 일반 투두의
+ * OverdueBadge("N일 초과")와 같은 목적으로 반복 투두 쪽에 최소한의 신호를 남긴다.
+ * count가 0 이하면 아무것도 렌더링하지 않는다 — 호출부에서 조건부로 감싸지 않아도
+ * 안전하도록 컴포넌트 자체에서 가드한다.
+ */
+const RecurrenceMissedBadge = ({ count }: RecurrenceMissedBadgeProps) => {
+  if (count <= 0) return null;
+
+  return <Badge>{count}회 밀림</Badge>;
+};
+
+export default RecurrenceMissedBadge;
+export type { RecurrenceMissedBadgeProps };


### PR DESCRIPTION
## Summary
- 반복 투두 중 완료하지 않고 dueAt이 지난 인스턴스를 하드 삭제 대신 `overdueArchived` 플래그로 처리해, 목록/칸반의 "대표 노출" 로직(`collapseRecurringInstances`)에서 제외한다. 기존에는 "가장 이른 dueAt"을 무조건 대표로 선택해 지난 미완료 회차가 영구히 대표 자리를 차지하고 다음 회차가 화면에서 숨겨지는 문제가 있었다.
- 기존 done-투두용 `archived` 필드와는 별도 필드로 분리해, Firestore 쿼리 단계에서 걸러지지 않도록 했다(캘린더의 `useGetTodos`는 영향받지 않고 과거/미래 이력을 그대로 렌더링).
- `sweepOverdueRecurringTodos`로 앱 진입 시 1회성 클라이언트 사이드 스윕을 실행해 archived 플래그를 세운다.
- 대표로 승격된 카드(목록/칸반)에 "N회 밀림" 배지를 추가해, 조용히 대표가 넘어가는 것에 대한 최소한의 사용자 인지를 제공한다(기존 `OverdueBadge`와 동일한 색상 톤 재사용).
- `editRecurringSeriesImpl`의 기존 계약("지난 미완료 todo 인스턴스는 삭제하지 않는다", `recurringTodoApi.test.ts:378`)은 archived가 삭제가 아니므로 그대로 유지됨을 회귀 테스트로 확인.
- `recurringTodo.spec.md`에 정책 반영.
- 확장 버전(놓친 회차 모아보기 배너 + 완료/건너뛰기 명시적 선택 UI)은 Notion 기술부채 백로그로 별도 기록, 이번 PR 범위 아님.

## Test plan
- [x] `npm run lint` (client) — 0 errors
- [x] `npm run build` (tsc + vite build) — 통과
- [x] `npx vitest run` (client) — 37 files / 352 tests 통과 (타임존 경계 케이스: Asia/Seoul, America/New_York 포함)
- [x] 기존 회귀 테스트("지난 미완료 todo 인스턴스는 삭제하지 않는다") 통과 확인
- [x] server 테스트(pre-commit 훅) — 통과 (server/는 변경하지 않음)
- [ ] 실제 배포 환경에서 목록/칸반 화면 육안 확인 (리뷰어)

🤖 Generated with [Claude Code](https://claude.com/claude-code)