### PR TITLE
feat: Sentry 에러 모니터링 도입

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,17 @@ jobs:
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
           VITE_FIREBASE_MEASUREMENT_ID: ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }}
+          # VITE_ 접두사가 붙어 클라이언트 번들(import.meta.env)에 포함된다. Vite는
+          # VITE_* 변수를 빌드 타임에 정적으로 인라인하므로, 이 스텝에서 주입되지
+          # 않으면 배포된 번들에는 dsn이 빈 값으로 굳어져 Sentry가 초기화되지 않는다.
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          # Sentry 소스맵 업로드 전용 시크릿. VITE_ 접두사가 아니므로 클라이언트
+          # 번들(import.meta.env)에는 노출되지 않고, vite.config.ts의 Node 빌드
+          # 프로세스(@sentry/vite-plugin)에서만 읽힌다. client job(테스트 빌드)에는
+          # 의도적으로 주입하지 않는다 — 실제 배포 빌드에서만 업로드가 필요하다.
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         run: npm run build
 
       - name: Deploy to Firebase Hosting & Firestore Rules/Indexes

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,17 @@
+# 이 파일을 복사해 .env로 저장한 뒤 실제 값을 채워 넣으세요.
+# cp .env.example .env
+
+VITE_API_URI=http://localhost:3000
+
+# Firebase 프로젝트 설정 (Firebase 콘솔 > 프로젝트 설정 > 일반 > 내 앱에서 확인)
+VITE_FIREBASE_API_KEY=
+VITE_FIREBASE_AUTH_DOMAIN=
+VITE_FIREBASE_PROJECT_ID=
+VITE_FIREBASE_STORAGE_BUCKET=
+VITE_FIREBASE_MESSAGING_SENDER_ID=
+VITE_FIREBASE_APP_ID=
+VITE_FIREBASE_MEASUREMENT_ID=
+
+# Sentry 에러 모니터링. 비워두면(로컬 개발 등) Sentry가 비활성화된다.
+# 형식: https://<key>@o<org>.ingest.sentry.io/<project-id>
+VITE_SENTRY_DSN=

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16,6 +16,7 @@
         "@fullcalendar/interaction": "^6.1.19",
         "@fullcalendar/react": "^6.1.19",
         "@fullcalendar/timegrid": "^6.1.19",
+        "@sentry/react": "^10.69.0",
         "@tanstack/react-query": "^5.90.5",
         "@tanstack/react-query-devtools": "^5.90.2",
         "firebase": "^12.10.0",
@@ -31,6 +32,7 @@
       "devDependencies": {
         "@eslint/js": "^9.33.0",
         "@playwright/test": "^1.57.0",
+        "@sentry/vite-plugin": "^5.4.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -122,13 +124,13 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -136,10 +138,164 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -147,23 +303,47 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -182,15 +362,49 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2549,6 +2763,28 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -3499,6 +3735,431 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.69.0.tgz",
+      "integrity": "sha512-8391tnm96YbR7b8SYfEA/NEIZuyb2r3SZrtAT0bhZtjlujcYWjo7gugQvk8sWLU9cAa/euD00eJoIoJvNfpd7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.69.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.69.0",
+        "@sentry/feedback": "10.69.0",
+        "@sentry/replay": "10.69.0",
+        "@sentry/replay-canvas": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.69.0.tgz",
+      "integrity": "sha512-e/u1Abj0zRPwR/deGZAP3GOULrsx67/XXnM5Skniqs4uxTsdNtPek1Nef0tpxwaQJYxwh6pWdhswLPPbbPOgBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/bundler-plugins": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugins/-/bundler-plugins-10.69.0.tgz",
+      "integrity": "sha512-I1otnSJIH4IOugLp+kcBbT0Kcex+J8xnHuUyzMAwCYSpZ0FMVvA723uNmkMdW0PxRRw0oEhe0qDB+t+ZjHxUiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.18.5",
+        "@sentry/cli": "^2.58.6",
+        "@sentry/core": "10.69.0",
+        "dotenv": "^17.4.2",
+        "find-up": "^5.0.0",
+        "glob": "^13.0.6",
+        "magic-string": "~0.30.8"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "rollup": ">=3.2.0",
+        "webpack": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/bundler-plugins/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@sentry/bundler-plugins/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@sentry/bundler-plugins/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/bundler-plugins/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/bundler-plugins/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.6.tgz",
+      "integrity": "sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "FSL-1.1-MIT",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.58.6",
+        "@sentry/cli-linux-arm": "2.58.6",
+        "@sentry/cli-linux-arm64": "2.58.6",
+        "@sentry/cli-linux-i686": "2.58.6",
+        "@sentry/cli-linux-x64": "2.58.6",
+        "@sentry/cli-win32-arm64": "2.58.6",
+        "@sentry/cli-win32-i686": "2.58.6",
+        "@sentry/cli-win32-x64": "2.58.6"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.6.tgz",
+      "integrity": "sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==",
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.6.tgz",
+      "integrity": "sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.6.tgz",
+      "integrity": "sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.6.tgz",
+      "integrity": "sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.6.tgz",
+      "integrity": "sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.6.tgz",
+      "integrity": "sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.6.tgz",
+      "integrity": "sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.6.tgz",
+      "integrity": "sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.69.0.tgz",
+      "integrity": "sha512-+uuqVEeiDzYuAKjZLqsROKXvRTbl/QeH0gfGRtpYib1cud4rAFWRIkFmcR7Jb7JGFYwmReyQotiTj/hcDszTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/feedback": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.69.0.tgz",
+      "integrity": "sha512-qrGz5Qaw93/IhMjlFN6uIaXeHwgHDaKGa6FkTAP6PonpkvSbGGqan6xfsENxzj9HUVoli1lZ6tMRDnt2qtSPhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.69.0.tgz",
+      "integrity": "sha512-f0Il/JMteHjdWPNZQB3rtp1Pcj2Leb3p0KSZuv3rh0EUril9CbWtQVy5zJhoAppi+MWWmgRWa+6BpHbQf+ABQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.69.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.69.0.tgz",
+      "integrity": "sha512-uRhmNhtFGPOlM0iniVmWKAX3KVXI0le41yYK/iKdPjinT9jA3ZrmykO/Fv1v/KI5znOtwa9D6eHRnDTTMRxFrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.69.0",
+        "@sentry/core": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.69.0.tgz",
+      "integrity": "sha512-VF6nXvSninHcc7dC1Zme0RjkC7VgRMCixs6jKaQX5zTNeqTW3dZGSefSOVv+ZteRi3hJvVORq985VjUC9Z/0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.69.0",
+        "@sentry/replay": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/vite-plugin": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-5.4.0.tgz",
+      "integrity": "sha512-fFJgCxs5hDyAm9BbZJ+LbA+LK2tjX5OoD0v0ARU4StR6KQmGUduoPs69yJ9AfqZ0om3Rlp5JDliiwFcNkasORA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/bundler-plugins": "^10.64.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -4945,6 +5606,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -5161,6 +5835,41 @@
         "node": ">=8"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -5281,6 +5990,27 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "6.2.1",
@@ -5919,6 +6649,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -6397,6 +7134,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -6463,6 +7213,13 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.402",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.402.tgz",
+      "integrity": "sha512-/oOpMaPT6Yg+6/1XQhyIPlzgj7Ye9zf+nNM2Uh6OcE2G2oNptWazFa+qB2Pdqqbsc9KnIDzgAntoYN0dbwOXwA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -7115,6 +7872,7 @@
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -7744,6 +8502,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -9045,6 +9813,19 @@
         }
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-bigint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
@@ -9097,6 +9878,19 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/jsonfile": {
       "version": "6.2.1",
@@ -10005,6 +10799,16 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.52",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.52.tgz",
+      "integrity": "sha512-MRlTqhAfoMx/4mhEbPo3Hi02g9LJZaJkka69V6h67Cb1gjrAG0jsTE4CZX1eptNx+VCAwJmfpnDIF4P0Nh1A7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/nopt": {
@@ -12831,6 +13635,37 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/update-notifier-cjs": {
       "version": "5.1.7",
       "resolved": "https://registry.npmjs.org/update-notifier-cjs/-/update-notifier-cjs-5.1.7.tgz",
@@ -13553,7 +14388,6 @@
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/client/package.json
+++ b/client/package.json
@@ -23,6 +23,7 @@
     "@fullcalendar/interaction": "^6.1.19",
     "@fullcalendar/react": "^6.1.19",
     "@fullcalendar/timegrid": "^6.1.19",
+    "@sentry/react": "^10.69.0",
     "@tanstack/react-query": "^5.90.5",
     "@tanstack/react-query-devtools": "^5.90.2",
     "firebase": "^12.10.0",
@@ -41,6 +42,7 @@
   "devDependencies": {
     "@eslint/js": "^9.33.0",
     "@playwright/test": "^1.57.0",
+    "@sentry/vite-plugin": "^5.4.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/client/src/features/auth/context/__tests__/authProvider.test.tsx
+++ b/client/src/features/auth/context/__tests__/authProvider.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import type { User } from 'firebase/auth'
+import * as Sentry from '@sentry/react'
+import { AuthProvider } from '../authProvider'
+import { useAuth } from '../useAuth'
+
+let authStateCallback: ((user: User | null) => void) | null = null
+
+vi.mock('@/shared/lib/firebase', () => ({
+  auth: {},
+  googleProvider: {},
+  db: {},
+}))
+
+vi.mock('firebase/auth', () => ({
+  onAuthStateChanged: vi.fn((_auth, callback) => {
+    authStateCallback = callback
+    return vi.fn()
+  }),
+  signOut: vi.fn(),
+}))
+
+vi.mock('@sentry/react', () => ({
+  setUser: vi.fn(),
+}))
+
+const mockUser = {
+  uid: 'test-user-id',
+  email: 'user@example.com',
+  displayName: '테스트 사용자',
+} as User
+
+const Consumer = () => {
+  const { user, loading } = useAuth()
+  if (loading) return <div>로딩 중</div>
+  return <div>{user ? `로그인: ${user.uid}` : '비로그인'}</div>
+}
+
+describe('AuthProvider', () => {
+  beforeEach(() => {
+    authStateCallback = null
+    vi.mocked(Sentry.setUser).mockClear()
+  })
+
+  it('로그인 상태가 되면 Sentry.setUser에 uid만 전달하고 email은 전달하지 않는다', async () => {
+    render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>,
+    )
+
+    act(() => {
+      authStateCallback?.(mockUser)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('로그인: test-user-id')).toBeInTheDocument()
+    })
+
+    expect(Sentry.setUser).toHaveBeenCalledWith({ id: 'test-user-id' })
+    const calledArg = vi.mocked(Sentry.setUser).mock.calls[0][0]
+    expect(calledArg).not.toHaveProperty('email')
+  })
+
+  it('로그아웃 상태가 되면 Sentry.setUser에 null을 전달해 사용자 태그를 지운다', async () => {
+    render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>,
+    )
+
+    act(() => {
+      authStateCallback?.(null)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('비로그인')).toBeInTheDocument()
+    })
+
+    expect(Sentry.setUser).toHaveBeenCalledWith(null)
+  })
+})

--- a/client/src/features/auth/context/authProvider.tsx
+++ b/client/src/features/auth/context/authProvider.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, type ReactNode } from "react";
 import type { User } from "firebase/auth";
 import { onAuthStateChanged, signOut } from "firebase/auth";
+import * as Sentry from "@sentry/react";
 import { auth } from "@/shared/lib/firebase";
 import { AuthContext } from "@/features/auth/context/authContext";
 
@@ -14,6 +15,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       clearTimeout(timeout);
       setUser(user);
       setLoading(false);
+      // uid만 태깅한다. email 등은 절대 넘기지 않는다(beforeSend에서도 걸러지지만 여기서도 이중 방어).
+      Sentry.setUser(user ? { id: user.uid } : null);
     });
     return () => {
       clearTimeout(timeout);

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -7,7 +7,13 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { RouterProvider } from "react-router-dom";
 import { ToastProvider, ErrorBoundary } from "@/shared";
 import { AuthProvider } from "@/features/auth/context/authProvider";
+import { initSentry } from "@/shared/lib/sentry";
 import { router } from "./router";
+
+// 다른 모든 초기화(Firebase, React Query 등)보다 먼저 호출해야
+// 이후 렌더링/네트워크 단계에서 발생하는 에러도 빠짐없이 캡처할 수 있다.
+initSentry();
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {

--- a/client/src/shared/lib/__tests__/sentry.test.ts
+++ b/client/src/shared/lib/__tests__/sentry.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest'
+import type { ErrorEvent as SentryErrorEvent } from '@sentry/react'
+import { scrubEvent } from '../sentry'
+
+describe('scrubEvent', () => {
+  it('extra에 담긴 title/description 등 사용자 입력 텍스트를 결과 이벤트에서 완전히 제거한다', () => {
+    const event = {
+      type: undefined,
+      message: 'TypeError: something failed',
+      extra: {
+        title: '민감한 할 일 제목',
+        description: '민감한 상세 설명',
+      },
+    } as unknown as SentryErrorEvent
+
+    const result = scrubEvent(event)
+
+    expect(result.extra).toBeUndefined()
+    expect(JSON.stringify(result)).not.toContain('민감한')
+  })
+
+  it('contexts에 담긴 커스텀 컨텍스트(todo 등)의 title/description을 결과 이벤트에서 완전히 제거한다', () => {
+    const event = {
+      type: undefined,
+      contexts: {
+        browser: { name: 'Chrome' },
+        os: { name: 'macOS' },
+        todo: {
+          title: '민감한 할 일 제목',
+          description: '민감한 상세 설명',
+        },
+      },
+    } as unknown as SentryErrorEvent
+
+    const result = scrubEvent(event)
+
+    expect(result.contexts).toEqual({
+      browser: { name: 'Chrome' },
+      os: { name: 'macOS' },
+      react: undefined,
+    })
+    expect(JSON.stringify(result)).not.toContain('민감한')
+  })
+
+  it('user.email이 담긴 이벤트에서 email은 사라지고 id만 남는다', () => {
+    const event = {
+      type: undefined,
+      user: { id: 'uid-123', email: 'user@example.com', username: 'user123' },
+    } as unknown as SentryErrorEvent
+
+    const result = scrubEvent(event)
+
+    expect(result.user).toEqual({ id: 'uid-123' })
+    expect(JSON.stringify(result)).not.toContain('user@example.com')
+    expect(JSON.stringify(result)).not.toContain('user123')
+  })
+
+  it('user 필드가 없으면 결과에도 user 필드가 없다', () => {
+    const event = { type: undefined } as unknown as SentryErrorEvent
+
+    const result = scrubEvent(event)
+
+    expect(result.user).toBeUndefined()
+  })
+
+  it('request.url에서 쿼리스트링을 제거한다', () => {
+    const event = {
+      type: undefined,
+      request: {
+        url: 'https://tododo.app/todos?search=민감검색어&foo=bar',
+      },
+    } as unknown as SentryErrorEvent
+
+    const result = scrubEvent(event)
+
+    expect(result.request?.url).toBe('https://tododo.app/todos')
+    expect(result.request?.url).not.toContain('search')
+    expect(JSON.stringify(result)).not.toContain('민감검색어')
+  })
+
+  it('request.data 등 쿼리스트링 제거 대상이 아닌 request 필드는 결과에 남기지 않는다', () => {
+    const event = {
+      type: undefined,
+      request: {
+        url: 'https://tododo.app/todos',
+        data: { title: '민감한 폼 입력값' },
+      },
+    } as unknown as SentryErrorEvent
+
+    const result = scrubEvent(event)
+
+    expect(result.request).toEqual({ url: 'https://tododo.app/todos' })
+    expect(JSON.stringify(result)).not.toContain('민감한 폼 입력값')
+  })
+
+  it('사용자 입력과 무관한 breadcrumb 카테고리(navigation)는 통과시킨다', () => {
+    const event = {
+      type: undefined,
+      breadcrumbs: [
+        {
+          type: 'navigation',
+          category: 'navigation',
+          level: 'info',
+          timestamp: 1234,
+          data: { from: '/today', to: '/kanban' },
+        },
+      ],
+    } as unknown as SentryErrorEvent
+
+    const result = scrubEvent(event)
+
+    expect(result.breadcrumbs).toHaveLength(1)
+    expect(result.breadcrumbs?.[0]).toEqual({
+      type: 'navigation',
+      category: 'navigation',
+      level: 'info',
+      timestamp: 1234,
+      data: { from: '/today', to: '/kanban' },
+    })
+  })
+
+  it('사용자 입력이 섞일 수 있는 breadcrumb 카테고리(ui.input)는 걸러낸다', () => {
+    const event = {
+      type: undefined,
+      breadcrumbs: [
+        {
+          type: 'default',
+          category: 'ui.input',
+          level: 'info',
+          timestamp: 1234,
+          message: '민감한 입력값',
+        },
+        {
+          type: 'default',
+          category: 'ui.click',
+          level: 'info',
+          timestamp: 1235,
+        },
+        {
+          type: 'default',
+          category: 'console',
+          level: 'log',
+          timestamp: 1236,
+          message: '민감한 콘솔 로그',
+        },
+      ],
+    } as unknown as SentryErrorEvent
+
+    const result = scrubEvent(event)
+
+    expect(result.breadcrumbs).toHaveLength(0)
+  })
+
+  it('navigation과 ui.input이 섞여 있으면 navigation만 남기고 ui.input은 제거한다', () => {
+    const event = {
+      type: undefined,
+      breadcrumbs: [
+        { type: 'navigation', category: 'navigation', timestamp: 1 },
+        {
+          type: 'default',
+          category: 'ui.input',
+          timestamp: 2,
+          message: '민감한 입력값',
+        },
+      ],
+    } as unknown as SentryErrorEvent
+
+    const result = scrubEvent(event)
+
+    expect(result.breadcrumbs).toHaveLength(1)
+    expect(result.breadcrumbs?.[0].category).toBe('navigation')
+  })
+
+  it('breadcrumb.message는 허용된 카테고리(navigation)여도 항상 제거한다', () => {
+    const event = {
+      type: undefined,
+      breadcrumbs: [
+        {
+          type: 'navigation',
+          category: 'navigation',
+          timestamp: 1,
+          message: '혹시 모를 사용자 입력',
+        },
+      ],
+    } as unknown as SentryErrorEvent
+
+    const result = scrubEvent(event)
+
+    expect(result.breadcrumbs?.[0].message).toBeUndefined()
+  })
+
+  it('exception, message 등 에러 진단에 필요한 필드는 그대로 유지한다', () => {
+    const event = {
+      type: undefined,
+      message: 'TypeError: cannot read property of undefined',
+      exception: {
+        values: [{ type: 'TypeError', value: 'cannot read property of undefined' }],
+      },
+      level: 'error',
+      environment: 'production',
+    } as unknown as SentryErrorEvent
+
+    const result = scrubEvent(event)
+
+    expect(result.message).toBe('TypeError: cannot read property of undefined')
+    expect(result.exception).toEqual(event.exception)
+    expect(result.level).toBe('error')
+    expect(result.environment).toBe('production')
+  })
+})

--- a/client/src/shared/lib/sentry.ts
+++ b/client/src/shared/lib/sentry.ts
@@ -1,0 +1,126 @@
+import * as Sentry from "@sentry/react";
+import type { Breadcrumb, ErrorEvent as SentryErrorEvent } from "@sentry/react";
+
+// 기계적으로 생성되는(=사용자가 직접 입력한 텍스트가 들어가지 않는) breadcrumb 카테고리만 허용한다.
+// "console"(console.log 인자), "ui.click"/"ui.input"/"dom"(클릭·입력 이벤트, input value 포함 가능)은
+// title/description 등 사용자 입력이 섞여 들어올 수 있어 통째로 제외한다.
+const ALLOWED_BREADCRUMB_CATEGORIES = new Set(["navigation", "fetch", "xhr"]);
+
+// breadcrumb.data 중에서도 URL/HTTP 메서드/상태코드 등 구조화된 값만 통과시킨다.
+// (fetch/xhr breadcrumb의 request body 등은 애초에 Sentry가 기본적으로 담지 않지만, 방어적으로 명시한다.)
+const ALLOWED_BREADCRUMB_DATA_KEYS = new Set([
+  "url",
+  "method",
+  "status_code",
+  "from",
+  "to",
+  "request_body_size",
+  "response_body_size",
+]);
+
+// URL 문자열에서 쿼리스트링을 제거한다. 현재 라우트 쿼리 파라미터에 민감정보가 없는 것을 확인했지만,
+// 이후 실수로 쿼리에 토큰/이메일 등이 추가되어도 기본적으로 잘려나가도록 보수적으로 제거한다.
+const stripQueryString = (url: string): string => url.split("?")[0];
+
+const scrubBreadcrumbData = (
+  data: Breadcrumb["data"],
+): Breadcrumb["data"] | undefined => {
+  if (!data) return undefined;
+
+  const result: Record<string, unknown> = {};
+  for (const key of ALLOWED_BREADCRUMB_DATA_KEYS) {
+    const value = data[key];
+    if (value === undefined) continue;
+    result[key] = typeof value === "string" ? stripQueryString(value) : value;
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+};
+
+const scrubBreadcrumb = (crumb: Breadcrumb): Breadcrumb => ({
+  type: crumb.type,
+  category: crumb.category,
+  level: crumb.level,
+  timestamp: crumb.timestamp,
+  data: scrubBreadcrumbData(crumb.data),
+  // message는 의도적으로 제외한다. console breadcrumb 등에서 사용자가 입력한 title/description
+  // 문자열이 그대로 로그로 찍혀 message에 담기는 경우를 배제할 수 없기 때문이다.
+});
+
+/**
+ * Sentry로 전송되는 이벤트를 allowlist 방식으로 재구성한다.
+ *
+ * denylist("이 필드는 빼자")가 아니라 allowlist("이 필드만 보내자")를 쓰는 이유:
+ * Sentry SDK가 버전업되며 이벤트에 새 필드가 추가되거나, 앞으로 코드에서 실수로
+ * extra/contexts에 Todo 객체(title, description 포함)를 통째로 넘기는 실수를 해도
+ * 여기서 명시적으로 허용하지 않은 필드는 기본적으로 전송 자체가 차단된다.
+ *
+ * 허용 필드:
+ * - message, exception(에러 메시지/스택트레이스): 코드 위치 파악에 필요한 정보이며 사용자 입력이 아니다.
+ * - request.url(쿼리스트링 제거): 어떤 페이지에서 에러가 났는지 파악하기 위함.
+ * - contexts.browser / contexts.os: Sentry가 기본 수집하는 환경 정보, PII 아님.
+ * - contexts.react(componentStack): React가 만들어내는 컴포넌트 트리 문자열로, 사용자 입력 아님.
+ * - tags: 문자열/숫자/불리언 원시값만 존재하므로 통째로 허용(문자열 자유 입력 필드가 아님).
+ * - user.id: Firebase Auth uid만 허용.
+ *
+ * 차단 필드(명시적으로 옮겨 담지 않아 자동 제거됨):
+ * - request.data: 폼 입력값이 그대로 담길 수 있다.
+ * - extra, contexts의 그 외 커스텀 컨텍스트: Todo의 title/description 등이 실수로 담길 위험이 가장 큰 지점.
+ * - user.email, user.username: uid 이외의 PII.
+ * - breadcrumbs의 "console"/"ui.click"/"ui.input"/"dom" 카테고리: 사용자 입력 텍스트가 섞일 수 있다.
+ */
+export const scrubEvent = (event: SentryErrorEvent): SentryErrorEvent => {
+  const scrubbed: SentryErrorEvent = {
+    type: event.type,
+    event_id: event.event_id,
+    timestamp: event.timestamp,
+    platform: event.platform,
+    level: event.level,
+    environment: event.environment,
+    release: event.release,
+    message: event.message,
+    exception: event.exception,
+    fingerprint: event.fingerprint,
+    tags: event.tags,
+    sdk: event.sdk,
+  };
+
+  if (event.contexts) {
+    scrubbed.contexts = {
+      browser: event.contexts.browser,
+      os: event.contexts.os,
+      react: event.contexts.react,
+    };
+  }
+
+  if (event.request?.url) {
+    scrubbed.request = { url: stripQueryString(event.request.url) };
+  }
+
+  if (event.user?.id !== undefined) {
+    scrubbed.user = { id: event.user.id };
+  }
+
+  if (event.breadcrumbs) {
+    scrubbed.breadcrumbs = event.breadcrumbs
+      .filter((crumb) => ALLOWED_BREADCRUMB_CATEGORIES.has(crumb.category ?? ""))
+      .map(scrubBreadcrumb);
+  }
+
+  return scrubbed;
+};
+
+// main.tsx 최상단(다른 모든 초기화보다 먼저)에서 호출한다.
+export const initSentry = () => {
+  const dsn = import.meta.env.VITE_SENTRY_DSN;
+
+  // DSN이 없는 환경(로컬 개발 등)에서는 init 자체를 생략해 조용히 비활성화한다.
+  if (!dsn) return;
+
+  Sentry.init({
+    dsn,
+    environment: import.meta.env.MODE,
+    // dsn을 로컬에 설정해두더라도 실제로는 프로덕션 빌드에서만 전송되도록 이중으로 방어한다.
+    enabled: import.meta.env.PROD,
+    beforeSend: (event) => scrubEvent(event),
+  });
+};

--- a/client/src/shared/ui/errorBoundary/__tests__/errorBoundary.test.tsx
+++ b/client/src/shared/ui/errorBoundary/__tests__/errorBoundary.test.tsx
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import * as Sentry from '@sentry/react'
 import ErrorBoundary from '../errorBoundary'
+
+vi.mock('@sentry/react', () => ({
+  captureException: vi.fn(),
+}))
 
 const ThrowingChild = () => {
   throw new Error('boom')
@@ -18,6 +23,7 @@ describe('ErrorBoundary 컴포넌트', () => {
       configurable: true,
       value: { ...window.location, reload: reloadSpy },
     })
+    vi.mocked(Sentry.captureException).mockClear()
   })
 
   afterEach(() => {
@@ -56,5 +62,42 @@ describe('ErrorBoundary 컴포넌트', () => {
     await user.click(screen.getByRole('button', { name: '새로고침' }))
 
     expect(reloadSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('하위 컴포넌트가 예외를 던지면 Sentry.captureException을 호출한다', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>,
+    )
+
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1)
+  })
+
+  it('Sentry.captureException 호출 시 에러 객체와 componentStack을 담은 react 컨텍스트를 함께 전달한다', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>,
+    )
+
+    const [error, context] = vi.mocked(Sentry.captureException).mock.calls[0]
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toBe('boom')
+    expect(context).toEqual({
+      contexts: {
+        react: { componentStack: expect.any(String) },
+      },
+    })
+  })
+
+  it('정상 렌더링 시에는 Sentry.captureException을 호출하지 않는다', () => {
+    render(
+      <ErrorBoundary>
+        <div>정상 화면</div>
+      </ErrorBoundary>,
+    )
+
+    expect(Sentry.captureException).not.toHaveBeenCalled()
   })
 })

--- a/client/src/shared/ui/errorBoundary/errorBoundary.tsx
+++ b/client/src/shared/ui/errorBoundary/errorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
+import * as Sentry from "@sentry/react";
 import { Container, Title, Description, ReloadButton } from "./errorBoundary.styles";
 
 interface ErrorBoundaryProps {
@@ -19,6 +20,11 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error("ErrorBoundary caught an error", error, errorInfo);
+    // beforeSend(scrubEvent)가 contexts.react만 허용하므로 여기서 componentStack을 담아도
+    // title/description 같은 사용자 입력이 섞일 위험 없이 전달된다.
+    Sentry.captureException(error, {
+      contexts: { react: { componentStack: errorInfo.componentStack } },
+    });
   }
 
   render() {

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,18 +1,57 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react-swc'
+import { sentryVitePlugin } from '@sentry/vite-plugin'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import os from 'node:os'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
+// Sentry Auth Token은 절대 VITE_ 접두사를 붙이지 않는다. VITE_ 접두사가 붙으면
+// Vite가 import.meta.env를 통해 브라우저 번들에 그대로 노출시키기 때문이다. 이 값은
+// 이 파일(빌드 타임 Node 프로세스)에서만 읽히며, .env/VITE_* 체계와는 완전히 분리된
+// GitHub Actions repo secrets(SENTRY_AUTH_TOKEN)로만 주입해야 한다. 로컬 .env에는
+// 절대 넣지 말 것.
+const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN
+
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    // 소스맵을 Sentry에 업로드하는 플러그인. authToken이 없으면(로컬 개발, CI의
+    // client 테스트 빌드) 플러그인이 자체적으로 "No auth token provided" 경고만
+    // 남기고 업로드를 스킵한다(라이브러리 기본 동작) — 빌드 자체는 항상 정상적으로
+    // 끝난다. authToken이 있는데도 업로드가 실패하는 경우(Sentry 프로젝트 미생성,
+    // 네트워크 오류 등)에도 errorHandler가 throw 대신 경고만 남기도록 해 배포 빌드
+    // (deploy job)가 소스맵 업로드 실패만으로 깨지지 않게 한다.
+    sentryVitePlugin({
+      org: process.env.SENTRY_ORG,
+      project: process.env.SENTRY_PROJECT,
+      authToken: sentryAuthToken,
+      errorHandler: (error) => {
+        console.warn('[sentry-vite-plugin] 소스맵 업로드 실패, 빌드는 계속 진행합니다:', error)
+      },
+      // release.name을 명시하지 않으면 플러그인이 자동으로 git HEAD의 커밋 SHA를
+      // 사용한다(CI/로컬 모두 git 정보로 충분히 식별 가능하므로 별도 지정 불필요).
+      sourcemaps: {
+        // 업로드가 끝난 뒤 dist에서 .map 파일을 삭제해, 배포된 사이트에서
+        // 소스맵이 공개적으로 서빙되지 않도록 한다.
+        filesToDeleteAfterUpload: ['./dist/**/*.map'],
+      },
+      telemetry: false,
+    }),
+  ],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),
     },
+  },
+  build: {
+    // Sentry 플러그인이 업로드할 소스맵을 Vite가 실제로 생성하도록 한다. 위
+    // filesToDeleteAfterUpload는 업로드 성공/스킵 여부와 무관하게 항상 실행되므로
+    // (@sentry/bundler-plugins의 deleteArtifacts가 finally 블록에서 동작), authToken이
+    // 없는 로컬/client 빌드를 포함해 모든 경우에 .map 파일은 최종 dist에 남지 않는다.
+    sourcemap: true,
   },
   test: {
     globals: true,


### PR DESCRIPTION
## Summary
- 친구들에게 서비스를 공개하기 전, 프로덕션 에러를 개발자가 파악할 수 있도록 Sentry(`@sentry/react`) 연동
- 기존 `ErrorBoundary`와 연동해 캐치된 렌더링 에러를 리포팅
- `beforeSend`에서 allowlist 방식 스크러빙 적용 — todo 제목/설명, 이메일 등 사용자 PII가 전송되지 않도록 명시적으로 허용된 필드만 통과
- 소스맵은 CI `deploy` job에서만 업로드 후 dist에서 삭제 (Auth Token은 `VITE_` 접두사 없이 CI 시크릿 전용으로 관리해 클라이언트 번들 미노출)
- Sentry 프로젝트 설정에서 IP 기반 위치 정보 저장 차단(Prevent Storing of IP Addresses) 적용

## 검증
- [x] lint, 타입체크, 빌드, 유닛테스트(385개, 신규 44개 포함) 전체 통과
- [x] 프로덕션 빌드(`npm run build && npm run preview`)로 실제 uncaught 에러를 발생시켜 Sentry 대시보드에 정상 캡처되는 것까지 end-to-end 확인
- [x] 이슈 상세에서 PII 미노출(스크러빙 정상 동작) 육안 확인
- [x] code-reviewer, security-specialist 독립 리뷰 완료 (발견된 critical 이슈 — `deploy` job에 `VITE_SENTRY_DSN` 누락 — 수정 반영)
- [x] GitHub Secrets 등록 완료: `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `VITE_SENTRY_DSN`

## Test plan
- [ ] `main` 머지 후 실제 배포 빌드에서 Sentry가 이벤트를 정상 수신하는지 최종 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)