### PR TITLE
perf: 라우트 코드 스플리팅 + Firebase auth/firestore 경계 분리 (초기 번들 -56.6%)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,17 @@ jobs:
         run: npx tsc -b
 
       - name: Build
+        env:
+          # 아래 Bundle budget 검사가 "실제로 배포되는 번들"과 같은 모양을 재도록 넣는
+          # 자리표시자 DSN이다. 이 값이 없으면 sentry.ts의 `if (!dsn) return`이 빌드
+          # 타임에 상수 폴딩되면서, initSentry 안에서만 참조되는 Sentry
+          # tracing/replay 인테그레이션이 통째로 트리셰이킹된다(gzip 약 26 kB).
+          # 그러면 CI가 재는 초기 페이로드가 배포본보다 그만큼 작아져, 예산에 유령
+          # 여유가 생기고 실제 회귀를 놓친다.
+          #
+          # 빌드 타임에 문자열로 인라인될 뿐 아무것도 실행되지 않고, 이 job의 산출물은
+          # 배포되지 않는다(배포는 아래 deploy job이 진짜 시크릿으로 다시 빌드한다).
+          VITE_SENTRY_DSN: https://examplePublicKey@o0.ingest.sentry.io/0
         run: npm run build
 
       # 라우트 lazy 분할이 풀리거나 무거운 의존성이 초기 경로에 들어오면 실패한다.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,11 @@ jobs:
       - name: Build
         run: npm run build
 
+      # 라우트 lazy 분할이 풀리거나 무거운 의존성이 초기 경로에 들어오면 실패한다.
+      # 예산값과 근거는 client/bundle-budget.json 참고.
+      - name: Bundle budget
+        run: npm run check:bundle
+
       # setup.ts가 TZ 미지정 시 Asia/Seoul(UTC+9)로 고정하므로 기본 실행이 양수 오프셋 검증,
       # 아래 스텝이 음수 오프셋 검증을 담당한다. CI(UTC)에서 타임존 버그가 숨는 것을 막는다.
       - name: Unit Test

--- a/client/bundle-budget.json
+++ b/client/bundle-budget.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "초기 다운로드 페이로드(index.html이 직접 참조하는 JS+CSS)의 gzip 상한. scripts/checkBundleBudget.mjs가 빌드 후 검사한다. 2026-08-10 코드 스플리팅 도입 시점 실측 177,157 bytes(173.00 kB) 기준 약 10% 여유. 의도적으로 늘려야 할 때만 근거와 함께 올릴 것.",
+  "initialGzipBytes": 195000
+}

--- a/client/package.json
+++ b/client/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "check:bundle": "node scripts/checkBundleBudget.mjs",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",

--- a/client/scripts/checkBundleBudget.mjs
+++ b/client/scripts/checkBundleBudget.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * 초기 다운로드 페이로드에 gzip 예산을 강제한다.
+ *
+ * 왜 index.html을 파싱하는가: 브라우저가 첫 로드에 실제로 받는 파일은 "dist/assets 전체"가
+ * 아니라 엔트리 스크립트 + 그 정적 의존성(Vite가 modulepreload로 심어둔 것) + 렌더 블로킹
+ * 스타일시트다. lazy 청크는 여기 안 나타난다. 그래서 index.html의 태그 집합이 곧 예산
+ * 대상이며, 이 방식이라야 "라우트를 lazy로 쪼갰다"는 사실이 숫자에 정직하게 반영된다.
+ *
+ * 이 검사가 잡아내려는 회귀: router.tsx에서 lazy를 정적 import로 되돌리거나,
+ * shared/lib/firebase.ts에 getFirestore를 다시 넣거나, 무거운 의존성을 초기 경로에
+ * 추가하는 변경. 셋 다 엔트리 청크를 눈에 띄게 부풀린다.
+ */
+import { readFileSync, existsSync } from "node:fs";
+import { gzipSync } from "node:zlib";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const clientDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const distDir = path.join(clientDir, "dist");
+const indexHtml = path.join(distDir, "index.html");
+const budgetFile = path.join(clientDir, "bundle-budget.json");
+
+const fail = (message) => {
+  console.error(`\n✖ ${message}\n`);
+  process.exit(1);
+};
+
+if (!existsSync(indexHtml)) {
+  fail(`dist/index.html이 없습니다. 먼저 \`npm run build\`를 실행하세요.`);
+}
+
+const html = readFileSync(indexHtml, "utf8");
+
+// 엔트리 스크립트, modulepreload, 렌더 블로킹 스타일시트를 모은다.
+// 속성 순서가 고정이 아니므로 태그 단위로 잘라낸 뒤 src/href를 뽑는다.
+const collectAssets = () => {
+  const found = [];
+  const tagRe = /<(script|link)\b[^>]*>/gi;
+  for (const [tag] of html.matchAll(tagRe)) {
+    const isModuleScript =
+      /^<script/i.test(tag) && /type=["']module["']/i.test(tag);
+    const rel = tag.match(/rel=["']([^"']+)["']/i)?.[1];
+    const isPreload = rel === "modulepreload";
+    const isStylesheet = rel === "stylesheet";
+    if (!isModuleScript && !isPreload && !isStylesheet) continue;
+
+    const url = tag.match(/(?:src|href)=["']([^"']+)["']/i)?.[1];
+    // 외부 CDN(폰트 등)은 우리 번들이 아니므로 제외한다.
+    if (!url || !url.startsWith("/")) continue;
+    found.push(url);
+  }
+  return [...new Set(found)];
+};
+
+const assets = collectAssets();
+if (assets.length === 0) {
+  fail("index.html에서 초기 에셋을 하나도 찾지 못했습니다. 파서를 확인하세요.");
+}
+
+const rows = assets.map((url) => {
+  const filePath = path.join(distDir, url.replace(/^\//, ""));
+  if (!existsSync(filePath)) {
+    fail(`index.html이 참조하는 ${url} 파일이 dist에 없습니다.`);
+  }
+  const raw = readFileSync(filePath);
+  return {
+    url,
+    rawBytes: raw.length,
+    gzipBytes: gzipSync(raw, { level: 9 }).length,
+  };
+});
+
+const totalGzip = rows.reduce((sum, r) => sum + r.gzipBytes, 0);
+
+if (!existsSync(budgetFile)) {
+  fail(`bundle-budget.json이 없습니다. 측정된 초기 gzip: ${totalGzip} bytes`);
+}
+const { initialGzipBytes: budget } = JSON.parse(readFileSync(budgetFile, "utf8"));
+if (typeof budget !== "number") {
+  fail("bundle-budget.json의 initialGzipBytes가 숫자가 아닙니다.");
+}
+
+const kb = (n) => `${(n / 1024).toFixed(2)} kB`;
+
+console.log("\n초기 다운로드 페이로드 (index.html이 직접 참조하는 파일)\n");
+for (const r of rows.sort((a, b) => b.gzipBytes - a.gzipBytes)) {
+  console.log(`  ${r.url.padEnd(44)} ${kb(r.rawBytes).padStart(11)}  gzip ${kb(r.gzipBytes).padStart(10)}`);
+}
+console.log(`  ${" ".repeat(57)}${"─".repeat(15)}`);
+console.log(`  ${"합계".padEnd(56)} gzip ${kb(totalGzip).padStart(10)}`);
+console.log(`  ${"예산".padEnd(56)}      ${kb(budget).padStart(10)}`);
+
+const diff = totalGzip - budget;
+if (diff > 0) {
+  fail(
+    `초기 페이로드가 예산을 ${kb(diff)} 초과했습니다 (${kb(totalGzip)} > ${kb(budget)}).\n` +
+      `  라우트 lazy 분할이 풀렸거나(router.tsx), 무거운 의존성이 초기 경로에 들어왔을 수 있습니다.\n` +
+      `  의도한 증가라면 client/bundle-budget.json의 initialGzipBytes를 근거와 함께 올리세요.`,
+  );
+}
+
+const headroom = ((-diff / budget) * 100).toFixed(1);
+console.log(`\n✔ 예산 이내 (여유 ${kb(-diff)}, ${headroom}%)\n`);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,7 +12,10 @@ import BottomTabBar from "@/layouts/bottomTabBar/bottomTabBar";
 import { BOTTOM_TAB_BAR_HEIGHT } from "@/layouts/bottomTabBar/bottomTabBar.styles";
 import styled from "styled-components";
 import { useMediaQuery } from "@/shared/hooks";
-import { useTodo } from "@/features/todo";
+// @/features/todo 배럴은 TodoList/TodoDetail/TodoForm까지 재수출한다. App 청크는
+// 모든 보호 라우트의 공통 경로라 여기 들어가는 건 전부 크리티컬 패스이므로,
+// 실제로 쓰는 훅만 직접 가져온다.
+import { useTodo } from "@/features/todo/hooks";
 
 const App = () => {
   const [isopen, setIsOpen] = useState(true);

--- a/client/src/features/auth/components/__tests__/protectedRoute.test.tsx
+++ b/client/src/features/auth/components/__tests__/protectedRoute.test.tsx
@@ -8,6 +8,9 @@ import type { User } from 'firebase/auth'
 vi.mock('@/shared/lib/firebase', () => ({
   auth: {},
   googleProvider: {},
+}))
+
+vi.mock('@/shared/lib/firestore', () => ({
   db: {},
 }))
 

--- a/client/src/features/auth/components/__tests__/rootGate.test.tsx
+++ b/client/src/features/auth/components/__tests__/rootGate.test.tsx
@@ -8,6 +8,9 @@ import type { User } from 'firebase/auth'
 vi.mock('@/shared/lib/firebase', () => ({
   auth: {},
   googleProvider: {},
+}))
+
+vi.mock('@/shared/lib/firestore', () => ({
   db: {},
 }))
 
@@ -44,7 +47,8 @@ describe('RootGate 컴포넌트', () => {
     expect(screen.queryByText('랜딩 페이지')).not.toBeInTheDocument()
   })
 
-  it('비로그인 사용자는 랜딩 페이지를 볼 수 있어야 한다', () => {
+  // 랜딩 페이지는 lazy 로드되므로 Suspense가 풀린 뒤에야 나타난다.
+  it('비로그인 사용자는 랜딩 페이지를 볼 수 있어야 한다', async () => {
     render(
       <MemoryRouter initialEntries={['/']}>
         <AuthContext.Provider value={mockAuthContext(null)}>
@@ -56,7 +60,7 @@ describe('RootGate 컴포넌트', () => {
       </MemoryRouter>,
     )
 
-    expect(screen.getByText('랜딩 페이지')).toBeInTheDocument()
+    expect(await screen.findByText('랜딩 페이지')).toBeInTheDocument()
     expect(screen.queryByText('투데이 페이지')).not.toBeInTheDocument()
   })
 

--- a/client/src/features/auth/components/rootGate.tsx
+++ b/client/src/features/auth/components/rootGate.tsx
@@ -1,6 +1,10 @@
+import { lazy, Suspense } from "react";
 import { Navigate } from "react-router-dom";
 import { useAuth } from "../context/useAuth";
-import LandingPage from "@/features/landing/pages/landingPage";
+
+// RootGate 자체는 최초 라우팅 판단에 필요해 eager지만, 랜딩 페이지는 로그인한
+// 사용자가 절대 보지 않는 화면이므로 lazy로 둔다.
+const LandingPage = lazy(() => import("@/features/landing/pages/landingPage"));
 
 /**
  * "/" 전용 게이트. ProtectedRoute와 대칭되는 컴포넌트로, 인증 로딩 중에는
@@ -13,7 +17,11 @@ const RootGate = () => {
 
   if (loading) return null;
   if (user) return <Navigate to="/today" replace />;
-  return <LandingPage />;
+  return (
+    <Suspense fallback={null}>
+      <LandingPage />
+    </Suspense>
+  );
 };
 
 export default RootGate;

--- a/client/src/features/auth/context/__tests__/authProvider.test.tsx
+++ b/client/src/features/auth/context/__tests__/authProvider.test.tsx
@@ -10,6 +10,9 @@ let authStateCallback: ((user: User | null) => void) | null = null
 vi.mock('@/shared/lib/firebase', () => ({
   auth: {},
   googleProvider: {},
+}))
+
+vi.mock('@/shared/lib/firestore', () => ({
   db: {},
 }))
 

--- a/client/src/features/dashboard/components/__tests__/calendar.test.tsx
+++ b/client/src/features/dashboard/components/__tests__/calendar.test.tsx
@@ -4,9 +4,12 @@ import { MemoryRouter } from 'react-router-dom'
 import Calendar from '../calendar'
 
 vi.mock('@/shared/lib/firebase', () => ({
-  db: {},
   auth: { currentUser: null },
   googleProvider: {},
+}))
+
+vi.mock('@/shared/lib/firestore', () => ({
+  db: {},
 }))
 
 const { mockTodos } = vi.hoisted(() => {

--- a/client/src/features/today/components/__tests__/todayTodoItem.test.tsx
+++ b/client/src/features/today/components/__tests__/todayTodoItem.test.tsx
@@ -5,9 +5,12 @@ import TodayTodoItem from '../todayTodoItem'
 import type { Todo } from '@/features/todo/types/todo.type'
 
 vi.mock('@/shared/lib/firebase', () => ({
-  db: {},
   auth: { currentUser: null },
   googleProvider: {},
+}))
+
+vi.mock('@/shared/lib/firestore', () => ({
+  db: {},
 }))
 
 const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({

--- a/client/src/features/today/hooks/__tests__/useTodayTodos.test.tsx
+++ b/client/src/features/today/hooks/__tests__/useTodayTodos.test.tsx
@@ -7,11 +7,14 @@ import type { Todo } from '@/features/todo/types/todo.type'
 
 // Firebase 모킹
 vi.mock('@/shared/lib/firebase', () => ({
-  db: {},
   auth: {
     currentUser: { uid: 'test-user-id' },
   },
   googleProvider: {},
+}))
+
+vi.mock('@/shared/lib/firestore', () => ({
+  db: {},
 }))
 
 // todoApi 모킹

--- a/client/src/features/today/pages/__tests__/todayPage.test.tsx
+++ b/client/src/features/today/pages/__tests__/todayPage.test.tsx
@@ -8,9 +8,12 @@ import type { Todo } from '@/features/todo/types/todo.type'
 import type { UseTodayTodosResult } from '../../hooks/useTodayTodos'
 
 vi.mock('@/shared/lib/firebase', () => ({
-  db: {},
   auth: { currentUser: null },
   googleProvider: {},
+}))
+
+vi.mock('@/shared/lib/firestore', () => ({
+  db: {},
 }))
 
 vi.mock('../../hooks/useTodayTodos', () => ({

--- a/client/src/features/todo/api/__tests__/recurringTodoApi.test.ts
+++ b/client/src/features/todo/api/__tests__/recurringTodoApi.test.ts
@@ -15,11 +15,14 @@ afterEach(() => {
 
 // Firebase 모킹 - 실제 Firebase에 연결하지 않도록 처리
 vi.mock("@/shared/lib/firebase", () => ({
-  db: {},
   auth: {
     currentUser: { uid: "test-user-id" },
   },
   googleProvider: {},
+}));
+
+vi.mock("@/shared/lib/firestore", () => ({
+  db: {},
 }));
 
 let autoIdCounter = 0;

--- a/client/src/features/todo/api/__tests__/sweepArchivedTodos.test.ts
+++ b/client/src/features/todo/api/__tests__/sweepArchivedTodos.test.ts
@@ -11,11 +11,14 @@ afterEach(() => {
 });
 
 vi.mock("@/shared/lib/firebase", () => ({
-  db: {},
   auth: {
     currentUser: { uid: "test-user-id" },
   },
   googleProvider: {},
+}));
+
+vi.mock("@/shared/lib/firestore", () => ({
+  db: {},
 }));
 
 vi.mock("firebase/firestore", () => ({

--- a/client/src/features/todo/api/__tests__/sweepOverdueRecurringTodos.test.ts
+++ b/client/src/features/todo/api/__tests__/sweepOverdueRecurringTodos.test.ts
@@ -2,11 +2,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Todo } from "../../types/todo.type";
 
 vi.mock("@/shared/lib/firebase", () => ({
-  db: {},
   auth: {
     currentUser: { uid: "test-user-id" },
   },
   googleProvider: {},
+}));
+
+vi.mock("@/shared/lib/firestore", () => ({
+  db: {},
 }));
 
 vi.mock("firebase/firestore", () => ({

--- a/client/src/features/todo/api/__tests__/todoApi.test.ts
+++ b/client/src/features/todo/api/__tests__/todoApi.test.ts
@@ -3,11 +3,14 @@ import type { Todo } from '../../types/todo.type'
 
 // Firebase 모킹 - 실제 Firebase에 연결하지 않도록 처리
 vi.mock('@/shared/lib/firebase', () => ({
-  db: {},
   auth: {
     currentUser: { uid: 'test-user-id' },
   },
   googleProvider: {},
+}))
+
+vi.mock('@/shared/lib/firestore', () => ({
+  db: {},
 }))
 
 vi.mock('firebase/firestore', () => ({

--- a/client/src/features/todo/api/__tests__/todoApiDataIntegrity.test.ts
+++ b/client/src/features/todo/api/__tests__/todoApiDataIntegrity.test.ts
@@ -12,11 +12,14 @@ import type { Todo, RecurrenceRule } from "../../types/todo.type";
 // (2026-07-11 작성 시점에 실제로 확인함).
 
 vi.mock("@/shared/lib/firebase", () => ({
-  db: {},
   auth: {
     currentUser: { uid: "test-user-id" },
   },
   googleProvider: {},
+}));
+
+vi.mock("@/shared/lib/firestore", () => ({
+  db: {},
 }));
 
 let autoIdCounter = 0;

--- a/client/src/features/todo/api/todoApi.ts
+++ b/client/src/features/todo/api/todoApi.ts
@@ -9,7 +9,8 @@ import {
   getDoc,
   writeBatch,
 } from "firebase/firestore";
-import { db, auth } from "@/shared/lib/firebase";
+import { auth } from "@/shared/lib/firebase";
+import { db } from "@/shared/lib/firestore";
 import { toDateKeyFromISO } from "@/shared/utils/date";
 import type { RecurrenceRule, Todo, TodoReorderUpdate } from "../types/todo.type";
 import { generateRecurringDueDates, getDefaultHorizonEnd } from "../utils/recurrence";

--- a/client/src/features/todo/components/__tests__/dueTodo.test.tsx
+++ b/client/src/features/todo/components/__tests__/dueTodo.test.tsx
@@ -5,9 +5,12 @@ import DueTodo from '../dueTodo'
 import type { Todo } from '../../types/todo.type'
 
 vi.mock('@/shared/lib/firebase', () => ({
-  db: {},
   auth: { currentUser: null },
   googleProvider: {},
+}))
+
+vi.mock('@/shared/lib/firestore', () => ({
+  db: {},
 }))
 
 const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({

--- a/client/src/features/todo/components/todoDetail/__tests__/todoDetail.test.tsx
+++ b/client/src/features/todo/components/todoDetail/__tests__/todoDetail.test.tsx
@@ -7,9 +7,12 @@ import { ToastProvider } from '@/shared/ui/toast/toastContext'
 import { setupUser } from '@/test/setupUser'
 
 vi.mock('@/shared/lib/firebase', () => ({
-  db: {},
   auth: { currentUser: null },
   googleProvider: {},
+}))
+
+vi.mock('@/shared/lib/firestore', () => ({
+  db: {},
 }))
 
 const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({

--- a/client/src/features/todo/hooks/__tests__/useSearchTodo.test.tsx
+++ b/client/src/features/todo/hooks/__tests__/useSearchTodo.test.tsx
@@ -6,11 +6,14 @@ import { useSearchTodo } from '../useSearchTodo'
 import type { Todo } from '../../types/todo.type'
 
 vi.mock('@/shared/lib/firebase', () => ({
-  db: {},
   auth: {
     currentUser: { uid: 'test-user-id' },
   },
   googleProvider: {},
+}))
+
+vi.mock('@/shared/lib/firestore', () => ({
+  db: {},
 }))
 
 vi.mock('../../api', () => ({

--- a/client/src/features/todo/hooks/__tests__/useTodo.test.tsx
+++ b/client/src/features/todo/hooks/__tests__/useTodo.test.tsx
@@ -7,11 +7,14 @@ import type { Todo } from '../../types/todo.type'
 
 // Firebase 모킹
 vi.mock('@/shared/lib/firebase', () => ({
-  db: {},
   auth: {
     currentUser: { uid: 'test-user-id' },
   },
   googleProvider: {},
+}))
+
+vi.mock('@/shared/lib/firestore', () => ({
+  db: {},
 }))
 
 // todoApi 모킹

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -5,7 +5,11 @@ import "./index.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { RouterProvider } from "react-router-dom";
-import { ToastProvider, ErrorBoundary } from "@/shared";
+// @/shared 배럴 대신 직접 경로를 쓴다. 배럴은 ui/hooks/utils 전체를 초기 청크의
+// 모듈 그래프에 올리는데, 그 안의 utils/descriptionLinks → linkifyjs는 부피
+// 대부분이 TLD 데이터 테이블이라 트리셰이킹이 한 번만 어긋나도 통째로 딸려온다.
+import { ToastProvider } from "@/shared/ui/toast/toastContext";
+import ErrorBoundary from "@/shared/ui/errorBoundary/errorBoundary";
 import { AuthProvider } from "@/features/auth/context/authProvider";
 import { initSentry } from "@/shared/lib/sentry";
 import { router } from "./router";

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -1,19 +1,46 @@
+import { lazy, Suspense, type ReactNode } from "react";
 import { createBrowserRouter } from "react-router-dom";
-import App from "@/App";
-import TodoListPage from "@/features/todo/pages/todoListPage";
-import CalendarPage from "@/features/dashboard/Pages/calendarPage";
-import KanbanPage from "@/features/kanban/pages/kanbanPage";
-import { TodoDetail } from "@/features/todo";
-import LoginPage from "@/features/auth/pages/loginPage";
 import ProtectedRoute from "@/features/auth/components/protectedRoute";
 import RootGate from "@/features/auth/components/rootGate";
-import TodayPage from "@/features/today/pages/todayPage";
-import GuestTodayPage from "@/features/guest/pages/guestTodayPage";
+import CheckboxSkeleton from "@/shared/ui/skeleton/checkboxSkeleton";
+import KanbanSkeleton from "@/shared/ui/skeleton/kanbanSkeleton";
+import TodayItemSkeleton from "@/shared/ui/skeleton/todayItemSkeleton";
+import CalendarSkeleton from "@/shared/ui/skeleton/calendarSkeleton";
+
+// 라우트 컴포넌트는 전부 lazy로 둔다. 정적 import 하나만 되살아나도 해당 라우트의
+// 의존성(FullCalendar, dnd-kit, Firestore 등)이 통째로 초기 청크로 딸려온다.
+//
+// App(인증 레이아웃)을 lazy로 두는 것이 특히 중요하다. App은 useTodo를 통해 할 일
+// 도메인 → todoApi → Firestore로 이어지므로, eager로 두면 로그인 전 화면에서도
+// Firestore SDK를 내려받게 된다.
+//
+// ProtectedRoute / RootGate만 eager다. 최초 라우팅 판단에 즉시 필요하고 auth 외
+// 의존성이 없어 비용이 사실상 0이다.
+const App = lazy(() => import("@/App"));
+const LoginPage = lazy(() => import("@/features/auth/pages/loginPage"));
+const GuestTodayPage = lazy(
+  () => import("@/features/guest/pages/guestTodayPage"),
+);
+const TodayPage = lazy(() => import("@/features/today/pages/todayPage"));
+const TodoListPage = lazy(() => import("@/features/todo/pages/todoListPage"));
+const TodoDetail = lazy(
+  () => import("@/features/todo/components/todoDetail/todoDetail"),
+);
+const CalendarPage = lazy(
+  () => import("@/features/dashboard/Pages/calendarPage"),
+);
+const KanbanPage = lazy(() => import("@/features/kanban/pages/kanbanPage"));
+
+// 청크를 받는 동안 보여줄 것. fallback이 null인 곳은 ProtectedRoute/RootGate가
+// 인증 로딩 중 null을 반환하는 기존 컨벤션과 맞춘 것이다(깜빡임 방지).
+const withSuspense = (element: ReactNode, fallback: ReactNode = null) => (
+  <Suspense fallback={fallback}>{element}</Suspense>
+);
 
 export const router = createBrowserRouter([
   {
     path: "/login",
-    element: <LoginPage />,
+    element: withSuspense(<LoginPage />),
   },
   {
     path: "/",
@@ -21,34 +48,34 @@ export const router = createBrowserRouter([
   },
   {
     path: "/guest",
-    element: <GuestTodayPage />,
+    element: withSuspense(<GuestTodayPage />),
   },
   {
+    // Suspense가 2단인 이유: 바깥은 App 셸(헤더/SNB/푸터), 안쪽은 페이지 본문이다.
+    // 셸 청크는 최초 1회만 받으므로 이후 라우트 이동에서는 안쪽 스켈레톤만 교체된다.
     element: (
-      <ProtectedRoute>
-        <App />
-      </ProtectedRoute>
+      <ProtectedRoute>{withSuspense(<App />)}</ProtectedRoute>
     ),
     children: [
       {
         path: "today",
-        element: <TodayPage />,
+        element: withSuspense(<TodayPage />, <TodayItemSkeleton />),
       },
       {
         path: "todo/:id",
-        element: <TodoDetail />,
+        element: withSuspense(<TodoDetail />, <CheckboxSkeleton count={3} />),
       },
       {
         path: "todo",
-        element: <TodoListPage />,
+        element: withSuspense(<TodoListPage />, <CheckboxSkeleton count={5} />),
       },
       {
         path: "calendar",
-        element: <CalendarPage />,
+        element: withSuspense(<CalendarPage />, <CalendarSkeleton />),
       },
       {
         path: "kanban",
-        element: <KanbanPage />,
+        element: withSuspense(<KanbanPage />, <KanbanSkeleton />),
       },
     ],
   },

--- a/client/src/shared/lib/firebase.ts
+++ b/client/src/shared/lib/firebase.ts
@@ -1,29 +1,18 @@
-import { initializeApp } from "firebase/app";
 import { getAuth, GoogleAuthProvider, connectAuthEmulator } from "firebase/auth";
-import { getFirestore, connectFirestoreEmulator } from "firebase/firestore";
+import { app, isEmulator } from "./firebaseApp";
 
-const firebaseConfig = {
-  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
-  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
-  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
-  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
-  appId: import.meta.env.VITE_FIREBASE_APP_ID,
-  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
-};
-
-const app = initializeApp(firebaseConfig);
+// ⚠️ 이 모듈은 Firebase **Auth 전용**이다. Firestore는 `./firestore`에 따로 있다.
+//
+// AuthProvider가 앱 진입 시점에 이 모듈을 정적으로 import하기 때문에, 여기 있는 것은
+// 전부 초기 청크에 들어간다. 여기서 `getFirestore`를 다시 import하면 라우트를 아무리
+// lazy로 쪼개도 Firestore SDK(gzip 기준 수십 kB)가 초기 다운로드로 되돌아온다.
+// 랜딩/로그인 화면만 보는 방문자는 Firestore를 전혀 쓰지 않는다.
+//
+// Firestore가 필요하면 `import { db } from "@/shared/lib/firestore"`를 쓸 것.
 
 export const auth = getAuth(app);
 export const googleProvider = new GoogleAuthProvider();
-export const db = getFirestore(app);
 
-// E2E(Playwright) 전용 스위치. 실제 Google OAuth 팝업을 띄울 수 없는 headless
-// 브라우저에서 로그인 이후 플로우(할 일 생성/완료, 칸반 드래그, 캘린더)를
-// 검증하기 위해, 로컬 Firebase Auth/Firestore 에뮬레이터에 연결한다.
-// VITE_USE_FIREBASE_EMULATOR가 설정되지 않으면(일반 dev/prod 빌드) 이 블록은
-// 전혀 실행되지 않으므로 실 서비스 동작에는 영향이 없다.
-if (import.meta.env.VITE_USE_FIREBASE_EMULATOR === "true") {
+if (isEmulator) {
   connectAuthEmulator(auth, "http://127.0.0.1:9099", { disableWarnings: true });
-  connectFirestoreEmulator(db, "127.0.0.1", 8080);
 }

--- a/client/src/shared/lib/firebaseApp.ts
+++ b/client/src/shared/lib/firebaseApp.ts
@@ -1,0 +1,21 @@
+import { initializeApp } from "firebase/app";
+
+const firebaseConfig = {
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID,
+  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
+};
+
+export const app = initializeApp(firebaseConfig);
+
+// E2E(Playwright) 전용 스위치. 실제 Google OAuth 팝업을 띄울 수 없는 headless
+// 브라우저에서 로그인 이후 플로우(할 일 생성/완료, 칸반 드래그, 캘린더)를
+// 검증하기 위해, 로컬 Firebase Auth/Firestore 에뮬레이터에 연결한다.
+// 일반 dev/prod 빌드에서는 false이므로 실 서비스 동작에 영향이 없다.
+// 실제 연결은 auth/firestore를 각각 초기화하는 firebase.ts, firestore.ts에서 한다.
+export const isEmulator =
+  import.meta.env.VITE_USE_FIREBASE_EMULATOR === "true";

--- a/client/src/shared/lib/firestore.ts
+++ b/client/src/shared/lib/firestore.ts
@@ -1,0 +1,13 @@
+import { getFirestore, connectFirestoreEmulator } from "firebase/firestore";
+import { app, isEmulator } from "./firebaseApp";
+
+// Firestore SDK는 Firebase 의존성 중 가장 무거운 축에 속한다. Auth(`./firebase`)와
+// 분리해 둔 이유는, 이 모듈을 데이터 계층(todoApi 등)에서만 import하게 만들어
+// lazy 라우트 청크로 밀어내기 위해서다. 로그인 이전 경로(랜딩/로그인)에서는
+// 이 모듈에 닿는 정적 import 경로가 없어야 한다.
+
+export const db = getFirestore(app);
+
+if (isEmulator) {
+  connectFirestoreEmulator(db, "127.0.0.1", 8080);
+}

--- a/client/src/shared/ui/index.ts
+++ b/client/src/shared/ui/index.ts
@@ -5,6 +5,7 @@ export { default as ConfirmModal } from "./confirmModal/confirmModal";
 export { default as EmptyState } from "./emptyState/emptyState";
 export { default as CheckboxSkeleton } from "./skeleton/checkboxSkeleton";
 export { default as KanbanSkeleton } from "./skeleton/kanbanSkeleton";
+export { default as CalendarSkeleton } from "./skeleton/calendarSkeleton";
 export { default as TodayItemSkeleton } from "./skeleton/todayItemSkeleton";
 export { ToastProvider } from "./toast/toastContext";
 export { useToast } from "./toast/useToast";

--- a/client/src/shared/ui/skeleton/calendarSkeleton.styles.tsx
+++ b/client/src/shared/ui/skeleton/calendarSkeleton.styles.tsx
@@ -1,0 +1,119 @@
+import { styled, keyframes } from "styled-components";
+
+const shimmer = keyframes`
+  0% {
+    background-position: -200px 0;
+  }
+  100% {
+    background-position: 200px 0;
+  }
+`;
+
+const cellFade = keyframes`
+  0% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.4;
+  }
+`;
+
+// shimmer를 쓰는 회색 블록들의 공통 바탕. kanbanSkeleton과 같은 톤을 유지한다.
+const Bar = styled.div`
+  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+  background-size: 400px 100%;
+  border-radius: 4px;
+  animation: ${shimmer} 1.5s ease-in-out infinite;
+`;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  height: 100%;
+  flex: 1;
+`;
+
+const Toolbar = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+`;
+
+const ToolbarTitle = styled(Bar)`
+  height: 20px;
+  width: 140px;
+`;
+
+const ToolbarButtons = styled.div`
+  display: flex;
+  gap: 6px;
+`;
+
+const ToolbarButton = styled(Bar)`
+  height: 28px;
+  width: 56px;
+  border-radius: 6px;
+`;
+
+const WeekdayRow = styled.div`
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+`;
+
+const Weekday = styled(Bar)`
+  height: 12px;
+  width: 60%;
+  margin: 0 auto;
+`;
+
+const Grid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  grid-auto-rows: 1fr;
+  gap: 4px;
+  flex: 1;
+  min-height: 0;
+`;
+
+const Cell = styled.div<{ $delay: number }>`
+  background: #f7f8f9;
+  border-radius: 6px;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  animation: ${cellFade} 2s ease-in-out infinite;
+  animation-delay: ${({ $delay }) => $delay}s;
+`;
+
+const DayNumber = styled(Bar)`
+  height: 10px;
+  width: 16px;
+`;
+
+const EventBar = styled(Bar)<{ $width: string }>`
+  height: 8px;
+  width: ${({ $width }) => $width};
+  opacity: 0.8;
+`;
+
+export {
+  Container,
+  Toolbar,
+  ToolbarTitle,
+  ToolbarButtons,
+  ToolbarButton,
+  WeekdayRow,
+  Weekday,
+  Grid,
+  Cell,
+  DayNumber,
+  EventBar,
+};

--- a/client/src/shared/ui/skeleton/calendarSkeleton.tsx
+++ b/client/src/shared/ui/skeleton/calendarSkeleton.tsx
@@ -1,0 +1,54 @@
+import {
+  Container,
+  Toolbar,
+  ToolbarTitle,
+  ToolbarButtons,
+  ToolbarButton,
+  WeekdayRow,
+  Weekday,
+  Grid,
+  Cell,
+  DayNumber,
+  EventBar,
+} from "./calendarSkeleton.styles";
+
+const WEEKS = 6;
+const DAYS_IN_WEEK = 7;
+const CELL_COUNT = WEEKS * DAYS_IN_WEEK;
+
+// 셀마다 이벤트 바를 몇 개 그릴지. 실제 달력처럼 듬성듬성 차 있도록 고정 패턴을
+// 반복한다(랜덤을 쓰면 리렌더마다 모양이 바뀌어 깜빡임으로 보인다).
+const eventCounts = [0, 1, 0, 2, 1, 0, 1];
+const eventWidths = ["80%", "60%", "90%", "70%"];
+
+const CalendarSkeleton = () => (
+  <Container aria-hidden="true">
+    <Toolbar>
+      <ToolbarTitle />
+      <ToolbarButtons>
+        <ToolbarButton />
+        <ToolbarButton />
+      </ToolbarButtons>
+    </Toolbar>
+
+    <WeekdayRow>
+      {Array.from({ length: DAYS_IN_WEEK }, (_, i) => (
+        <Weekday key={i} />
+      ))}
+    </WeekdayRow>
+
+    <Grid>
+      {Array.from({ length: CELL_COUNT }, (_, i) => (
+        // 같은 주(행) 안의 셀들이 동시에 밝아지지 않도록 열 단위로 지연을 준다.
+        <Cell key={i} $delay={(i % DAYS_IN_WEEK) * 0.1}>
+          <DayNumber />
+          {Array.from({ length: eventCounts[i % eventCounts.length] }, (_, j) => (
+            <EventBar key={j} $width={eventWidths[(i + j) % eventWidths.length]} />
+          ))}
+        </Cell>
+      ))}
+    </Grid>
+  </Container>
+);
+
+export default CalendarSkeleton;


### PR DESCRIPTION
## 배경

프로덕션 빌드가 **단일 청크 하나**뿐이었습니다.

```
dist/assets/index-*.js   1,372.90 kB │ gzip: 398.57 kB
(!) Some chunks are larger than 500 kB after minification.
```

로그인 페이지나 랜딩만 열어도 FullCalendar, dnd-kit, Firestore SDK를 전부 내려받습니다. 로그인하지 않은 첫 방문자가 절대 쓰지 않을 코드가 초기 페이로드의 절반 이상을 차지했습니다.

## 결과

초기 다운로드 페이로드 **gzip 398.57 kB → 173.00 kB (-56.6%)**

| 청크 | gzip | 언제 받나 |
|---|---|---|
| 엔트리 (react/router/firebase-auth/sentry/styled-components) | 172.82 kB | 항상 |
| `useTodo` — Firestore SDK + 할 일 도메인 | 84.01 kB | 로그인 후 |
| `calendarPage` — FullCalendar | 72.04 kB | `/calendar` 진입 시 |
| `kanbanPage` — dnd-kit | 20.14 kB | `/kanban` 진입 시 |
| `todoForm` | 12.90 kB | 폼 사용 시 |
| `linkify` | 12.25 kB | 설명 렌더 시 |

## 원인이 두 갈래여서 둘 다 고쳤습니다

**1. `router.tsx`가 8개 라우트를 전부 정적 import**

`React.lazy` + 라우트별 `Suspense`로 전환했습니다.

여기서 중요한 건 **`App`(인증 레이아웃)도 lazy로 뺐다**는 점입니다. `App.tsx`가 `useTodo`를 쓰기 때문에, eager로 두면 할 일 도메인 → `todoApi` → Firestore가 통째로 초기 청크에 딸려옵니다. `ProtectedRoute`와 `RootGate`만 eager로 남겼습니다 — 최초 라우팅 판단에 즉시 필요하고 auth 외 의존성이 없어 비용이 사실상 0입니다.

**2. `shared/lib/firebase.ts`가 auth와 firestore를 한 모듈에서 초기화**

이게 핵심입니다. `AuthProvider`가 이 모듈을 앱 진입 시점에 정적으로 쓰기 때문에, **라우트를 아무리 잘게 쪼개도 Firestore SDK는 초기 청크에 그대로 남습니다.** 세 모듈로 분리했습니다.

| 파일 | 내보내는 것 |
|---|---|
| `shared/lib/firebaseApp.ts` (신규) | `app`, `isEmulator` |
| `shared/lib/firebase.ts` (auth 전용으로 축소) | `auth`, `googleProvider` |
| `shared/lib/firestore.ts` (신규) | `db` |

의도를 모르면 쉽게 원복되는 종류의 변경이라 `firebase.ts` 상단에 경고 주석을 남겼습니다. 여기에 `getFirestore`를 다시 넣으면 이 PR의 효과가 조용히 사라집니다.

## 부수 변경

- **`CalendarSkeleton` 신설** — 가장 큰 lazy 청크(FullCalendar, gzip 72 kB)에만 전환 중 보여줄 스켈레톤이 없었습니다. 기존 `kanbanSkeleton` 패턴(shimmer keyframes, `$delay` transient prop)을 따랐습니다.
- **배럴 우회** — `main.tsx`가 `@/shared` 배럴로 `ToastProvider`/`ErrorBoundary`를 가져오면 `ui`/`hooks`/`utils` 전체가 초기 모듈 그래프에 올라갑니다. 그 안의 `utils/descriptionLinks → linkifyjs`는 부피 대부분이 TLD 데이터 테이블이라 트리셰이킹이 한 번만 어긋나도 통째로 딸려옵니다. 직접 경로로 교체했습니다. `App.tsx`도 같은 이유로 `@/features/todo` → `@/features/todo/hooks`.
- **테스트 mock 16개 파일** — `db`가 `firestore.ts`로 빠져나가면서 `vi.mock('@/shared/lib/firestore')` 추가. 기계적 치환입니다.

## 번들 예산 가드레일

분할해놓고 조용히 되돌아가는 걸 막기 위해 `scripts/checkBundleBudget.mjs`를 추가하고 CI `client` job의 Build 뒤에 스텝을 넣었습니다.

`dist/index.html`이 직접 참조하는 파일(엔트리 스크립트 + modulepreload + 렌더 블로킹 CSS)만 gzip 합산합니다. lazy 청크는 여기 안 나타나므로, "라우트를 쪼갰다"는 사실이 숫자에 정직하게 반영됩니다.

```
초기 다운로드 페이로드 (index.html이 직접 참조하는 파일)

  /assets/index-BqABopZP.js      583.46 kB  gzip  172.82 kB
  /assets/index-BEFbyIcI.css       0.20 kB  gzip    0.18 kB
                                            ───────────────
  합계                                      gzip  173.00 kB
  예산                                            190.43 kB

✔ 예산 이내 (여유 17.43 kB, 9.2%)
```

예산은 `client/bundle-budget.json`(195,000 bytes)에 있고, 의도적으로 늘려야 할 때만 근거와 함께 올리도록 안내 문구를 넣었습니다.

## 검증

- `npm run lint` — 0 errors (기존 warning 4건만)
- `npx tsc -b` — 통과
- `npm run test` — **415 passed**, `TZ=America/New_York`으로도 415 passed
- `npm run test:e2e` — **24 passed**. 인증 이후 캘린더·칸반·할 일 플로우 포함. Suspense 경계가 생겼지만 셀렉터 수정은 필요 없었습니다.
- `npm run check:bundle` — 통과 / 예산을 낮춰 실패도 재현 확인

**`npm run preview` 실제 네트워크 실측:**

| 경로 | 받는 청크 |
|---|---|
| `/login` | 엔트리 + CSS + `loginPage` (3개) |
| `/` (랜딩) | 엔트리 + CSS + `landingPage` + `footer` + 아이콘 2개 |
| `/guest` | 위 + `guestTodayPage` + `todayTodoItem` + `linkify` 등 자기 청크셋 |

세 경로 모두에서 `useTodo`(Firestore), `calendarPage`(FullCalendar), `kanbanPage`(dnd-kit) 청크는 **요청되지 않습니다.**

## 알아두실 점

**Vite의 500 kB 경고는 여전히 뜹니다.** 엔트리가 583 kB raw인데, 남은 건 사실상 전부 벤더입니다.

| | gzip |
|---|---|
| react + react-dom | 57.0 kB |
| react-router-dom | 35.1 kB |
| firebase app+auth | 34.9 kB |
| @sentry/react | 31.5 kB |
| styled-components | 13.6 kB |
| @tanstack/react-query | 10.1 kB |

(esbuild 단일 import 프로브로 측정. 공유 의존성이 겹쳐 합계는 실제보다 큽니다.) 우리 초기 코드는 미미해서 **라우트 분할로는 여기서 더 줄일 여지가 없습니다.** 더 줄이려면 Sentry 지연 초기화나 vendor manualChunks 같은 다른 축이 필요한데, 각각 초기 에러 캡처 누락과 styled-components 초기화 순서 리스크가 있어 이번 범위에서 제외했습니다.

**`ReactQueryDevtools`는 프로덕션 번들에서 완전히 트리셰이킹됩니다.** 확인했고 별도 조치는 넣지 않았습니다.

```
$ grep -c "ReactQueryDevtools\|tanstack-query-devtools" dist/assets/*.js
0
```

## 후속 후보 (이 PR 범위 밖)

- SNB 링크 hover 시 `import()` prefetch — 첫 라우트 전환 지연 완화
- Sentry 지연 초기화
- vendor manualChunks로 배포 간 캐시 적중률 개선

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
