### PR TITLE
기술부채 정리: calcParentStatus 중복 제거 / ErrorBoundary 추가 / RootGate 테스트

### DIFF
--- a/client/src/features/auth/components/__tests__/rootGate.test.tsx
+++ b/client/src/features/auth/components/__tests__/rootGate.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import RootGate from '../rootGate'
+import { AuthContext } from '../../context/authContext'
+import type { User } from 'firebase/auth'
+
+vi.mock('@/shared/lib/firebase', () => ({
+  auth: {},
+  googleProvider: {},
+  db: {},
+}))
+
+vi.mock('@/features/landing/pages/landingPage', () => ({
+  default: () => <div>랜딩 페이지</div>,
+}))
+
+const mockAuthContext = (user: User | null, loading = false) => ({
+  user,
+  loading,
+  logout: vi.fn().mockResolvedValue(undefined),
+})
+
+const mockUser = {
+  uid: 'test-user-id',
+  email: 'test@example.com',
+  displayName: '테스트 사용자',
+} as User
+
+describe('RootGate 컴포넌트', () => {
+  it('로그인된 사용자는 /today로 리다이렉트되어야 한다', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <AuthContext.Provider value={mockAuthContext(mockUser)}>
+          <Routes>
+            <Route path="/" element={<RootGate />} />
+            <Route path="/today" element={<div>투데이 페이지</div>} />
+          </Routes>
+        </AuthContext.Provider>
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('투데이 페이지')).toBeInTheDocument()
+    expect(screen.queryByText('랜딩 페이지')).not.toBeInTheDocument()
+  })
+
+  it('비로그인 사용자는 랜딩 페이지를 볼 수 있어야 한다', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <AuthContext.Provider value={mockAuthContext(null)}>
+          <Routes>
+            <Route path="/" element={<RootGate />} />
+            <Route path="/today" element={<div>투데이 페이지</div>} />
+          </Routes>
+        </AuthContext.Provider>
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('랜딩 페이지')).toBeInTheDocument()
+    expect(screen.queryByText('투데이 페이지')).not.toBeInTheDocument()
+  })
+
+  it('로딩 중일 때 아무것도 렌더링하지 않아야 한다', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/']}>
+        <AuthContext.Provider value={mockAuthContext(null, true)}>
+          <Routes>
+            <Route path="/" element={<RootGate />} />
+            <Route path="/today" element={<div>투데이 페이지</div>} />
+          </Routes>
+        </AuthContext.Provider>
+      </MemoryRouter>,
+    )
+
+    expect(screen.queryByText('랜딩 페이지')).not.toBeInTheDocument()
+    expect(screen.queryByText('투데이 페이지')).not.toBeInTheDocument()
+    // 로딩 중에는 null 반환
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/client/src/features/todo/api/todoApi.ts
+++ b/client/src/features/todo/api/todoApi.ts
@@ -146,7 +146,7 @@ export const createTodo = async (todo: Todo) => {
   return { ...todo, id: docRef.id };
 };
 
-const calcParentStatus = (
+export const calcParentStatus = (
   siblings: Todo[],
 ): { status: Todo["status"]; doneAt: string | null } => {
   const now = new Date().toISOString();

--- a/client/src/features/todo/hooks/useTodo.ts
+++ b/client/src/features/todo/hooks/useTodo.ts
@@ -16,6 +16,7 @@ import {
   sweepArchivedTodos,
   sweepOverdueRecurringTodos,
   reorderTodos,
+  calcParentStatus,
 } from "../api";
 
 export const useTodo = () => {
@@ -56,23 +57,11 @@ export const useTodo = () => {
           const siblings = next.filter(
             (t) => t.parentId === updatedTodo.parentId,
           );
-          let newParentStatus: Todo["status"];
-          if (siblings.every((s) => s.status === "done")) {
-            newParentStatus = "done";
-          } else if (
-            siblings.some((s) => s.status === "doing" || s.status === "done")
-          ) {
-            newParentStatus = "doing";
-          } else {
-            newParentStatus = "todo";
-          }
+          const { status: newParentStatus, doneAt } =
+            calcParentStatus(siblings);
           next = next.map((t) =>
             t.id === updatedTodo.parentId
-              ? {
-                  ...t,
-                  status: newParentStatus,
-                  doneAt: newParentStatus === "done" ? now : null,
-                }
+              ? { ...t, status: newParentStatus, doneAt }
               : t,
           );
         }

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -5,7 +5,7 @@ import "./index.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { RouterProvider } from "react-router-dom";
-import { ToastProvider } from "@/shared";
+import { ToastProvider, ErrorBoundary } from "@/shared";
 import { AuthProvider } from "@/features/auth/context/authProvider";
 import { router } from "./router";
 const queryClient = new QueryClient({
@@ -18,13 +18,15 @@ const queryClient = new QueryClient({
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <ReactQueryDevtools initialIsOpen={false} />
-      <ToastProvider>
-        <AuthProvider>
-          <RouterProvider router={router} />
-        </AuthProvider>
-      </ToastProvider>
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <ReactQueryDevtools initialIsOpen={false} />
+        <ToastProvider>
+          <AuthProvider>
+            <RouterProvider router={router} />
+          </AuthProvider>
+        </ToastProvider>
+      </QueryClientProvider>
+    </ErrorBoundary>
   </StrictMode>,
 );

--- a/client/src/shared/ui/errorBoundary/__tests__/errorBoundary.test.tsx
+++ b/client/src/shared/ui/errorBoundary/__tests__/errorBoundary.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ErrorBoundary from '../errorBoundary'
+
+const ThrowingChild = () => {
+  throw new Error('boom')
+}
+
+describe('ErrorBoundary 컴포넌트', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+  let reloadSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    reloadSpy = vi.fn()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload: reloadSpy },
+    })
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('정상 렌더링 시 children을 그대로 보여준다', () => {
+    render(
+      <ErrorBoundary>
+        <div>정상 화면</div>
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByText('정상 화면')).toBeInTheDocument()
+  })
+
+  it('하위 컴포넌트가 렌더링 중 예외를 던지면 fallback UI를 보여준다', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByText('문제가 발생했습니다')).toBeInTheDocument()
+    expect(screen.queryByText('정상 화면')).not.toBeInTheDocument()
+  })
+
+  it('새로고침 버튼 클릭 시 페이지를 새로고침한다', async () => {
+    const user = userEvent.setup()
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>,
+    )
+
+    await user.click(screen.getByRole('button', { name: '새로고침' }))
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/client/src/shared/ui/errorBoundary/errorBoundary.styles.tsx
+++ b/client/src/shared/ui/errorBoundary/errorBoundary.styles.tsx
@@ -1,0 +1,41 @@
+import styled from "styled-components";
+import { colors } from "@/styles/colors";
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  padding: 40px 20px;
+  text-align: center;
+`;
+
+export const Title = styled.h1`
+  margin: 0 0 8px 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: ${colors.text.primary};
+`;
+
+export const Description = styled.p`
+  margin: 0 0 24px 0;
+  font-size: 14px;
+  color: ${colors.text.secondary};
+  line-height: 1.5;
+`;
+
+export const ReloadButton = styled.button`
+  padding: 12px 24px;
+  border: none;
+  border-radius: 8px;
+  background-color: ${colors.brand.secondary};
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${colors.brand.primary};
+  }
+`;

--- a/client/src/shared/ui/errorBoundary/errorBoundary.tsx
+++ b/client/src/shared/ui/errorBoundary/errorBoundary.tsx
@@ -1,0 +1,45 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Container, Title, Description, ReloadButton } from "./errorBoundary.styles";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+// getDerivedStateFromError/componentDidCatch는 훅으로 대체할 수 없어 클래스 컴포넌트로 작성한다.
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("ErrorBoundary caught an error", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Container>
+          <Title>문제가 발생했습니다</Title>
+          <Description>
+            페이지를 표시하는 중 오류가 발생했습니다.
+            <br />
+            새로고침 후 다시 시도해주세요.
+          </Description>
+          <ReloadButton onClick={() => window.location.reload()}>
+            새로고침
+          </ReloadButton>
+        </Container>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/client/src/shared/ui/index.ts
+++ b/client/src/shared/ui/index.ts
@@ -14,3 +14,4 @@ export { default as RecurrenceBadge } from "./recurrenceBadge/recurrenceBadge";
 export type { RecurrenceBadgeProps } from "./recurrenceBadge/recurrenceBadge";
 export { default as RecurrenceMissedBadge } from "./recurrenceMissedBadge/recurrenceMissedBadge";
 export type { RecurrenceMissedBadgeProps } from "./recurrenceMissedBadge/recurrenceMissedBadge";
+export { default as ErrorBoundary } from "./errorBoundary/errorBoundary";


### PR DESCRIPTION
## Summary
- `calcParentStatus`를 `todoApi.ts`에서 export해 `useTodo.ts`의 낙관적 업데이트(onMutate)가 재사용하도록 변경 — 상위 상태 계산 로직이 두 곳에 따로 있어 상태 전이 규칙 변경 시 한쪽만 고칠 위험이 있었음
- 최상위 `ErrorBoundary`를 `main.tsx`에 추가해 렌더링 예외 발생 시 흰 화면 대신 fallback UI 노출 (라우팅 전용 처리가 아니라 프로바이더 트리 전체를 포괄하는 범용 React 에러 바운더리)
- `ProtectedRoute`와 대칭 컴포넌트인 `RootGate`에 테스트가 없어 추가 (로그인/비로그인/로딩 3가지 상태 검증)

08-02 improvement-finder 재탐색에서 발견한 신규 항목 중 중간 우선순위 3건을 처리했습니다.

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `npm run lint` 통과 (기존 무관 경고 4건 외 신규 없음)
- [x] `npm run test` 전체 358개 통과
- [x] code-reviewer 서브에이전트 컨벤션/아키텍처 리뷰 완료 — 필수 수정 0건, 권장 2건(향후 개선 여지로 기록)

🤖 Generated with [Claude Code](https://claude.com/claude-code)