### PR TITLE
feat: 설명 입력폼 개선 — 줄바꿈 입력, 링크 열기, 본문 URL 색상 구분

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -20,6 +20,7 @@
         "@tanstack/react-query": "^5.90.5",
         "@tanstack/react-query-devtools": "^5.90.2",
         "firebase": "^12.10.0",
+        "linkifyjs": "^4.3.3",
         "lucide-react": "^0.562.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -154,6 +155,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -10043,6 +10045,12 @@
         "libsodium": "^0.7.16"
       }
     },
+    "node_modules/linkifyjs": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+      "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
+      "license": "MIT"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -12252,6 +12260,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.1.tgz",
       "integrity": "sha512-78E9voJHwnXQMiQdiqswVLZwJIzdBKJ1GdI5Zx6XwoFKUIk09/sSrr+05QFzvYb8q6Y9pPV45zzDuYa3907TZA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },

--- a/client/package.json
+++ b/client/package.json
@@ -27,6 +27,7 @@
     "@tanstack/react-query": "^5.90.5",
     "@tanstack/react-query-devtools": "^5.90.2",
     "firebase": "^12.10.0",
+    "linkifyjs": "^4.3.3",
     "lucide-react": "^0.562.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/client/src/features/today/components/todayTodoItem.styles.tsx
+++ b/client/src/features/today/components/todayTodoItem.styles.tsx
@@ -85,12 +85,39 @@ const Title = styled.span<{ $isDone: boolean }>`
   white-space: nowrap;
 `;
 
-const Description = styled.span`
-  font-size: 12px;
+const DescriptionRow = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+  min-width: 0;
   color: ${colors.text.secondary};
+`;
+
+/**
+ * description에 링크가 있음을 알리는 표시.
+ * 여기서 URL 자체를 링크로 만들지 않는 이유는 이 행 전체가 상세 진입 클릭 영역이라서다
+ * — 잘린 URL을 탭 타겟으로 만들면 "링크 열기"와 "상세 열기"가 같은 자리에서 경쟁한다.
+ */
+const LinkIndicator = styled.span`
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  margin-top: 3px;
+  color: ${colors.brand.secondary};
+`;
+
+const Description = styled.span`
+  min-width: 0;
+  font-size: 12px;
+  /* 이제 description에 줄바꿈을 입력할 수 있으므로 pre-wrap으로 보존한다.
+     다만 행이 무한정 길어지면 목록의 훑어보기 성능이 떨어지므로 2줄에서 자른다.
+     긴 URL이 행 폭을 밀어내지 않도록 anywhere로 강제 줄바꿈한다. */
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 `;
 
 const TimeLabel = styled.span`
@@ -145,6 +172,8 @@ export {
   Content,
   TitleRow,
   Title,
+  DescriptionRow,
+  LinkIndicator,
   Description,
   TimeLabel,
   OverdueBadge,

--- a/client/src/features/today/components/todayTodoItem.tsx
+++ b/client/src/features/today/components/todayTodoItem.tsx
@@ -1,7 +1,8 @@
-import { Check, Trash2 } from "lucide-react";
+import { Check, Link2, Trash2 } from "lucide-react";
+import { useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import type { Todo } from "@/features/todo/types";
-import { RecurrenceBadge } from "@/shared";
+import { RecurrenceBadge, extractLinks } from "@/shared";
 import { getDaysLeft, getDueBadgeLabel, getUrgency } from "@/shared/utils/due";
 import { getPeriodProgress } from "@/shared/utils/dateRange";
 import { toDateKey } from "@/shared/utils/date";
@@ -13,6 +14,8 @@ import {
   Content,
   TitleRow,
   Title,
+  DescriptionRow,
+  LinkIndicator,
   Description,
   TimeLabel,
   OverdueBadge,
@@ -55,6 +58,12 @@ const TodayTodoItem = ({
   const handleItemClick = () =>
     onItemClick ? onItemClick(todo) : navigate(`/todo/${todo.id}`);
 
+  // 목록의 모든 행마다 스캔이 돌므로 description이 바뀔 때만 다시 계산한다.
+  const hasLinks = useMemo(
+    () => extractLinks(todo.description).length > 0,
+    [todo.description]
+  );
+
   return (
     <Row>
       <Checkbox
@@ -81,7 +90,16 @@ const TodayTodoItem = ({
           <Title $isDone={isDone}>{todo.title}</Title>
           {todo.recurrenceId != null && <RecurrenceBadge compact />}
         </TitleRow>
-        {todo.description && <Description>{todo.description}</Description>}
+        {todo.description && (
+          <DescriptionRow>
+            {hasLinks && (
+              <LinkIndicator aria-label="링크 포함">
+                <Link2 size={11} />
+              </LinkIndicator>
+            )}
+            <Description>{todo.description}</Description>
+          </DescriptionRow>
+        )}
       </Content>
       {!isDone && daysLeft !== null && urgency === "danger" && (
         <OverdueBadge>{getDueBadgeLabel(daysLeft)}</OverdueBadge>

--- a/client/src/features/today/components/todayTodoItem.tsx
+++ b/client/src/features/today/components/todayTodoItem.tsx
@@ -93,7 +93,9 @@ const TodayTodoItem = ({
         {todo.description && (
           <DescriptionRow>
             {hasLinks && (
-              <LinkIndicator aria-label="링크 포함">
+              // span의 암묵 role은 generic이라 aria-label이 무시된다.
+              // role="img"를 줘야 스크린리더가 라벨을 읽는다.
+              <LinkIndicator role="img" aria-label="링크 포함">
                 <Link2 size={11} />
               </LinkIndicator>
             )}

--- a/client/src/features/todo/components/todoDetail/__tests__/todoDetail.test.tsx
+++ b/client/src/features/todo/components/todoDetail/__tests__/todoDetail.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route, useNavigate } from 'react-router-dom'
 import TodoDetail from '../todoDetail'
 import type { Todo } from '../../../types/todo.type'
 import { ToastProvider } from '@/shared/ui/toast/toastContext'
@@ -35,10 +35,34 @@ const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
  * 고정 객체를 반환하면 "서버 데이터가 갱신되는" 상황 자체를 재현할 수 없다.
  * useTodoDetail이 매 렌더 읽어가는 가변 홀더로 두어 refetch를 흉내낸다.
  */
-const mockState = vi.hoisted(() => ({ todo: null as unknown }))
+const mockState = vi.hoisted(() => ({
+  todo: null as unknown,
+  /** true면 요청받은 id에 맞는 todo를 만들어 반환한다(다른 todo로 이동하는 시나리오용). */
+  byId: false,
+}))
 
 vi.mock('../../../hooks', () => ({
-  useTodoDetail: () => ({ todo: mockState.todo }),
+  useTodoDetail: ({ id }: { id: string }) => ({
+    todo: mockState.byId
+      ? {
+          id,
+          userId: 'user-1',
+          title: `${id} 제목`,
+          description: `${id} 설명`,
+          status: 'todo',
+          priority: 'medium',
+          startAt: null,
+          dueAt: null,
+          doneAt: null,
+          parentId: null,
+          order: 0,
+          recurrence: null,
+          recurrenceId: null,
+          createdAt: '2026-06-14T00:00:00.000Z',
+          updatedAt: '2026-06-14T00:00:00.000Z',
+        }
+      : mockState.todo,
+  }),
   useTodo: () => ({
     useUpdateTodo: { mutate: vi.fn() },
     useCreateRecurringTodo: { mutate: vi.fn() },
@@ -68,7 +92,17 @@ const renderDetail = () => render(detailUi())
 
 beforeEach(() => {
   mockState.todo = makeTodo()
+  mockState.byId = false
 })
+
+const GoToOtherTodo = () => {
+  const navigate = useNavigate()
+  return (
+    <button type="button" onClick={() => navigate('/todo/B')}>
+      B로 이동
+    </button>
+  )
+}
 
 describe('TodoDetail 컴포넌트', () => {
   it('기존 description이 설명 textarea에 표시되어야 한다', () => {
@@ -119,6 +153,36 @@ describe('TodoDetail 컴포넌트', () => {
       rerender(detailUi())
 
       expect(screen.getByPlaceholderText('할 일 제목')).toHaveValue('서버에서 바뀐 제목')
+    })
+
+    /**
+     * keepDirtyValues는 "같은 todo를 보는 동안"만 유효해야 한다. 라우트 파라미터만
+     * 바뀌면 React Router가 컴포넌트를 재마운트하지 않으므로(하위 할 일 카드 클릭이
+     * 이 경로다), key를 주지 않으면 A에서 편집하던 값이 B로 넘어가고 저장 시
+     * B의 설명을 A의 내용으로 덮어쓴다.
+     */
+    it('다른 todo로 이동하면 이전 편집 내용을 가져가지 않는다', async () => {
+      mockState.byId = true
+      const user = setupUser()
+      render(
+        <ToastProvider>
+          <MemoryRouter initialEntries={['/todo/A']}>
+            <GoToOtherTodo />
+            <Routes>
+              <Route path="/todo/:id" element={<TodoDetail />} />
+            </Routes>
+          </MemoryRouter>
+        </ToastProvider>,
+      )
+
+      const desc = screen.getByPlaceholderText('상세 설명을 입력하세요')
+      await user.clear(desc)
+      await user.type(desc, 'A에서 작성중')
+
+      await user.click(screen.getByRole('button', { name: 'B로 이동' }))
+
+      expect(screen.getByPlaceholderText('할 일 제목')).toHaveValue('B 제목')
+      expect(screen.getByPlaceholderText('상세 설명을 입력하세요')).toHaveValue('B 설명')
     })
   })
 })

--- a/client/src/features/todo/components/todoDetail/__tests__/todoDetail.test.tsx
+++ b/client/src/features/todo/components/todoDetail/__tests__/todoDetail.test.tsx
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import TodoDetail from '../todoDetail'
 import type { Todo } from '../../../types/todo.type'
 import { ToastProvider } from '@/shared/ui/toast/toastContext'
+import { setupUser } from '@/test/setupUser'
 
 vi.mock('@/shared/lib/firebase', () => ({
   db: {},
@@ -30,10 +31,14 @@ const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
   ...overrides,
 })
 
-const todo = makeTodo()
+/**
+ * 고정 객체를 반환하면 "서버 데이터가 갱신되는" 상황 자체를 재현할 수 없다.
+ * useTodoDetail이 매 렌더 읽어가는 가변 홀더로 두어 refetch를 흉내낸다.
+ */
+const mockState = vi.hoisted(() => ({ todo: null as unknown }))
 
 vi.mock('../../../hooks', () => ({
-  useTodoDetail: () => ({ todo }),
+  useTodoDetail: () => ({ todo: mockState.todo }),
   useTodo: () => ({
     useUpdateTodo: { mutate: vi.fn() },
     useCreateRecurringTodo: { mutate: vi.fn() },
@@ -44,33 +49,76 @@ vi.mock('../../../hooks', () => ({
   }),
 }))
 
+/**
+ * 매번 새 엘리먼트를 만들어야 한다. 같은 엘리먼트 객체를 rerender에 넘기면 React가
+ * 참조 동일성으로 서브트리 렌더를 통째로 건너뛰어, 리렌더가 일어난 것처럼 보이지만
+ * 실제로는 아무 일도 일어나지 않는다(테스트가 거짓 통과한다).
+ */
+const detailUi = () => (
+  <ToastProvider>
+    <MemoryRouter initialEntries={['/todo/todo-1']}>
+      <Routes>
+        <Route path="/todo/:id" element={<TodoDetail />} />
+      </Routes>
+    </MemoryRouter>
+  </ToastProvider>
+)
+
+const renderDetail = () => render(detailUi())
+
+beforeEach(() => {
+  mockState.todo = makeTodo()
+})
+
 describe('TodoDetail 컴포넌트', () => {
   it('기존 description이 설명 textarea에 표시되어야 한다', () => {
-    render(
-      <ToastProvider>
-        <MemoryRouter initialEntries={['/todo/todo-1']}>
-          <Routes>
-            <Route path="/todo/:id" element={<TodoDetail />} />
-          </Routes>
-        </MemoryRouter>
-      </ToastProvider>,
-    )
+    renderDetail()
 
     const descInput = screen.getByPlaceholderText('상세 설명을 입력하세요') as HTMLTextAreaElement
     expect(descInput.value).toBe('기존 설명 텍스트')
   })
 
   it('제목도 description과 함께 정상 표시되어야 한다', () => {
-    render(
-      <ToastProvider>
-        <MemoryRouter initialEntries={['/todo/todo-1']}>
-          <Routes>
-            <Route path="/todo/:id" element={<TodoDetail />} />
-          </Routes>
-        </MemoryRouter>
-      </ToastProvider>,
-    )
+    renderDetail()
 
     expect(screen.getByPlaceholderText('할 일 제목')).toHaveValue('테스트 할 일')
+  })
+
+  describe('서버 데이터 갱신 중 편집 내용 보존', () => {
+    /**
+     * useForm이 defaultValues가 아닌 values prop 기반이라, 넘긴 객체가 달라지면
+     * 폼 전체가 리셋된다. 그런데 리셋을 유발하는 기능이 이 패널 안에 있다 —
+     * 하위 할 일을 추가하면 createChildTodo가 부모 status/doneAt을 재계산하고
+     * ["todoDetail"]을 무효화하므로, refetch된 status가 values를 바꾼다.
+     * resetOptions.keepDirtyValues가 없으면 여기서 입력 중이던 설명이 사라진다.
+     */
+    it('편집 중인 설명은 서버 데이터가 바뀌어도 유지된다', async () => {
+      const user = setupUser()
+      const { rerender } = renderDetail()
+
+      const desc = screen.getByPlaceholderText('상세 설명을 입력하세요')
+      await user.clear(desc)
+      await user.type(desc, '작성 중인 새 설명')
+
+      // 하위 할 일 추가로 부모 status가 서버에서 바뀐 상황
+      mockState.todo = makeTodo({ status: 'doing' })
+      rerender(detailUi())
+
+      expect(desc).toHaveValue('작성 중인 새 설명')
+    })
+
+    it('건드리지 않은 필드는 서버 값으로 갱신된다', async () => {
+      // keepDirtyValues를 "values 동기화를 통째로 끄는" 식으로 잘못 고치면 이 테스트가 깨진다.
+      const user = setupUser()
+      const { rerender } = renderDetail()
+
+      const desc = screen.getByPlaceholderText('상세 설명을 입력하세요')
+      await user.type(desc, ' 추가분')
+
+      mockState.todo = makeTodo({ title: '서버에서 바뀐 제목' })
+      rerender(detailUi())
+
+      expect(screen.getByPlaceholderText('할 일 제목')).toHaveValue('서버에서 바뀐 제목')
+    })
   })
 })

--- a/client/src/features/todo/components/todoDetail/descriptionLinkAction.styles.tsx
+++ b/client/src/features/todo/components/todoDetail/descriptionLinkAction.styles.tsx
@@ -20,18 +20,23 @@ const trigger = `
   gap: 4px;
   height: 44px;
   margin: -12px 0;
-  padding: 0 4px;
+  padding: 0 10px;
   max-width: 100%;
   border: none;
-  background: none;
+  border-radius: 6px;
   cursor: pointer;
   font-size: 13px;
   font-family: inherit;
-  color: ${colors.brand.secondary};
   text-decoration: none;
+  /* 13px는 WCAG large text(18.66px bold / 24px)가 아니므로 대비 4.5:1이 적용된다.
+     brand.secondary(#1D9E75)는 흰 배경에서 3.39:1로 미달이라 쓸 수 없다.
+     brand.primary(#0F6E56)는 흰 배경 6.20:1, tint 배경(#E8F5EF) 위에서도 5.54:1로 통과. */
+  color: ${colors.brand.primary};
+  background-color: ${colors.brand.background};
+  transition: background-color 0.15s ease;
 
   &:hover {
-    color: ${colors.brand.primary};
+    background-color: #d9ece4;
     text-decoration: underline;
   }
 

--- a/client/src/features/todo/components/todoDetail/descriptionLinkAction.styles.tsx
+++ b/client/src/features/todo/components/todoDetail/descriptionLinkAction.styles.tsx
@@ -1,0 +1,112 @@
+import { styled } from "styled-components";
+import { colors } from "@/styles/colors";
+
+const Container = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  /* 라벨 행의 남는 오른쪽 공간을 쓴다 — 세로 공간을 추가로 차지하지 않기 위해서다. */
+  margin-left: auto;
+  min-width: 0;
+`;
+
+/**
+ * 링크 액션 트리거. 44px 터치 타겟을 확보하되 라벨 행 높이를 밀어 올리지 않도록
+ * 음수 마진으로 흡수한다(todayTodoItem의 Checkbox/DeleteButton과 같은 기법).
+ */
+const trigger = `
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 44px;
+  margin: -12px 0;
+  padding: 0 4px;
+  max-width: 100%;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 13px;
+  font-family: inherit;
+  color: ${colors.brand.secondary};
+  text-decoration: none;
+
+  &:hover {
+    color: ${colors.brand.primary};
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${colors.brand.secondary};
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+`;
+
+const OpenLink = styled.a`
+  ${trigger}
+`;
+
+const ToggleButton = styled.button`
+  ${trigger}
+`;
+
+const TriggerLabel = styled.span`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const Popover = styled.div`
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 10;
+  min-width: 220px;
+  max-width: min(320px, 80vw);
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  background-color: ${colors.background.primary};
+  border: 1px solid ${colors.border.tertiary};
+  border-radius: 8px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
+`;
+
+const PopoverLink = styled.a`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  /* 팝오버 항목도 각각 44px 터치 타겟을 지킨다. */
+  min-height: 44px;
+  padding: 0 10px;
+  border-radius: 6px;
+  font-size: 13px;
+  color: ${colors.text.primary};
+  text-decoration: none;
+
+  &:hover {
+    background-color: ${colors.background.secondary};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${colors.brand.secondary};
+    outline-offset: -2px;
+  }
+`;
+
+const PopoverLinkText = styled.span`
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export {
+  Container,
+  OpenLink,
+  ToggleButton,
+  TriggerLabel,
+  Popover,
+  PopoverLink,
+  PopoverLinkText,
+};

--- a/client/src/features/todo/components/todoDetail/descriptionLinkAction.tsx
+++ b/client/src/features/todo/components/todoDetail/descriptionLinkAction.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useRef, useState } from "react";
+import { ExternalLink, Link2 } from "lucide-react";
+import type { DetectedLink } from "@/shared";
+import {
+  Container,
+  OpenLink,
+  ToggleButton,
+  TriggerLabel,
+  Popover,
+  PopoverLink,
+  PopoverLinkText,
+} from "./descriptionLinkAction.styles";
+
+interface DescriptionLinkActionProps {
+  links: DetectedLink[];
+}
+
+/**
+ * 설명 라벨 행 우측에 붙는 링크 열기 액션.
+ *
+ * textarea는 편집기로 그대로 두고 "링크를 여는 수단"만 분리한 형태다. 본문 안에서
+ * 링크를 활성화하면 편집 클릭(캐럿 배치)과 링크 클릭이 같은 좌표에서 경쟁하는데,
+ * 특히 모바일에서는 문장을 고치려다 외부 사이트가 열리면서 아직 저장하지 않은
+ * 제목/마감일/반복 설정까지 날아갈 수 있다. 타겟을 물리적으로 떼어 놓으면 그 충돌이
+ * 구조적으로 불가능해진다.
+ */
+const DescriptionLinkAction = ({ links }: DescriptionLinkActionProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handlePointerDown = (e: MouseEvent | TouchEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setIsOpen(false);
+    };
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsOpen(false);
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("touchstart", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("touchstart", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
+
+  // 링크가 하나뿐이면 팝오버를 거칠 이유가 없다 — 바로 여는 앵커로 둔다.
+  if (links.length === 1) {
+    const [link] = links;
+    return (
+      <Container>
+        <OpenLink
+          href={link.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          title={link.href}
+        >
+          <Link2 size={13} />
+          <TriggerLabel>{link.label} 열기</TriggerLabel>
+          <ExternalLink size={12} />
+        </OpenLink>
+      </Container>
+    );
+  }
+
+  return (
+    <Container ref={containerRef}>
+      <ToggleButton
+        // 이 컴포넌트는 todo-detail-form 안에 있다. type을 명시하지 않으면 submit으로
+        // 동작해서 버튼을 누르는 순간 저장되고 패널이 닫힌다.
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        onClick={() => setIsOpen((prev) => !prev)}
+      >
+        <Link2 size={13} />
+        <TriggerLabel>링크 {links.length}</TriggerLabel>
+      </ToggleButton>
+
+      {isOpen && (
+        <Popover role="menu">
+          {links.map((link) => (
+            <PopoverLink
+              key={link.href}
+              role="menuitem"
+              href={link.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              title={link.href}
+              onClick={() => setIsOpen(false)}
+            >
+              <ExternalLink size={13} />
+              <PopoverLinkText>{link.label}</PopoverLinkText>
+            </PopoverLink>
+          ))}
+        </Popover>
+      )}
+    </Container>
+  );
+};
+
+export default DescriptionLinkAction;

--- a/client/src/features/todo/components/todoDetail/todoDetail.styles.tsx
+++ b/client/src/features/todo/components/todoDetail/todoDetail.styles.tsx
@@ -1,4 +1,4 @@
-import { keyframes, styled } from "styled-components";
+import { css, keyframes, styled } from "styled-components";
 import { media } from "../../../../styles/breakpoints";
 import { colors } from "@/styles/colors";
 import { statusColors, type Status } from "@/styles/statusColors";
@@ -169,6 +169,9 @@ const TextArea = styled.textarea`
   box-sizing: border-box;
   line-height: 1.5;
   font-family: inherit;
+  /* color를 명시하는 이유: 하이라이트 오버레이(DescriptionOverlay)가 같은 색으로
+     본문을 그려야 하는데, 미지정이면 UA 기본색이라 두 값이 미세하게 달라진다. */
+  color: ${colors.text.primary};
   /* 높이는 useAutoGrowTextArea가 관리한다. 수동 리사이즈 핸들은 auto-grow와 서로 싸우고,
      우하단 핸들이 라벨 행 액션과 시각적으로 충돌하기도 해서 끈다. */
   resize: none;
@@ -184,6 +187,73 @@ const TextArea = styled.textarea`
     border-color: ${colors.brand.secondary};
     box-shadow: 0 0 0 3px rgba(29, 158, 117, 0.12);
   }
+`;
+
+/**
+ * TextArea 위에 겹쳐 본문을 다시 그리는 레이어. 링크 구간만 색과 밑줄을 받는다.
+ *
+ * 아래 텍스트 박스 관련 값들은 TextArea와 **정확히 같아야** 한다. 하나라도 어긋나면
+ * 줄바꿈 위치가 달라져 오버레이가 컨테이너를 넘친다. TextArea를 고칠 때 여기도 같이 고칠 것.
+ */
+const DescriptionOverlay = styled.div`
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  border-radius: 8px;
+
+  /* ↓ TextArea와 일치시켜야 하는 값들 */
+  padding: 12px 14px;
+  border: 1px solid transparent;
+  box-sizing: border-box;
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 1.5;
+  color: ${colors.text.primary};
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  word-break: normal;
+`;
+
+/** 오버레이에서 링크로 인식된 구간. 색만으로 구분하지 않도록 밑줄을 함께 준다. */
+const OverlayLink = styled.span`
+  /* brand.secondary(#1D9E75)는 흰 배경 대비 3.39:1로 WCAG AA(4.5:1)에 미달한다.
+     brand.primary(#0F6E56)는 6.20:1로 통과.
+     다만 #0F6E56과 본문색(#1A1A1A)의 대비는 2.81:1이라 색만으로는 구분이 보장되지
+     않는다(WCAG 1.4.1). 밑줄은 장식이 아니라 필수 요건이다. */
+  color: ${colors.brand.primary};
+  text-decoration: underline;
+  text-underline-offset: 2px;
+`;
+
+/**
+ * 설명 입력 필드와 하이라이트 오버레이를 겹치는 컨테이너.
+ *
+ * 포커스가 있을 때는 오버레이를 끄고 순정 textarea로 되돌린다. 한글 IME 조합, 캐럿,
+ * 드래그 선택은 전부 포커스 상태에서만 일어나므로 이 상태에서는 브라우저 네이티브
+ * 동작을 그대로 쓰는 것이다. 결과적으로 두 레이어가 동시에 보이는 순간이 없어,
+ * 줄바꿈이 어긋나더라도 글자가 두 벌 겹쳐 보이는 고스팅이 발생할 수 없다.
+ */
+const DescriptionField = styled.div<{ $highlight: boolean }>`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+
+  ${({ $highlight }) =>
+    $highlight &&
+    css`
+      ${TextArea} {
+        color: transparent;
+      }
+
+      &:focus-within ${TextArea} {
+        color: ${colors.text.primary};
+      }
+
+      &:focus-within ${DescriptionOverlay} {
+        opacity: 0;
+      }
+    `}
 `;
 
 const Select = styled.select`
@@ -476,6 +546,9 @@ export {
   LabelRow,
   Input,
   TextArea,
+  DescriptionField,
+  DescriptionOverlay,
+  OverlayLink,
   Select,
   InfoRow,
   InfoItem,

--- a/client/src/features/todo/components/todoDetail/todoDetail.styles.tsx
+++ b/client/src/features/todo/components/todoDetail/todoDetail.styles.tsx
@@ -126,6 +126,19 @@ const Label = styled.label`
   color: ${colors.text.primary};
 `;
 
+/**
+ * 라벨과 그 행의 보조 액션을 나란히 두는 행.
+ * 액션을 별도 블록으로 내리지 않고 라벨 행의 남는 오른쪽을 쓰는 이유는, 이 패널이
+ * 이미 매우 긴 폼이라 세로 공간을 추가로 쓰는 비용이 크기 때문이다.
+ */
+const LabelRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  min-height: 20px;
+`;
+
 const Input = styled.input`
   width: 100%;
   padding: 12px 14px;
@@ -154,7 +167,12 @@ const TextArea = styled.textarea`
   border-radius: 8px;
   outline: none;
   box-sizing: border-box;
-  resize: vertical;
+  line-height: 1.5;
+  font-family: inherit;
+  /* 높이는 useAutoGrowTextArea가 관리한다. 수동 리사이즈 핸들은 auto-grow와 서로 싸우고,
+     우하단 핸들이 라벨 행 액션과 시각적으로 충돌하기도 해서 끈다. */
+  resize: none;
+  overflow: hidden;
   min-height: 100px;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 
@@ -455,6 +473,7 @@ export {
   FormContainer,
   FormGroup,
   Label,
+  LabelRow,
   Input,
   TextArea,
   Select,

--- a/client/src/features/todo/components/todoDetail/todoDetail.styles.tsx
+++ b/client/src/features/todo/components/todoDetail/todoDetail.styles.tsx
@@ -159,33 +159,49 @@ const Input = styled.input`
   }
 `;
 
-const TextArea = styled.textarea`
-  width: 100%;
+/**
+ * TextArea와 DescriptionOverlay가 **같은 줄바꿈**을 만들기 위해 픽셀 단위로 일치해야
+ * 하는 값들. 한쪽만 수정하는 사고를 막으려고 한 곳에서 정의해 양쪽에 보간한다.
+ * (이전에는 같은 값을 양쪽에 손으로 복사하고 주석으로만 동기화를 약속하고 있었다.)
+ *
+ * 테두리/모서리/포커스 링은 여기 없다 — 스크롤 컨테이너인 DescriptionField가 갖는다.
+ * 내용과 함께 스크롤돼 사라지면 안 되기 때문이다.
+ */
+const textBoxMetrics = css`
   padding: 12px 14px;
-  font-size: 14px;
-  border: 1px solid ${colors.border.secondary};
-  border-radius: 8px;
-  outline: none;
   box-sizing: border-box;
-  line-height: 1.5;
   font-family: inherit;
-  /* color를 명시하는 이유: 하이라이트 오버레이(DescriptionOverlay)가 같은 색으로
-     본문을 그려야 하는데, 미지정이면 UA 기본색이라 두 값이 미세하게 달라진다. */
+  font-size: 14px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  word-break: normal;
+`;
+
+const TextArea = styled.textarea`
+  ${textBoxMetrics}
+  width: 100%;
+  border: none;
+  outline: none;
+  background: transparent;
   color: ${colors.text.primary};
+  display: block;
   /* 높이는 useAutoGrowTextArea가 관리한다. 수동 리사이즈 핸들은 auto-grow와 서로 싸우고,
-     우하단 핸들이 라벨 행 액션과 시각적으로 충돌하기도 해서 끈다. */
+     우하단 핸들이 라벨 행 액션과 시각적으로 충돌하기도 해서 끈다.
+     overflow: hidden은 오버레이 설계의 전제다 — textarea가 자체 스크롤을 가지면
+     오버레이와 scrollTop을 동기화해야 하는데, 지금은 스크롤러가 바깥에 하나뿐이라
+     그 코드가 아예 필요 없다. */
   resize: none;
   overflow: hidden;
   min-height: 100px;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  /* DescriptionField가 max-height를 가진 flex 컨테이너라, 기본값(flex-shrink: 1)이면
+     textarea가 컨테이너 높이에 맞춰 눌린다. 그러면 auto-grow로 잡아둔 높이가 무시되고
+     overflow: hidden 때문에 넘치는 내용이 스크롤도 안 되고 잘려버린다.
+     높이를 지키고 스크롤은 컨테이너에 맡긴다. */
+  flex-shrink: 0;
 
   &::placeholder {
     color: ${colors.text.tertiary};
-  }
-
-  &:focus {
-    border-color: ${colors.brand.secondary};
-    box-shadow: 0 0 0 3px rgba(29, 158, 117, 0.12);
   }
 `;
 
@@ -196,23 +212,17 @@ const TextArea = styled.textarea`
  * 줄바꿈 위치가 달라져 오버레이가 컨테이너를 넘친다. TextArea를 고칠 때 여기도 같이 고칠 것.
  */
 const DescriptionOverlay = styled.div`
+  ${textBoxMetrics}
   position: absolute;
-  inset: 0;
+  top: 0;
+  left: 0;
+  right: 0;
+  /* bottom을 auto로 두는 게 중요하다. inset:0으로 컨테이너에 고정하면 컨테이너가
+     스크롤될 때 오버레이만 제자리에 남아 본문과 어긋난다. 내용 높이만큼만 차지하게
+     두면 textarea와 함께 스크롤된다. */
+  bottom: auto;
   pointer-events: none;
-  overflow: hidden;
-  border-radius: 8px;
-
-  /* ↓ TextArea와 일치시켜야 하는 값들 */
-  padding: 12px 14px;
-  border: 1px solid transparent;
-  box-sizing: border-box;
-  font-family: inherit;
-  font-size: 14px;
-  line-height: 1.5;
   color: ${colors.text.primary};
-  white-space: pre-wrap;
-  overflow-wrap: break-word;
-  word-break: normal;
 `;
 
 /** 오버레이에서 링크로 인식된 구간. 색만으로 구분하지 않도록 밑줄을 함께 준다. */
@@ -238,6 +248,32 @@ const DescriptionField = styled.div<{ $highlight: boolean }>`
   position: relative;
   display: flex;
   flex-direction: column;
+  /* 테두리·모서리·포커스 링을 textarea에서 여기로 올렸다. 이 요소가 스크롤 컨테이너라
+     안쪽에 두면 내용과 함께 스크롤돼 사라진다. */
+  border: 1px solid ${colors.border.secondary};
+  border-radius: 8px;
+  background-color: ${colors.background.primary};
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+  /* auto-grow는 내용이 길어지는 만큼 끝없이 늘어난다. 상한이 없으면 2000자 설명이
+     필드를 모바일에서 1200px 넘게 키워, 우선순위/마감일/하위 할 일이 화면 몇 개
+     아래로 밀려난다. 모바일 기준 약 420자부터 체감된다.
+     상한을 textarea가 아니라 이 컨테이너에 두는 이유는 textarea에 내부 스크롤이
+     생기면 오버레이와 scrollTop을 동기화해야 하기 때문이다. 스크롤러를 바깥에
+     하나만 두면 오버레이가 내용과 같이 움직여 동기화가 필요 없다.
+     .5줄로 끊은 것도 의도적이다 — 마지막 줄이 반쯤 잘려야 JS 없이 "아래에 더 있다"는
+     신호가 된다. 정수 줄이면 깔끔하게 끝나 보여 그 신호가 사라진다. */
+  max-height: 330px;
+  overflow-y: auto;
+
+  ${media.mobile} {
+    max-height: 246px;
+  }
+
+  &:focus-within {
+    border-color: ${colors.brand.secondary};
+    box-shadow: 0 0 0 3px rgba(29, 158, 117, 0.12);
+  }
 
   ${({ $highlight }) =>
     $highlight &&

--- a/client/src/features/todo/components/todoDetail/todoDetail.tsx
+++ b/client/src/features/todo/components/todoDetail/todoDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { useTodoDetail, useTodo } from "../../hooks";
@@ -10,6 +10,7 @@ import {
   toDatetimeLocalValue,
   useAutoGrowTextArea,
   extractLinks,
+  toDescriptionSegments,
   DESCRIPTION_MAX_LENGTH,
 } from "@/shared";
 import DescriptionLinkAction from "./descriptionLinkAction";
@@ -44,6 +45,9 @@ import {
   LabelRow,
   Input,
   TextArea,
+  DescriptionField,
+  DescriptionOverlay,
+  OverlayLink,
   Select,
   Button,
   ErrorText,
@@ -121,6 +125,14 @@ const TodoDetail = () => {
     () => extractLinks(descriptionWatch),
     [descriptionWatch]
   );
+
+  // 본문 하이라이트용 — 위치를 보존하고 중복 URL도 각각 유지한다(extractLinks와 요구가 다름).
+  const descriptionSegments = useMemo(
+    () => toDescriptionSegments(descriptionWatch),
+    [descriptionWatch]
+  );
+  // 링크가 없으면 오버레이를 아예 렌더하지 않는다 — 이득 없이 정렬 리스크만 지는 상태를 만들지 않는다.
+  const hasDescriptionHighlight = descriptionSegments.some((s) => s.isLink);
 
   // register가 ref 슬롯을 가져가므로, auto-grow용 ref와 합치려면 미리 분리해 둔다.
   const { ref: descriptionFieldRef, ...descriptionField } = register("description", {
@@ -403,15 +415,33 @@ const TodoDetail = () => {
                   <DescriptionLinkAction links={descriptionLinks} />
                 )}
               </LabelRow>
-              <TextArea
-                {...descriptionField}
-                ref={(el) => {
-                  descriptionFieldRef(el);
-                  setDescriptionRef(el);
-                }}
-                id="todo-detail-description"
-                placeholder="상세 설명을 입력하세요"
-              />
+              <DescriptionField $highlight={hasDescriptionHighlight}>
+                {hasDescriptionHighlight && (
+                  // 실제 콘텐츠는 아래 textarea가 갖고 있다. 오버레이는 순수 장식이므로
+                  // 스크린리더에는 같은 본문이 두 번 읽히지 않도록 숨긴다.
+                  <DescriptionOverlay aria-hidden="true">
+                    {descriptionSegments.map((segment, index) =>
+                      segment.isLink ? (
+                        <OverlayLink key={index}>{segment.text}</OverlayLink>
+                      ) : (
+                        <Fragment key={index}>{segment.text}</Fragment>
+                      )
+                    )}
+                    {/* textarea는 끝의 개행 뒤 빈 줄을 렌더하지만 div는 접는다.
+                        폭 0 문자를 붙여 마지막 줄 높이를 textarea와 맞춘다. */}
+                    {"​"}
+                  </DescriptionOverlay>
+                )}
+                <TextArea
+                  {...descriptionField}
+                  ref={(el) => {
+                    descriptionFieldRef(el);
+                    setDescriptionRef(el);
+                  }}
+                  id="todo-detail-description"
+                  placeholder="상세 설명을 입력하세요"
+                />
+              </DescriptionField>
               {errors.description && (
                 <ErrorText>{errors.description.message}</ErrorText>
               )}

--- a/client/src/features/todo/components/todoDetail/todoDetail.tsx
+++ b/client/src/features/todo/components/todoDetail/todoDetail.tsx
@@ -80,10 +80,9 @@ const formatDateTime = (dateString: string | null) => {
   });
 };
 
-const TodoDetail = () => {
-  const { id } = useParams<{ id: string }>();
+const TodoDetailView = ({ id }: { id: string }) => {
   const navigate = useNavigate();
-  const { todo } = useTodoDetail({ id: id! });
+  const { todo } = useTodoDetail({ id });
   const {
     useUpdateTodo,
     useCreateRecurringTodo,
@@ -631,6 +630,20 @@ const TodoDetail = () => {
       </Modal>
     </>
   );
+};
+
+/**
+ * 라우트 파라미터만 바뀌면(예: 하위 할 일 카드 클릭 → navigate(`/todo/${child.id}`))
+ * React Router는 같은 엘리먼트를 재사용하므로 컴포넌트가 **재마운트되지 않는다**.
+ * 그러면 useForm의 values만 다음 todo로 갈아끼워지는데, resetOptions.keepDirtyValues가
+ * 이전 todo에서 편집 중이던 값을 그대로 들고 가버린다 — 그 상태로 저장하면 A의 설명이
+ * B에 덮어써진다.
+ *
+ * id를 key로 줘서 다른 todo로 이동하면 폼 상태를 새로 시작하게 한다.
+ */
+const TodoDetail = () => {
+  const { id } = useParams<{ id: string }>();
+  return <TodoDetailView key={id} id={id!} />;
 };
 
 export default TodoDetail;

--- a/client/src/features/todo/components/todoDetail/todoDetail.tsx
+++ b/client/src/features/todo/components/todoDetail/todoDetail.tsx
@@ -4,7 +4,15 @@ import { useForm } from "react-hook-form";
 import { useTodoDetail, useTodo } from "../../hooks";
 import type { Todo } from "../../types";
 import { X, Trash2, Plus, ChevronDown, ChevronRight } from "lucide-react";
-import { useToast, ConfirmModal, toDatetimeLocalValue } from "@/shared";
+import {
+  useToast,
+  ConfirmModal,
+  toDatetimeLocalValue,
+  useAutoGrowTextArea,
+  extractLinks,
+  DESCRIPTION_MAX_LENGTH,
+} from "@/shared";
+import DescriptionLinkAction from "./descriptionLinkAction";
 import useModal from "@/shared/hooks/useModal";
 import Modal from "@/shared/ui/modal/modal";
 import RecurrenceFields from "../recurrence/recurrenceFields";
@@ -33,6 +41,7 @@ import {
   PriorityBadge,
   FormGroup,
   Label,
+  LabelRow,
   Input,
   TextArea,
   Select,
@@ -102,6 +111,24 @@ const TodoDetail = () => {
 
   const startAtWatch = watch("startAt");
   const dueAtWatch = watch("dueAt");
+  const descriptionWatch = watch("description");
+
+  const { setRef: setDescriptionRef } = useAutoGrowTextArea(descriptionWatch);
+
+  // 저장된 값이 아니라 입력 중인 값에서 링크를 뽑는다 — 붙여넣자마자 링크가 인식됐는지
+  // 확인할 수 있어야 오탐(파일명 등)도 그 자리에서 알아챌 수 있다.
+  const descriptionLinks = useMemo(
+    () => extractLinks(descriptionWatch),
+    [descriptionWatch]
+  );
+
+  // register가 ref 슬롯을 가져가므로, auto-grow용 ref와 합치려면 미리 분리해 둔다.
+  const { ref: descriptionFieldRef, ...descriptionField } = register("description", {
+    maxLength: {
+      value: DESCRIPTION_MAX_LENGTH,
+      message: `설명은 ${DESCRIPTION_MAX_LENGTH}자 이내로 입력해주세요`,
+    },
+  });
 
   // 하위 투두 배열 자체를 계산해두면(기존엔 존재 여부만 boolean으로 계산했음)
   // 반복 설정 비활성화 조건(hasChildren)과 신규 하위 투두 섹션 렌더링을 동일한
@@ -370,11 +397,24 @@ const TodoDetail = () => {
             </FormGroup>
 
             <FormGroup>
-              <Label>설명</Label>
+              <LabelRow>
+                <Label htmlFor="todo-detail-description">설명</Label>
+                {descriptionLinks.length > 0 && (
+                  <DescriptionLinkAction links={descriptionLinks} />
+                )}
+              </LabelRow>
               <TextArea
-                {...register("description")}
+                {...descriptionField}
+                ref={(el) => {
+                  descriptionFieldRef(el);
+                  setDescriptionRef(el);
+                }}
+                id="todo-detail-description"
                 placeholder="상세 설명을 입력하세요"
               />
+              {errors.description && (
+                <ErrorText>{errors.description.message}</ErrorText>
+              )}
             </FormGroup>
 
             <InfoRow>

--- a/client/src/features/todo/components/todoDetail/todoDetail.tsx
+++ b/client/src/features/todo/components/todoDetail/todoDetail.tsx
@@ -111,6 +111,12 @@ const TodoDetail = () => {
           dueAt: todo.dueAt ? toDatetimeLocalValue(todo.dueAt) : "",
         }
       : undefined,
+    // values prop은 넘긴 객체가 달라지면 폼 전체를 서버 값으로 되돌린다. 그런데 그
+    // 리셋을 유발하는 기능이 이 패널 안에 있다 — 하위 할 일을 추가하면 부모의
+    // status/doneAt이 재계산되고 ["todoDetail"]이 무효화되므로, refetch된 status가
+    // values를 바꾼다. 그대로 두면 그 순간 입력 중이던 설명이 사라진다.
+    // 사용자가 건드린 필드만 지키고 나머지는 정상적으로 서버 값을 따라간다.
+    resetOptions: { keepDirtyValues: true },
   });
 
   const startAtWatch = watch("startAt");

--- a/client/src/features/todo/components/todoDetail/todoDetail.tsx
+++ b/client/src/features/todo/components/todoDetail/todoDetail.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { useTodoDetail, useTodo } from "../../hooks";
@@ -146,6 +146,21 @@ const TodoDetailView = ({ id }: { id: string }) => {
       message: `설명은 ${DESCRIPTION_MAX_LENGTH}자 이내로 입력해주세요`,
     },
   });
+
+  // register()는 매 렌더 새 ref 함수를 반환한다. 그대로 인라인으로 합치면 ref의
+  // identity가 매번 달라져 React가 타건마다 ref를 null로 뗐다 다시 붙이고, 그때마다
+  // setRef가 resize()를 호출해 강제 리플로우가 한 번 더 일어난다.
+  // 최신 ref를 ref 박스에 담아 호출하면 stale 없이 identity를 고정할 수 있다.
+  const latestFieldRef = useRef(descriptionFieldRef);
+  latestFieldRef.current = descriptionFieldRef;
+
+  const setDescriptionTextArea = useCallback(
+    (el: HTMLTextAreaElement | null) => {
+      latestFieldRef.current(el);
+      setDescriptionRef(el);
+    },
+    [setDescriptionRef]
+  );
 
   // 하위 투두 배열 자체를 계산해두면(기존엔 존재 여부만 boolean으로 계산했음)
   // 반복 설정 비활성화 조건(hasChildren)과 신규 하위 투두 섹션 렌더링을 동일한
@@ -439,10 +454,7 @@ const TodoDetailView = ({ id }: { id: string }) => {
                 )}
                 <TextArea
                   {...descriptionField}
-                  ref={(el) => {
-                    descriptionFieldRef(el);
-                    setDescriptionRef(el);
-                  }}
+                  ref={setDescriptionTextArea}
                   id="todo-detail-description"
                   placeholder="상세 설명을 입력하세요"
                 />

--- a/client/src/features/todo/components/todoForm/todoForm.tsx
+++ b/client/src/features/todo/components/todoForm/todoForm.tsx
@@ -1,5 +1,5 @@
 import { useForm } from "react-hook-form";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useTodo } from "../../hooks";
 import {
@@ -299,6 +299,20 @@ const TodoForm = ({ todo, parentId, initialDueAt, onClose }: TodoFormProps) => {
     },
   });
 
+  // register()가 매 렌더 새 ref 함수를 반환해 인라인으로 합치면 타건마다 ref가
+  // 떨어졌다 붙는다(그때마다 resize()로 강제 리플로우 1회 추가).
+  // 최신 ref를 박스에 담아 호출해 stale 없이 identity를 고정한다.
+  const latestFieldRef = useRef(descriptionFieldRef);
+  latestFieldRef.current = descriptionFieldRef;
+
+  const setDescriptionTextArea = useCallback(
+    (el: HTMLTextAreaElement | null) => {
+      latestFieldRef.current(el);
+      setDescriptionRef(el);
+    },
+    [setDescriptionRef]
+  );
+
   return (
     <>
       <FormContainer id="todo-form" onSubmit={handleSubmit(onSubmit)}>
@@ -319,10 +333,7 @@ const TodoForm = ({ todo, parentId, initialDueAt, onClose }: TodoFormProps) => {
             <InputLabel>설명</InputLabel>
             <TextArea
               {...descriptionField}
-              ref={(el) => {
-                descriptionFieldRef(el);
-                setDescriptionRef(el);
-              }}
+              ref={setDescriptionTextArea}
               rows={2}
               placeholder="상세 설명을 입력하세요"
             />

--- a/client/src/features/todo/components/todoForm/todoForm.tsx
+++ b/client/src/features/todo/components/todoForm/todoForm.tsx
@@ -86,6 +86,14 @@ const TodoForm = ({ todo, parentId, initialDueAt, onClose }: TodoFormProps) => {
     if (showMore) resizeDescription();
   }, [showMore, resizeDescription]);
 
+  // 설명 에러 메시지는 접히는 DetailSection 안에 있다. 접힌 상태로 저장을 누르면
+  // 유효성 검사에 걸려 제출은 막히는데 메시지는 0fr 안에 잘려 보이지 않고, RHF의
+  // shouldFocusError가 안 보이는 textarea로 포커스를 옮겨 폼이 죽은 것처럼 보인다.
+  // 에러가 생기면 섹션을 열어 사용자가 무엇이 문제인지 볼 수 있게 한다.
+  useEffect(() => {
+    if (errors.description) setShowMore(true);
+  }, [errors.description]);
+
   // 하위 할 일 생성 폼(parentId 존재, 케이스 D)에서는 반복 섹션 자체를 렌더링하지 않는다.
   const showRecurrenceSection = !parentId;
 

--- a/client/src/features/todo/components/todoForm/todoForm.tsx
+++ b/client/src/features/todo/components/todoForm/todoForm.tsx
@@ -2,7 +2,13 @@ import { useForm } from "react-hook-form";
 import { useEffect, useMemo, useState } from "react";
 
 import { useTodo } from "../../hooks";
-import { useToast, ConfirmModal, toDatetimeLocalValue } from "@/shared";
+import {
+  useToast,
+  ConfirmModal,
+  toDatetimeLocalValue,
+  useAutoGrowTextArea,
+  DESCRIPTION_MAX_LENGTH,
+} from "@/shared";
 import type { RecurrenceRule, Todo } from "../../types";
 import RecurrenceFields from "../recurrence/recurrenceFields";
 import { getRecurrenceValidationError } from "../recurrence/recurrenceValidation";
@@ -12,6 +18,7 @@ import {
   FormContainer,
   InputLabel,
   Input,
+  TextArea,
   MoreButton,
   MoreButtonContainer,
   DetailSection,
@@ -68,6 +75,16 @@ const TodoForm = ({ todo, parentId, initialDueAt, onClose }: TodoFormProps) => {
 
   const startAtWatch = watch("startAt");
   const dueAtWatch = watch("dueAt");
+  const descriptionWatch = watch("description");
+
+  const { setRef: setDescriptionRef, resize: resizeDescription } =
+    useAutoGrowTextArea(descriptionWatch);
+
+  // "더보기"로 접혀 있는 동안 textarea는 grid 0fr 안에 있어 높이 측정이 신뢰할 수 없다.
+  // 섹션이 열리는 시점에 한 번 더 재서 기존 값이 잘려 보이지 않게 한다.
+  useEffect(() => {
+    if (showMore) resizeDescription();
+  }, [showMore, resizeDescription]);
 
   // 하위 할 일 생성 폼(parentId 존재, 케이스 D)에서는 반복 섹션 자체를 렌더링하지 않는다.
   const showRecurrenceSection = !parentId;
@@ -266,6 +283,14 @@ const TodoForm = ({ todo, parentId, initialDueAt, onClose }: TodoFormProps) => {
     }
   };
 
+  // register가 ref 슬롯을 가져가므로, auto-grow용 ref와 합치려면 미리 분리해 둔다.
+  const { ref: descriptionFieldRef, ...descriptionField } = register("description", {
+    maxLength: {
+      value: DESCRIPTION_MAX_LENGTH,
+      message: `설명은 ${DESCRIPTION_MAX_LENGTH}자 이내로 입력해주세요`,
+    },
+  });
+
   return (
     <>
       <FormContainer id="todo-form" onSubmit={handleSubmit(onSubmit)}>
@@ -284,10 +309,20 @@ const TodoForm = ({ todo, parentId, initialDueAt, onClose }: TodoFormProps) => {
         <DetailSection $isOpen={showMore}>
           <DetailContent>
             <InputLabel>설명</InputLabel>
-            <Input
-              {...register("description")}
+            <TextArea
+              {...descriptionField}
+              ref={(el) => {
+                descriptionFieldRef(el);
+                setDescriptionRef(el);
+              }}
+              rows={2}
               placeholder="상세 설명을 입력하세요"
             />
+            {errors.description && (
+              <span style={{ color: "red", fontSize: "12px" }}>
+                {errors.description.message}
+              </span>
+            )}
 
             <InputLabel>우선순위</InputLabel>
             <Select {...register("priority")} defaultValue="medium">

--- a/client/src/features/todo/components/todoForm/todoFrom.styles.tsx
+++ b/client/src/features/todo/components/todoForm/todoFrom.styles.tsx
@@ -28,6 +28,29 @@ const Input = styled.input`
   }
 `;
 
+const TextArea = styled.textarea`
+  width: 100%;
+  padding: 10px 12px;
+  font-size: 14px;
+  font-family: inherit;
+  line-height: 1.5;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  outline: none;
+  box-sizing: border-box;
+  /* 높이는 useAutoGrowTextArea가 관리한다. 수동 리사이즈 핸들은 서로 싸우므로 끄고,
+     overflow를 숨겨 스크롤바 대신 높이가 늘어나게 한다.
+     min-height는 인라인 height보다 우선하므로 빈 상태에서도 2줄 높이를 유지한다
+     — "여기는 여러 줄을 쓸 수 있다"는 어포던스를 잃지 않기 위해서다. */
+  resize: none;
+  overflow: hidden;
+  min-height: 64px;
+
+  &:focus {
+    border-color: ${colors.brand.secondary};
+  }
+`;
+
 const MoreButton = styled.button`
   height: 40px;
   border: none;
@@ -81,6 +104,7 @@ export {
   FormContainer,
   InputLabel,
   Input,
+  TextArea,
   MoreButton,
   MoreButtonContainer,
   DetailSection,

--- a/client/src/features/todo/components/todoForm/todoFrom.styles.tsx
+++ b/client/src/features/todo/components/todoForm/todoFrom.styles.tsx
@@ -1,5 +1,6 @@
 import { styled } from "styled-components";
 import { colors } from "@/styles/colors";
+import { media } from "@/styles/breakpoints";
 const FormContainer = styled.form`
   display: flex;
   flex-direction: column;
@@ -43,8 +44,18 @@ const TextArea = styled.textarea`
      min-height는 인라인 height보다 우선하므로 빈 상태에서도 2줄 높이를 유지한다
      — "여기는 여러 줄을 쓸 수 있다"는 어포던스를 잃지 않기 위해서다. */
   resize: none;
-  overflow: hidden;
   min-height: 64px;
+  /* auto-grow가 내용만큼 계속 키우므로 상한이 필요하다. 없으면 긴 설명이 모달을
+     밀어내 우선순위/날짜 필드가 화면 밖으로 나간다(ModalContainer는 max-height: 80vh).
+     상세 패널과 달리 여기엔 하이라이트 오버레이가 없어 textarea에 직접 걸어도 된다.
+     .5줄로 끊어 마지막 줄이 반쯤 보이게 하면 "아래에 더 있다"는 신호가 된다. */
+  max-height: 242px;
+  overflow-x: hidden;
+  overflow-y: auto;
+
+  ${media.mobile} {
+    max-height: 200px;
+  }
 
   &:focus {
     border-color: ${colors.brand.secondary};

--- a/client/src/shared/hooks/__tests__/useAutoGrowTextArea.test.tsx
+++ b/client/src/shared/hooks/__tests__/useAutoGrowTextArea.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import useAutoGrowTextArea from "../useAutoGrowTextArea";
+
+/**
+ * jsdom에는 레이아웃 엔진이 없어 실제 높이 계산은 검증할 수 없다.
+ * 대신 브라우저별 차이를 만드는 "읽는 순서"를 고정한다.
+ */
+const createTextArea = (scrollHeight: number) => {
+  const el = document.createElement("textarea");
+  const reads: string[] = [];
+
+  Object.defineProperty(el, "offsetHeight", {
+    get: () => {
+      reads.push("offsetHeight");
+      return 0;
+    },
+  });
+  Object.defineProperty(el, "scrollHeight", {
+    get: () => {
+      reads.push("scrollHeight");
+      return scrollHeight;
+    },
+  });
+
+  return { el, reads };
+};
+
+describe("useAutoGrowTextArea", () => {
+  it("내용 높이(scrollHeight)를 인라인 height로 반영한다", () => {
+    const { el } = createTextArea(120);
+    const { result } = renderHook(() => useAutoGrowTextArea(""));
+
+    result.current.setRef(el);
+
+    expect(el.style.height).toBe("120px");
+  });
+
+  it("scrollHeight를 읽기 전에 offsetHeight로 리플로우를 강제한다", () => {
+    // Firefox는 height:auto를 반영한 레이아웃을 즉시 계산하지 않아, 리플로우를
+    // 강제하지 않으면 scrollHeight가 직전 높이를 그대로 돌려주고 높이가 전혀 늘지 않는다.
+    // (Chromium/WebKit은 이 줄이 없어도 동작하므로, 지우면 Firefox에서만 조용히 깨진다.)
+    const { el, reads } = createTextArea(120);
+    const { result } = renderHook(() => useAutoGrowTextArea(""));
+
+    result.current.setRef(el);
+
+    expect(reads).toEqual(["offsetHeight", "scrollHeight"]);
+  });
+
+  it("ref가 없으면 아무 일도 하지 않는다", () => {
+    const { result } = renderHook(() => useAutoGrowTextArea(""));
+
+    expect(() => {
+      result.current.setRef(null);
+      result.current.resize();
+    }).not.toThrow();
+  });
+});

--- a/client/src/shared/hooks/index.ts
+++ b/client/src/shared/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useModal } from "./useModal";
 export { default as useResize } from "./useResize";
 export { default as useMediaQuery } from "./useMediaQuery";
+export { default as useAutoGrowTextArea } from "./useAutoGrowTextArea";

--- a/client/src/shared/hooks/useAutoGrowTextArea.ts
+++ b/client/src/shared/hooks/useAutoGrowTextArea.ts
@@ -21,6 +21,11 @@ const useAutoGrowTextArea = (value?: string) => {
     // scrollHeight는 현재 height보다 작아지지 않으므로, 줄어드는 경우도 처리하려면
     // auto로 되돌려 내용 높이를 다시 측정한 뒤 반영해야 한다.
     el.style.height = "auto";
+    // Firefox는 height:auto를 반영한 레이아웃을 바로 계산하지 않아, 이 시점의
+    // scrollHeight가 직전 높이(min-height 기준값)를 그대로 돌려준다 — 그러면 높이가
+    // 전혀 늘지 않는다. offsetHeight를 읽어 리플로우를 강제하면 세 엔진 모두
+    // 내용 높이를 반환한다. Chromium/WebKit에서는 이 줄이 있어도 결과가 같다.
+    void el.offsetHeight;
     el.style.height = `${el.scrollHeight}px`;
   }, []);
 

--- a/client/src/shared/hooks/useAutoGrowTextArea.ts
+++ b/client/src/shared/hooks/useAutoGrowTextArea.ts
@@ -1,0 +1,43 @@
+import { useCallback, useLayoutEffect, useRef } from "react";
+
+/**
+ * textarea 높이를 내용에 맞춰 자동으로 늘린다.
+ *
+ * react-hook-form의 register()가 ref 슬롯을 가져가므로 ref를 직접 넘길 수 없다.
+ * 대신 setRef를 반환해 register의 ref와 합쳐 쓰도록 한다:
+ *
+ *   const { ref: registerRef, ...field } = register("description");
+ *   <TextArea {...field} ref={(el) => { registerRef(el); setRef(el); }} />
+ *
+ * resize를 함께 반환하는 이유는, 값 변경 외의 사유로도 높이를 다시 재야 하기 때문이다
+ * (예: 접혀 있던 "더보기" 섹션이 열리면서 textarea가 처음 레이아웃을 받는 경우).
+ */
+const useAutoGrowTextArea = (value?: string) => {
+  const ref = useRef<HTMLTextAreaElement | null>(null);
+
+  const resize = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    // scrollHeight는 현재 height보다 작아지지 않으므로, 줄어드는 경우도 처리하려면
+    // auto로 되돌려 내용 높이를 다시 측정한 뒤 반영해야 한다.
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, []);
+
+  const setRef = useCallback(
+    (el: HTMLTextAreaElement | null) => {
+      ref.current = el;
+      // 기존 값이 있는 수정 폼에서 첫 렌더부터 맞춰 준다.
+      if (el) resize();
+    },
+    [resize]
+  );
+
+  useLayoutEffect(() => {
+    resize();
+  }, [value, resize]);
+
+  return { setRef, resize };
+};
+
+export default useAutoGrowTextArea;

--- a/client/src/shared/utils/__tests__/descriptionLinks.test.ts
+++ b/client/src/shared/utils/__tests__/descriptionLinks.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { extractLinks, DESCRIPTION_MAX_LENGTH } from "../descriptionLinks";
+import {
+  extractLinks,
+  toDescriptionSegments,
+  DESCRIPTION_MAX_LENGTH,
+} from "../descriptionLinks";
 
 describe("extractLinks", () => {
   it("빈 값이면 빈 배열을 반환한다", () => {
@@ -87,5 +91,85 @@ describe("extractLinks", () => {
   it("DESCRIPTION_MAX_LENGTH는 firestore.rules의 상한과 같은 2000이다", () => {
     // 한쪽만 바뀌면 클라이언트는 통과시키는데 서버가 거부하는 상태가 된다.
     expect(DESCRIPTION_MAX_LENGTH).toBe(2000);
+  });
+});
+
+describe("toDescriptionSegments", () => {
+  it("빈 값이면 빈 배열을 반환한다", () => {
+    expect(toDescriptionSegments(undefined)).toEqual([]);
+    expect(toDescriptionSegments("")).toEqual([]);
+  });
+
+  it("링크가 없으면 통짜 비링크 조각 하나를 반환한다", () => {
+    expect(toDescriptionSegments("우유 사기")).toEqual([
+      { text: "우유 사기", isLink: false },
+    ]);
+  });
+
+  it("링크 앞뒤 텍스트를 보존하며 쪼갠다", () => {
+    expect(toDescriptionSegments("시안 https://a.com/x 확인")).toEqual([
+      { text: "시안 ", isLink: false },
+      { text: "https://a.com/x", isLink: true },
+      { text: " 확인", isLink: false },
+    ]);
+  });
+
+  it("링크로 시작하고 끝나도 빈 조각을 만들지 않는다", () => {
+    expect(toDescriptionSegments("https://a.com/x")).toEqual([
+      { text: "https://a.com/x", isLink: true },
+    ]);
+  });
+
+  it("같은 URL이 두 번 나오면 두 곳 모두 링크로 표시한다", () => {
+    // extractLinks(열기 버튼)는 중복을 제거하지만, 하이라이트는 요구가 정반대다.
+    const segments = toDescriptionSegments("https://a.com/x 랑 https://a.com/x");
+    expect(segments.filter((s) => s.isLink)).toHaveLength(2);
+    expect(extractLinks("https://a.com/x 랑 https://a.com/x")).toHaveLength(1);
+  });
+
+  it("링크로 인정하지 않는 토큰은 칠하지 않는다", () => {
+    // extractLinks와 동일한 게이팅을 공유해야 한다 — 어긋나면 "색은 칠해졌는데
+    // 열기 버튼에는 없는" 상태가 된다.
+    for (const text of ["setup.sh 실행", "example.com 확인", "javascript:alert(1)"]) {
+      expect(toDescriptionSegments(text).some((s) => s.isLink)).toBe(false);
+      expect(extractLinks(text)).toHaveLength(0);
+    }
+  });
+
+  it("조각을 순서대로 이으면 원문과 정확히 일치한다", () => {
+    // 오버레이가 textarea와 같은 줄바꿈을 얻으려면 이 성질이 절대 깨지면 안 된다.
+    const samples = [
+      "시작 https://a.com/x 중간 https://b.com 끝",
+      "https://a.com/x\n두 번째 줄\n\n네 번째 줄",
+      "링크 없는 평범한 설명",
+      "끝에 개행\n",
+      "(참고: https://a.com) 그리고 setup.sh",
+    ];
+    for (const text of samples) {
+      expect(toDescriptionSegments(text).map((s) => s.text).join("")).toBe(text);
+    }
+  });
+
+  it("원문 대신 정규화된 URL을 넣지 않는다", () => {
+    // href는 https로 보정되지만 화면에 겹쳐 그리는 텍스트는 사용자가 친 그대로여야 한다.
+    // 다르면 오버레이와 textarea의 글자 수가 달라져 정렬이 깨진다.
+    const [segment] = toDescriptionSegments("www.example.com");
+    expect(segment).toEqual({ text: "www.example.com", isLink: true });
+    expect(extractLinks("www.example.com")[0].href).toBe("https://www.example.com/");
+  });
+
+  it("링크 판정이 extractLinks와 항상 일치한다", () => {
+    // 두 함수가 갈라지면 "본문은 칠해졌는데 열기 버튼에는 안 뜨는" 어긋남이 생긴다.
+    const samples = [
+      "https://a.com/x 하나",
+      "setup.sh 와 demo.zip",
+      "www.example.com 그리고 example.com",
+      "메일 a@b.com 과 https://c.com",
+      "링크 없음",
+    ];
+    for (const text of samples) {
+      const highlighted = toDescriptionSegments(text).some((s) => s.isLink);
+      expect(highlighted).toBe(extractLinks(text).length > 0);
+    }
   });
 });

--- a/client/src/shared/utils/__tests__/descriptionLinks.test.ts
+++ b/client/src/shared/utils/__tests__/descriptionLinks.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { extractLinks, DESCRIPTION_MAX_LENGTH } from "../descriptionLinks";
+
+describe("extractLinks", () => {
+  it("빈 값이면 빈 배열을 반환한다", () => {
+    expect(extractLinks(undefined)).toEqual([]);
+    expect(extractLinks(null)).toEqual([]);
+    expect(extractLinks("")).toEqual([]);
+  });
+
+  it("링크가 없는 평범한 설명에서는 아무것도 찾지 않는다", () => {
+    expect(extractLinks("장보기: 우유, 계란 사기")).toEqual([]);
+  });
+
+  describe("경계 판정 — 정규식으로는 틀리는 케이스들", () => {
+    it("문장 끝 마침표는 URL에 포함하지 않는다", () => {
+      expect(extractLinks("자료는 https://example.com/docs. 확인해줘")[0].href).toBe(
+        "https://example.com/docs"
+      );
+    });
+
+    it("문장을 감싼 괄호는 URL에 포함하지 않는다", () => {
+      expect(extractLinks("(참고: https://example.com)")[0].href).toBe(
+        "https://example.com/"
+      );
+    });
+
+    it("URL 자체의 괄호는 보존한다", () => {
+      // 위키백과처럼 경로에 괄호가 들어가는 URL — 위 케이스와 구분되어야 한다.
+      const [link] = extractLinks("https://ko.wikipedia.org/wiki/Function_(math)");
+      expect(decodeURI(link.href)).toBe(
+        "https://ko.wikipedia.org/wiki/Function_(math)"
+      );
+    });
+  });
+
+  describe("오탐 차단", () => {
+    it("파일명을 링크로 잡지 않는다", () => {
+      // .sh / .zip / .mov 는 전부 실제 TLD라서 TLD 목록만 보면 링크로 판정된다.
+      expect(extractLinks("setup.sh 실행하고 demo.zip 풀기, clip.mov 확인")).toEqual([]);
+    });
+
+    it("스킴 없는 맨 도메인은 링크로 잡지 않는다", () => {
+      expect(extractLinks("example.com 에서 확인")).toEqual([]);
+    });
+
+    it("javascript: 스킴은 링크로 잡지 않는다", () => {
+      expect(extractLinks("javascript:alert(1)")).toEqual([]);
+    });
+
+    it("이메일 주소는 링크 대상이 아니다", () => {
+      expect(extractLinks("문의는 someone@example.com 으로")).toEqual([]);
+    });
+  });
+
+  describe("정상 감지", () => {
+    it("https URL을 호스트명 라벨과 함께 반환한다", () => {
+      expect(extractLinks("시안 https://www.figma.com/file/abc 확인")).toEqual([
+        { href: "https://www.figma.com/file/abc", label: "figma.com" },
+      ]);
+    });
+
+    it("스킴이 없는 www. 는 https로 보정한다", () => {
+      expect(extractLinks("www.example.com")[0].href).toBe("https://www.example.com/");
+    });
+
+    it("명시된 http는 https로 바꾸지 않는다", () => {
+      // 사용자가 적은 주소를 임의로 승격하면 열리지 않는 페이지가 생길 수 있다.
+      expect(extractLinks("http://legacy.example.com")[0].href).toBe(
+        "http://legacy.example.com/"
+      );
+    });
+
+    it("여러 링크를 순서대로 반환한다", () => {
+      expect(
+        extractLinks("기획서: https://a.com/spec\n시안: https://b.com/design").map(
+          (l) => l.label
+        )
+      ).toEqual(["a.com", "b.com"]);
+    });
+
+    it("같은 URL이 여러 번 나와도 한 번만 반환한다", () => {
+      expect(extractLinks("https://a.com/x 랑 https://a.com/x 둘 다")).toHaveLength(1);
+    });
+  });
+
+  it("DESCRIPTION_MAX_LENGTH는 firestore.rules의 상한과 같은 2000이다", () => {
+    // 한쪽만 바뀌면 클라이언트는 통과시키는데 서버가 거부하는 상태가 된다.
+    expect(DESCRIPTION_MAX_LENGTH).toBe(2000);
+  });
+});

--- a/client/src/shared/utils/__tests__/descriptionLinks.test.ts
+++ b/client/src/shared/utils/__tests__/descriptionLinks.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, it, expect } from "vitest";
 import {
   extractLinks,
@@ -88,9 +90,16 @@ describe("extractLinks", () => {
     });
   });
 
-  it("DESCRIPTION_MAX_LENGTH는 firestore.rules의 상한과 같은 2000이다", () => {
-    // 한쪽만 바뀌면 클라이언트는 통과시키는데 서버가 거부하는 상태가 된다.
-    expect(DESCRIPTION_MAX_LENGTH).toBe(2000);
+  it("DESCRIPTION_MAX_LENGTH가 firestore.rules의 상한과 실제로 일치한다", () => {
+    // 주석으로만 동기화를 약속하면 한쪽만 바뀌었을 때 아무도 못 잡는다. 클라이언트는
+    // 통과시키는데 서버가 permission-denied로 거부하는, 원인 파악이 어려운 상태가 된다.
+    const rules = readFileSync(resolve(process.cwd(), "../firestore.rules"), "utf-8");
+    const limits = [...rules.matchAll(/\.size\(\)\s*<=\s*(\d+)/g)].map((m) => Number(m[1]));
+
+    expect(limits.length).toBeGreaterThan(0);
+    for (const limit of limits) {
+      expect(limit).toBe(DESCRIPTION_MAX_LENGTH);
+    }
   });
 });
 

--- a/client/src/shared/utils/descriptionLinks.ts
+++ b/client/src/shared/utils/descriptionLinks.ts
@@ -1,0 +1,68 @@
+import { find } from "linkifyjs";
+
+/**
+ * description 최대 길이.
+ * firestore.rules의 검증 값과 반드시 동일하게 유지해야 한다(둘 중 하나만 바꾸면
+ * 클라이언트는 통과시키는데 서버가 거부하는 상태가 된다).
+ */
+export const DESCRIPTION_MAX_LENGTH = 2000;
+
+/**
+ * 링크로 인정할 스킴 화이트리스트.
+ * denylist("javascript:를 막는다")가 아니라 allowlist인 이유는, 새 스킴이 생기거나
+ * 인코딩 우회가 나와도 목록에 없으면 자동으로 막히기 때문이다.
+ */
+const ALLOWED_PROTOCOLS: readonly string[] = ["http:", "https:"];
+
+/**
+ * linkify는 TLD 목록만 보고 판정하므로 setup.sh / demo.zip / clip.mov 같은 파일명도
+ * 링크로 잡는다(.sh .zip .mov 모두 실제 TLD다). 스킴이나 www.를 명시한 경우만
+ * "사용자가 링크로 적은 것"으로 인정해 오탐을 없앤다.
+ */
+const EXPLICIT_LINK = /^(https?:\/\/|www\.)/i;
+
+interface DetectedLink {
+  /** 실제로 열 URL(정규화된 절대 URL) */
+  href: string;
+  /** 버튼에 노출할 짧은 라벨 — 호스트명에서 www. 를 뗀 형태 */
+  label: string;
+}
+
+/**
+ * plain text description에서 열 수 있는 링크를 뽑아낸다.
+ *
+ * 저장 형식은 그대로 string이고, 감지는 이 함수를 호출하는 렌더링 시점에만 일어난다.
+ * 정규식 대신 linkify를 쓰는 이유는 경계 판정 때문이다 — "https://a.com. 확인"의
+ * 마지막 마침표는 문장부호지만 "https://a.com/x." 의 마침표는 경로의 일부일 수 있고,
+ * "(참고: https://a.com)"의 닫는 괄호는 URL이 아니지만 위키백과 URL의 괄호는 URL이다.
+ * 상태 없는 정규식으로는 이 구분이 되지 않는다.
+ */
+export const extractLinks = (text?: string | null): DetectedLink[] => {
+  if (!text) return [];
+
+  const seen = new Set<string>();
+  const links: DetectedLink[] = [];
+
+  for (const token of find(text, { defaultProtocol: "https" })) {
+    // find()는 email 등도 함께 반환한다. 지금 "열기"를 제공할 대상은 URL뿐이다.
+    if (token.type !== "url") continue;
+    if (!EXPLICIT_LINK.test(token.value)) continue;
+
+    let url: URL;
+    try {
+      url = new URL(token.href);
+    } catch {
+      continue;
+    }
+
+    if (!ALLOWED_PROTOCOLS.includes(url.protocol)) continue;
+    if (seen.has(url.href)) continue;
+
+    seen.add(url.href);
+    links.push({ href: url.href, label: url.hostname.replace(/^www\./i, "") });
+  }
+
+  return links;
+};
+
+export type { DetectedLink };

--- a/client/src/shared/utils/descriptionLinks.ts
+++ b/client/src/shared/utils/descriptionLinks.ts
@@ -28,6 +28,33 @@ interface DetectedLink {
   label: string;
 }
 
+/** description을 링크/비링크 구간으로 쪼갠 조각. 하이라이트 렌더링용. */
+interface DescriptionSegment {
+  text: string;
+  isLink: boolean;
+}
+
+type LinkifyMatch = ReturnType<typeof find>[number];
+
+/**
+ * "열어도 되는 링크"의 단일 판정 지점.
+ *
+ * extractLinks(열기 버튼)와 toDescriptionSegments(본문 하이라이트)가 반드시 이 함수를
+ * 공유해야 한다. 두 곳이 갈라지면 "색은 칠해졌는데 버튼에는 안 뜨는" 어긋남이 생기고,
+ * 그건 그 자체로 버그다.
+ */
+const toAllowedUrl = (token: LinkifyMatch): URL | null => {
+  if (token.type !== "url") return null;
+  if (!EXPLICIT_LINK.test(token.value)) return null;
+
+  try {
+    const url = new URL(token.href);
+    return ALLOWED_PROTOCOLS.includes(url.protocol) ? url : null;
+  } catch {
+    return null;
+  }
+};
+
 /**
  * plain text description에서 열 수 있는 링크를 뽑아낸다.
  *
@@ -44,18 +71,10 @@ export const extractLinks = (text?: string | null): DetectedLink[] => {
   const links: DetectedLink[] = [];
 
   for (const token of find(text, { defaultProtocol: "https" })) {
-    // find()는 email 등도 함께 반환한다. 지금 "열기"를 제공할 대상은 URL뿐이다.
-    if (token.type !== "url") continue;
-    if (!EXPLICIT_LINK.test(token.value)) continue;
-
-    let url: URL;
-    try {
-      url = new URL(token.href);
-    } catch {
-      continue;
-    }
-
-    if (!ALLOWED_PROTOCOLS.includes(url.protocol)) continue;
+    const url = toAllowedUrl(token);
+    if (!url) continue;
+    // 같은 URL이 두 번 적혀 있어도 열기 버튼은 하나면 충분하다.
+    // (본문 하이라이트는 요구가 정반대라 toDescriptionSegments에서 중복 제거를 하지 않는다.)
     if (seen.has(url.href)) continue;
 
     seen.add(url.href);
@@ -65,4 +84,35 @@ export const extractLinks = (text?: string | null): DetectedLink[] => {
   return links;
 };
 
-export type { DetectedLink };
+/**
+ * description을 링크/비링크 구간으로 쪼갠다. 본문 하이라이트 렌더링용.
+ *
+ * extractLinks와 달리 (1) 원문 내 위치를 보존하고 (2) 같은 URL이 여러 번 나오면
+ * 그 횟수만큼 반환한다 — 본문에 두 번 적힌 URL은 두 곳 다 칠해져야 하기 때문이다.
+ * 반환된 text 조각을 순서대로 이으면 원문과 정확히 일치한다(하이라이트 오버레이가
+ * textarea와 같은 줄바꿈을 얻으려면 이 성질이 깨지면 안 된다).
+ */
+export const toDescriptionSegments = (text?: string | null): DescriptionSegment[] => {
+  if (!text) return [];
+
+  const segments: DescriptionSegment[] = [];
+  let cursor = 0;
+
+  for (const token of find(text, { defaultProtocol: "https" })) {
+    if (!toAllowedUrl(token)) continue;
+
+    if (token.start > cursor) {
+      segments.push({ text: text.slice(cursor, token.start), isLink: false });
+    }
+    segments.push({ text: text.slice(token.start, token.end), isLink: true });
+    cursor = token.end;
+  }
+
+  if (cursor < text.length) {
+    segments.push({ text: text.slice(cursor), isLink: false });
+  }
+
+  return segments;
+};
+
+export type { DetectedLink, DescriptionSegment };

--- a/client/src/shared/utils/index.ts
+++ b/client/src/shared/utils/index.ts
@@ -11,3 +11,5 @@ export {
 } from "./date";
 export { isDateInTodoRange, getPeriodProgress } from "./dateRange";
 export type { TodoRangeLike, PeriodProgress } from "./dateRange";
+export { extractLinks, DESCRIPTION_MAX_LENGTH } from "./descriptionLinks";
+export type { DetectedLink } from "./descriptionLinks";

--- a/client/src/shared/utils/index.ts
+++ b/client/src/shared/utils/index.ts
@@ -11,5 +11,9 @@ export {
 } from "./date";
 export { isDateInTodoRange, getPeriodProgress } from "./dateRange";
 export type { TodoRangeLike, PeriodProgress } from "./dateRange";
-export { extractLinks, DESCRIPTION_MAX_LENGTH } from "./descriptionLinks";
-export type { DetectedLink } from "./descriptionLinks";
+export {
+  extractLinks,
+  toDescriptionSegments,
+  DESCRIPTION_MAX_LENGTH,
+} from "./descriptionLinks";
+export type { DetectedLink, DescriptionSegment } from "./descriptionLinks";

--- a/firestore.rules
+++ b/firestore.rules
@@ -7,10 +7,19 @@ service cloud.firestore {
       // 상한 2000은 클라이언트의 DESCRIPTION_MAX_LENGTH(shared/utils/descriptionLinks.ts)와
       // 같은 값이어야 한다 — 한쪽만 바꾸면 클라이언트는 통과시키는데 서버가 거부한다.
       function descriptionValid() {
-        return !("description" in request.resource.data)
-               || request.resource.data.description == null
-               || (request.resource.data.description is string
-                   && request.resource.data.description.size() <= 2000);
+        let d = request.resource.data.get("description", null);
+        return d == null || (d is string && d.size() <= 2000);
+      }
+
+      // update의 request.resource.data는 "쓰기 후 문서 전체"다. 즉 description을
+      // 건드리지 않는 부분 업데이트(완료 처리, 마감일 변경, 칸반 재정렬 배치 등)에도
+      // 이 검증이 걸린다. 상한 도입 전에 2000자를 넘겨 저장된 문서가 있다면 그 문서는
+      // 모든 쓰기가 막혀 사용자가 복구할 방법이 없어진다 — writeBatch는 원자적이라
+      // 그런 문서 하나가 재정렬 배치 전체를 실패시킨다.
+      // 그래서 "새 값이 유효하거나, description을 바꾸지 않는 쓰기"를 허용한다.
+      function descriptionUnchanged() {
+        return request.resource.data.get("description", null)
+               == resource.data.get("description", null);
       }
 
       allow read:   if request.auth != null && resource.data.userId == request.auth.uid;
@@ -20,7 +29,7 @@ service cloud.firestore {
       allow update: if request.auth != null
                     && resource.data.userId == request.auth.uid
                     && request.resource.data.userId == resource.data.userId
-                    && descriptionValid();
+                    && (descriptionValid() || descriptionUnchanged());
       allow delete: if request.auth != null && resource.data.userId == request.auth.uid;
     }
   }

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,11 +2,25 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /todos/{todoId} {
+      // description은 선택 필드다. 없거나 null이면 그대로 통과시키고, 값이 있으면
+      // 문자열이면서 길이 상한 이내여야 한다.
+      // 상한 2000은 클라이언트의 DESCRIPTION_MAX_LENGTH(shared/utils/descriptionLinks.ts)와
+      // 같은 값이어야 한다 — 한쪽만 바꾸면 클라이언트는 통과시키는데 서버가 거부한다.
+      function descriptionValid() {
+        return !("description" in request.resource.data)
+               || request.resource.data.description == null
+               || (request.resource.data.description is string
+                   && request.resource.data.description.size() <= 2000);
+      }
+
       allow read:   if request.auth != null && resource.data.userId == request.auth.uid;
-      allow create: if request.auth != null && request.resource.data.userId == request.auth.uid;
+      allow create: if request.auth != null
+                    && request.resource.data.userId == request.auth.uid
+                    && descriptionValid();
       allow update: if request.auth != null
                     && resource.data.userId == request.auth.uid
-                    && request.resource.data.userId == resource.data.userId;
+                    && request.resource.data.userId == resource.data.userId
+                    && descriptionValid();
       allow delete: if request.auth != null && resource.data.userId == request.auth.uid;
     }
   }


### PR DESCRIPTION
## Summary

설명(description)에 줄바꿈을 입력할 수 없고, 입력해도 어디에도 표시되지 않던 문제를 먼저 해결하고, 그 위에 "적어둔 URL을 클릭해서 열기"를 얹었습니다.

**Phase 1 — 입력/표시**
- 빠른 추가 폼 설명: 한 줄 `<input>` → `<textarea>` + auto-grow (`min-height`로 빈 상태에서도 2줄 어포던스 유지)
- 상세 패널 textarea도 auto-grow (수동 resize 핸들은 auto-grow와 서로 싸우므로 제거)
- today 리스트: `nowrap` → `pre-wrap` + 2줄 clamp — 줄바꿈은 보존하되 행 높이는 제한
- description 2000자 상한을 클라이언트 검증과 `firestore.rules` 양쪽에 (두 값은 반드시 동기화)

**링크 열기 — 설명 라벨 행 액션**
- 저장 형식은 `description: string` 그대로. 감지는 렌더링 시점에만 일어나므로 마이그레이션이 없고 라이브러리를 빼면 즉시 원상복구됩니다
- 링크 활성화 타깃을 본문 밖(라벨 행 우측)으로 분리 — 본문 안에서 활성화하면 캐럿 배치 클릭과 링크 클릭이 같은 좌표에서 경쟁하고, 모바일에서 문장을 고치려다 외부 사이트가 열리면 미저장 폼이 날아갑니다. 라벨 행을 쓰므로 세로 공간도 추가로 쓰지 않습니다
- 링크 0개면 아무것도 렌더하지 않아 기존 화면과 동일
- today 리스트는 링크화 대신 🔗 인디케이터만 — 행 전체가 상세 진입 영역이라 잘린 URL을 탭 타깃으로 만들면 두 액션이 충돌합니다

**본문 URL 색상 구분 — 포커스 인지형 오버레이**
- 비포커스: 텍스트 투명 + 오버레이 ON / 포커스: 순정 textarea + 오버레이 OFF
- 한글 IME 조합·캐럿·드래그 선택은 전부 포커스 상태에서만 일어나므로, 그 상태에서 네이티브 동작을 그대로 씁니다. 조합 중 글자 소실이 **발생할 수 없는 구조**입니다
- 두 레이어가 동시에 보이는 순간이 없어 줄바꿈이 어긋나도 고스팅이 불가능합니다
- CSS `:focus-within`만 사용 — 상태 0개, 추가 리렌더 0회

## 함께 고친 것

**접근성** — 링크 액션 트리거가 `brand.secondary`(#1D9E75)였는데 흰 배경 대비 **3.39:1로 WCAG AA(4.5:1) 미달**이었습니다(13px는 large text가 아님). `brand.primary`(#0F6E56, 6.20:1) + tint pill(#E8F5EF 위 5.54:1)로 변경. 본문 하이라이트는 #0F6E56과 본문색(#1A1A1A)의 대비가 2.81:1이라 색만으로는 구분이 보장되지 않아 **밑줄을 함께** 줍니다.

**Firefox auto-grow 미동작** — Firefox는 `height:auto`를 반영한 레이아웃을 즉시 계산하지 않아 `scrollHeight`가 직전 높이를 반환합니다(98 vs 리플로우 후 192). 즉 auto-grow가 Firefox에서 아예 동작하지 않고 있었습니다. `void el.offsetHeight;`로 리플로우를 강제해 해결했고, no-op처럼 보여 지워지기 쉬우므로 **읽는 순서를 고정하는 회귀 테스트**를 함께 넣었습니다.

## 왜 이 방식인가 (반려한 안)

- **마크다운/WYSIWYG** — 각각 +47kB / +124kB이고 WYSIWYG의 JSON 저장은 되돌릴 수 없습니다. plain string은 나중에 마크다운으로 가는 문이 열려 있습니다(렌더러만 교체)
- **HTML 저장** — sanitizer 우회가 발견되면 과거 데이터 전체가 소급 오염됩니다
- **click-to-edit** — 편집 종료 시 붙일 커밋 지점이 없습니다. 전체 폼 저장은 패널을 닫고 반복 시리즈 확인 모달까지 띄우며, 부분 저장은 `editTodo`가 통째 쓰기라 다른 필드의 미저장 변경을 덮어씁니다. 또 6개 필드 중 설명만 모드가 생기는 국소 불일치가 됩니다

## 검증

- [x] lint(0 error), 타입체크, 빌드, 유닛테스트 **414개**(신규 29개 포함) 전체 통과
- [x] **Chromium / WebKit / Firefox 3개 엔진에서 오버레이 정렬 실측 — 넘침 0건, 줄바꿈 지점 일치**
      (200자 무공백 URL, 공백 없는 한글, 다중 개행, CJK 혼용 등 8개 샘플. jsdom은 레이아웃 엔진이 없어 이 검증이 원리적으로 불가능하므로 동일 CSS 복제 하네스로 측정)
- [x] linkify 경계 판정 테스트: 문장 끝 마침표 제외, 문장 괄호 vs URL 괄호 구분, `setup.sh`/`demo.zip`/`clip.mov` 오탐 차단, `javascript:` 차단
- [x] 기존 `todoDetail.test.tsx` 단언 그대로 통과 (click-to-edit이었다면 깨졌을 테스트)
- [x] 번들 gzip 384.46 → 397.48kB (**+13.02kB, +3.4%**). 신규 의존성은 `linkifyjs` 하나

## Test plan

- [ ] 실제 앱에서 육안 확인 — Firebase 로그인이 필요해 자동 확인은 못 했습니다. 특히 **포커스 전환 시 색 변화의 체감**, "더보기" 접힘/펼침 시 textarea 높이, 팝오버가 패널 스크롤에서 잘리지 않는지
- [ ] `firestore.rules` 배포 후 2000자 초과 쓰기가 실제로 거부되는지 확인

## 함께 고친 데이터 유실 버그 (a0ca8dc)

`todoDetail`의 `useForm`이 `defaultValues`가 아닌 **`values` prop** 기반이라, 넘긴 객체가 달라지면 폼 전체를 서버 값으로 되돌립니다. 그런데 그 리셋을 유발하는 기능이 **같은 패널 안에** 있습니다.

```
설명 타이핑 중
  → 하위 할 일 추가
  → createChildTodo가 calcParentStatus로 부모 status/doneAt 재계산
  → ["todoDetail"] 무효화 → refetch → values.status 변경
  → 폼 전체 리셋 → 입력 중이던 설명 소실
```

`values` 객체가 `updatedAt`을 담지 않아 평범한 refetch로는 재현되지 않고, **status가 바뀌는 경로에서만** 터져서 눈에 잘 띄지 않았습니다. `resetOptions: { keepDirtyValues: true }`로 사용자가 건드린 필드만 지키고, 나머지는 그대로 서버 값을 따라갑니다.

- [x] 재현 테스트를 **먼저 만들어 수정 전 실패를 확인**한 뒤 수정
- [x] 반대 방향 테스트도 추가 — "건드리지 않은 필드는 서버 값으로 갱신된다". `values` 동기화를 통째로 끄는 식의 잘못된 수정이면 이쪽이 깨집니다
- [x] 기존 mock이 모듈 최상단 고정 객체를 반환해 "서버 데이터 갱신" 상황 자체를 재현할 수 없었음 → `vi.hoisted` 가변 홀더로 교체
- [x] `rerender`에 같은 엘리먼트 객체를 넘기면 React가 참조 동일성으로 서브트리를 건너뛰어 **테스트가 거짓 통과**합니다. 매번 새 엘리먼트를 만들도록 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)
