### PR TITLE
refactor: overdue 판정 로직을 shared/utils/due.ts로 통합

### DIFF
--- a/client/src/features/dashboard/utils/calendarUtils.ts
+++ b/client/src/features/dashboard/utils/calendarUtils.ts
@@ -1,14 +1,13 @@
-import { getDaysLeft } from "@/shared/utils/due";
+import { isTodoOverdue } from "@/shared/utils/due";
 import type { Todo } from "@/features/todo/types/todo.type";
 
 /**
  * todo가 기한 초과인지 판단합니다.
  * dueAt이 오늘 이전이고 status가 'done'이 아닌 경우 true를 반환합니다.
+ * 실제 판정 로직은 shared/utils/due.ts의 isTodoOverdue(공용 최소 단위 판정)에 위임한다.
  */
 export function isOverdue(todo: Todo): boolean {
-  if (!todo.dueAt) return false;
-  if (todo.status === "done") return false;
-  return getDaysLeft(todo.dueAt) < 0;
+  return isTodoOverdue(todo);
 }
 
 /**

--- a/client/src/features/todo/utils/projectUtils.ts
+++ b/client/src/features/todo/utils/projectUtils.ts
@@ -1,4 +1,5 @@
 import type { Todo } from "../types";
+import { isTodoOverdue } from "@/shared/utils/due";
 
 /**
  * 같은 recurrenceId를 가진 반복 인스턴스 중 dueAt이 가장 이른 것(지난 미완료(overdue)가
@@ -109,12 +110,7 @@ export function getProjectOverdue(
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
-  const isOverdueCandidate = (t: Todo) => {
-    if (!t.dueAt || t.status === "done") return false;
-    const dueDate = new Date(t.dueAt);
-    dueDate.setHours(0, 0, 0, 0);
-    return dueDate < today;
-  };
+  const isOverdueCandidate = (t: Todo) => isTodoOverdue(t);
 
   // 루트 투두 자신도 후보에 포함시켜, 하위 투두가 없거나 아직 지나지 않았더라도
   // 루트 자신의 dueAt이 지났으면 초과로 판정되도록 한다.

--- a/client/src/shared/utils/__tests__/due.test.ts
+++ b/client/src/shared/utils/__tests__/due.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
-import { getDaysLeft, getDueBadgeLabel, getUrgency, DUE_SOON_DAYS } from '../due'
+import { getDaysLeft, getDueBadgeLabel, getUrgency, DUE_SOON_DAYS, isTodoOverdue } from '../due'
 
 describe('due 유틸 함수', () => {
   beforeEach(() => {
@@ -88,6 +88,32 @@ describe('due 유틸 함수', () => {
     it('daysLeft가 DUE_SOON_DAYS(3)보다 크면 "normal"을 반환해야 한다', () => {
       expect(getUrgency(DUE_SOON_DAYS + 1)).toBe('normal')
       expect(getUrgency(10)).toBe('normal')
+    })
+  })
+
+  describe('isTodoOverdue', () => {
+    it('dueAt이 null이면 false를 반환해야 한다', () => {
+      expect(isTodoOverdue({ dueAt: null, status: 'todo' })).toBe(false)
+    })
+
+    it('status가 done이면 dueAt이 과거여도 false를 반환해야 한다', () => {
+      expect(isTodoOverdue({ dueAt: '2026-06-01', status: 'done' })).toBe(false)
+    })
+
+    it('마감일이 오늘이면 false를 반환해야 한다', () => {
+      expect(isTodoOverdue({ dueAt: '2026-06-14', status: 'todo' })).toBe(false)
+    })
+
+    it('마감일이 어제면 true를 반환해야 한다', () => {
+      expect(isTodoOverdue({ dueAt: '2026-06-13', status: 'todo' })).toBe(true)
+    })
+
+    it('마감일이 내일이면 false를 반환해야 한다', () => {
+      expect(isTodoOverdue({ dueAt: '2026-06-15', status: 'todo' })).toBe(false)
+    })
+
+    it('status가 doing이고 마감일이 과거면 true를 반환해야 한다', () => {
+      expect(isTodoOverdue({ dueAt: '2026-06-01', status: 'doing' })).toBe(true)
     })
   })
 })

--- a/client/src/shared/utils/due.ts
+++ b/client/src/shared/utils/due.ts
@@ -1,5 +1,23 @@
 export const DUE_SOON_DAYS = 3;
 
+/** overdue 판정에 필요한 최소 필드만 요구한다(Todo 전체에 의존하지 않음). */
+export interface TodoOverdueLike {
+  dueAt: string | null;
+  status: string;
+}
+
+/**
+ * todo 하나가 기한 초과(overdue)인지 판정하는 최소 단위 로직.
+ * dueAt이 없거나 status가 "done"이면 false, 그 외에는 getDaysLeft(로컬 자정 기준)가
+ * 음수인지로 판단한다. 프로젝트(루트+서브태스크) 롤업이나 캘린더 표시 등 이 판정을
+ * 소비하는 로직은 각 호출부(projectUtils.getProjectOverdue, calendarUtils.isOverdue)에
+ * 그대로 남기고, 여기서는 오직 "이 한 건이 초과냐 아니냐"만 책임진다.
+ */
+export function isTodoOverdue(todo: TodoOverdueLike): boolean {
+  if (!todo.dueAt || todo.status === "done") return false;
+  return getDaysLeft(todo.dueAt) < 0;
+}
+
 export function getDaysLeft(dueAt: string): number {
   const now = new Date();
   now.setHours(0, 0, 0, 0);

--- a/client/src/shared/utils/index.ts
+++ b/client/src/shared/utils/index.ts
@@ -1,5 +1,5 @@
-export { DUE_SOON_DAYS, getDaysLeft, getDueBadgeLabel, getUrgency } from "./due";
-export type { Urgency } from "./due";
+export { DUE_SOON_DAYS, getDaysLeft, getDueBadgeLabel, getUrgency, isTodoOverdue } from "./due";
+export type { Urgency, TodoOverdueLike } from "./due";
 export { formatTodayLabel, formatDueTime } from "./formatToday";
 export {
   parseLocalDateOnly,


### PR DESCRIPTION
## Summary
- 캘린더(`calendarUtils.isOverdue`)와 프로젝트 카드(`projectUtils.getProjectOverdue`)에 각자 구현돼 있던 "todo 하나가 마감 초과인지" 판정 로직을 `shared/utils/due.ts`의 `isTodoOverdue()`로 통합
- 프로젝트 롤업(루트+서브태스크 중 가장 오래된 초과 건 탐색, daysOver 계산) 로직은 그대로 유지
- `shared`가 `features`를 참조하지 않도록 `TodoOverdueLike`(`{ dueAt, status }`만 요구하는 구조적 타입) 사용

## Test plan
- [x] `npm run test` — 40 files / 369 tests 전부 통과 (`isTodoOverdue` 신규 케이스 6개 포함)
- [x] `npm run build` — 타입체크 + 빌드 성공
- [x] `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)